### PR TITLE
feat(ui): working-copy panel -- status, stage/unstage, commit and amend

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -25,6 +25,7 @@ qt_add_executable(git-branch-manager
     views/DiffView.cpp
     views/MainWindow.cpp
     views/OperationLogView.cpp
+    views/WorkingCopyView.cpp
 )
 
 target_include_directories(git-branch-manager PRIVATE

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -23,6 +23,7 @@ RepositorySession::RepositorySession(GitInstallation installation,
     history_ = std::make_unique<HistoryProvider>(*runner_, paths_);
     diffs_ = std::make_unique<DiffService>(*runner_, paths_);
     operations_ = std::make_unique<OperationRunner>(*runner_, paths_);
+    workingCopyStatusReader_ = std::make_unique<WorkingCopyStatusReader>(*runner_, paths_);
 }
 
 RepositorySession::~RepositorySession() {
@@ -202,6 +203,104 @@ void RepositorySession::checkout(const CheckoutRequest& request) {
 void RepositorySession::cancelPendingReads() {
     readCancel_.cancel();
     readCancel_ = CancellationSource();
+}
+
+void RepositorySession::refreshWorkingCopyStatus() {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, token] {
+        auto status = workingCopyStatusReader_->read(token);
+        if (status) {
+            workingCopyStatus_.publish(*status);
+            QMetaObject::invokeMethod(
+                this, [this] { emit workingCopyStatusUpdated(); }, Qt::QueuedConnection);
+        } else if (status.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(status).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::requestWorkingCopyDiff(const std::string& path, bool staged) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    // postFront: mirrors requestCommitDetails -- the newest selection is what
+    // the user is looking at, so it must not wait behind a stale request.
+    readPool_.postFront([this, path, staged, token] {
+        if (token.isCancelled()) {
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+
+        auto diff = diffs_->workingTreeDiff(staged, {path}, DiffOptions{}, token);
+        if (diff) {
+            auto diffPtr = *diff;
+            const QString qpath = QString::fromStdString(path);
+            QMetaObject::invokeMethod(
+                this,
+                [this, qpath, staged, diffPtr] {
+                    emit workingCopyDiffReady(qpath, staged, diffPtr);
+                },
+                Qt::QueuedConnection);
+        } else if (diff.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(diff).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::submitWorkingCopyOperation(std::unique_ptr<Operation> operation,
+                                                   bool alsoRefreshHistory) {
+    setBusy(true);
+    operations_->submit(std::move(operation), [this, alsoRefreshHistory](OperationOutcome outcome) {
+        // Runs on the operation runner's serial thread; hop to the UI thread
+        // before touching anything Qt.
+        QMetaObject::invokeMethod(
+            this,
+            [this, outcome = std::move(outcome), alsoRefreshHistory] {
+                setBusy(false);
+                emit workingCopyOperationFinished(outcome);
+                if (outcome.succeeded) {
+                    refreshWorkingCopyStatus();
+                    if (alsoRefreshHistory) {
+                        // A commit moved HEAD, so both the ref list and the
+                        // graph need to reflect it.
+                        refreshRefs();
+                        refreshHistory();
+                    }
+                }
+            },
+            Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::stageFiles(std::vector<std::string> paths) {
+    StageFilesRequest request;
+    request.paths = std::move(paths);
+    submitWorkingCopyOperation(makeStageFilesOperation(std::move(request)), false);
+}
+
+void RepositorySession::unstageFiles(std::vector<std::string> paths) {
+    UnstageFilesRequest request;
+    request.paths = std::move(paths);
+    submitWorkingCopyOperation(makeUnstageFilesOperation(std::move(request)), false);
+}
+
+void RepositorySession::applyPatch(std::string patch, bool reverse) {
+    ApplyPatchRequest request;
+    request.patch = std::move(patch);
+    request.reverse = reverse;
+    submitWorkingCopyOperation(makeApplyPatchOperation(std::move(request)), false);
+}
+
+void RepositorySession::commitChanges(const CommitRequest& request) {
+    submitWorkingCopyOperation(makeCommitOperation(request), true);
 }
 
 }  // namespace gbm

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -9,7 +9,10 @@
 #include "core/git/OperationRunner.h"
 #include "core/git/RefStore.h"
 #include "core/git/RepoState.h"
+#include "core/git/WorkingCopyStatus.h"
 #include "core/git/ops/CheckoutOp.h"
+#include "core/git/ops/CommitOps.h"
+#include "core/git/ops/StageOps.h"
 #include "core/graph/GraphSnapshot.h"
 #include "core/workers/ThreadPool.h"
 
@@ -68,6 +71,29 @@ public:
 
     void cancelPendingReads();
 
+    /// The most recent working-copy status. May be stale until the next
+    /// `workingCopyStatusUpdated`; never blocks.
+    WorkingCopyStatusPtr workingCopyStatus() const { return workingCopyStatus_.current(); }
+
+    /// Re-reads `git status`. Deliberately uncached at the RepositorySession
+    /// level too, matching WorkingCopyStatusReader: the work tree changes on
+    /// every keystroke, so a snapshot is only ever "as of the last refresh".
+    void refreshWorkingCopyStatus();
+
+    /// Diff of one path against the index (staged=false) or HEAD
+    /// (staged=true), for the working-copy panel.
+    void requestWorkingCopyDiff(const std::string& path, bool staged);
+
+    void stageFiles(std::vector<std::string> paths);
+    void unstageFiles(std::vector<std::string> paths);
+
+    /// Applies a hunk- or line-level patch to the index; see
+    /// UnifiedDiffParser::buildHunkPatch / buildLineSelectionPatch for how the
+    /// patch and `reverse` are meant to be paired.
+    void applyPatch(std::string patch, bool reverse);
+
+    void commitChanges(const CommitRequest& request);
+
 signals:
     /// A newer graph snapshot is available (possibly partial).
     void graphUpdated(bool complete);
@@ -80,8 +106,19 @@ signals:
     void errorOccurred(const GitError& error);
     void busyChanged(bool busy);
 
+    void workingCopyStatusUpdated();
+    void workingCopyDiffReady(QString path, bool staged, std::shared_ptr<const ParsedDiff> diff);
+    /// Separate from `operationFinished`: MainWindow's checkout-recovery UI
+    /// (stash/discard choices) does not apply to staging and commit, so the
+    /// working-copy panel gets its own completion signal to react to.
+    void workingCopyOperationFinished(OperationOutcome outcome);
+
 private:
     void setBusy(bool busy);
+    /// Runs a staging/commit Operation and, on success, refreshes whatever it
+    /// could have changed. Shared by stageFiles/unstageFiles/applyPatch/commitChanges
+    /// so each stays a one-line call.
+    void submitWorkingCopyOperation(std::unique_ptr<Operation> operation, bool alsoRefreshHistory);
 
     GitInstallation installation_;
     RepoPaths paths_;
@@ -93,9 +130,11 @@ private:
     std::unique_ptr<HistoryProvider> history_;
     std::unique_ptr<DiffService> diffs_;
     std::unique_ptr<OperationRunner> operations_;
+    std::unique_ptr<WorkingCopyStatusReader> workingCopyStatusReader_;
 
     SnapshotHolder<GraphSnapshot> graph_;
     SnapshotHolder<RefSnapshot> refs_;
+    SnapshotHolder<WorkingCopyStatus> workingCopyStatus_;
 
     /// Cancels the in-flight history walk when a new one starts.
     CancellationSource historyCancel_;

--- a/src/app/views/DiffView.cpp
+++ b/src/app/views/DiffView.cpp
@@ -1,10 +1,15 @@
 #include "app/views/DiffView.h"
 
+#include <QAction>
+#include <QContextMenuEvent>
 #include <QFont>
 #include <QFontDatabase>
+#include <QMenu>
 #include <QTextBlockFormat>
 #include <QTextCharFormat>
 #include <QTextCursor>
+
+#include <memory>
 
 namespace gbm {
 
@@ -35,13 +40,23 @@ DiffView::DiffView(QWidget* parent) : QPlainTextEdit(parent) {
     setUndoRedoEnabled(false);
 }
 
+void DiffView::setStagingEnabled(bool enabled) {
+    stagingEnabled_ = enabled;
+}
+
+void DiffView::setShowingStagedDiff(bool staged) {
+    showingStaged_ = staged;
+}
+
 void DiffView::clearDiff() {
     diff_.reset();
+    hunkSpans_.clear();
     clear();
 }
 
 void DiffView::showMessage(const QString& message) {
     diff_.reset();
+    hunkSpans_.clear();
     clear();
     appendPlainText(message);
 }
@@ -62,7 +77,71 @@ void DiffView::showFile(std::shared_ptr<const ParsedDiff> diff, const QString& p
     }
 }
 
+const DiffView::HunkSpan* DiffView::hunkSpanForBlock(int blockNumber) const {
+    for (const HunkSpan& span : hunkSpans_) {
+        if (blockNumber >= span.firstLine && blockNumber <= span.lastLine) {
+            return &span;
+        }
+    }
+    return nullptr;
+}
+
+void DiffView::contextMenuEvent(QContextMenuEvent* event) {
+    if (!stagingEnabled_ || !diff_) {
+        QPlainTextEdit::contextMenuEvent(event);
+        return;
+    }
+
+    const HunkSpan* span = hunkSpanForBlock(cursorForPosition(event->pos()).blockNumber());
+    if (span == nullptr) {
+        QPlainTextEdit::contextMenuEvent(event);
+        return;
+    }
+
+    std::unique_ptr<QMenu> menu(createStandardContextMenu());
+    menu->addSeparator();
+
+    QAction* hunkAction = menu->addAction(showingStaged_ ? tr("Unstage Hunk") : tr("Stage Hunk"));
+    const bool reverse = showingStaged_;
+    connect(hunkAction, &QAction::triggered, this, [this, span, reverse] {
+        const std::string patch = UnifiedDiffParser::buildHunkPatch(*span->file, *span->hunk);
+        emit applyPatchRequested(QString::fromStdString(patch), reverse);
+    });
+
+    // Line-level staging only when the selection sits entirely inside this
+    // hunk's body: a selection spanning hunks or files has no single patch.
+    const QTextCursor selection = textCursor();
+    if (selection.hasSelection()) {
+        QTextCursor start(document());
+        start.setPosition(selection.selectionStart());
+        QTextCursor end(document());
+        end.setPosition(selection.selectionEnd());
+        const int selStart = start.blockNumber();
+        const int selEnd = end.blockNumber();
+
+        if (selStart >= span->firstLine && selEnd <= span->lastLine) {
+            QAction* lineAction = menu->addAction(showingStaged_ ? tr("Unstage Selected Lines")
+                                                                 : tr("Stage Selected Lines"));
+            connect(lineAction, &QAction::triggered, this, [this, span, selStart, selEnd, reverse] {
+                std::vector<bool> selected(span->hunk->lines.size(), false);
+                for (int line = selStart; line <= selEnd; ++line) {
+                    const auto index = static_cast<std::size_t>(line - span->firstLine);
+                    if (index < selected.size()) {
+                        selected[index] = true;
+                    }
+                }
+                const std::string patch =
+                    UnifiedDiffParser::buildLineSelectionPatch(*span->file, *span->hunk, selected);
+                emit applyPatchRequested(QString::fromStdString(patch), reverse);
+            });
+        }
+    }
+
+    menu->exec(event->globalPos());
+}
+
 void DiffView::render(const ParsedDiff& diff, const QString& onlyPath) {
+    hunkSpans_.clear();
     QTextCursor cursor(document());
     cursor.beginEditBlock();
 
@@ -133,6 +212,7 @@ void DiffView::render(const ParsedDiff& diff, const QString& onlyPath) {
                 hunkLine += QStringLiteral(" ") + QString::fromStdString(hunk.heading);
             }
             cursor.insertText(hunkLine + QStringLiteral("\n"), hunkHeader);
+            const int firstLine = cursor.blockNumber();
 
             for (const DiffLine& line : hunk.lines) {
                 switch (line.kind) {
@@ -156,6 +236,10 @@ void DiffView::render(const ParsedDiff& diff, const QString& onlyPath) {
                                           dim);
                         break;
                 }
+            }
+
+            if (stagingEnabled_ && !hunk.lines.empty()) {
+                hunkSpans_.push_back({firstLine, cursor.blockNumber() - 1, &file, &hunk});
             }
         }
         cursor.insertText(QStringLiteral("\n"), plain);

--- a/src/app/views/DiffView.h
+++ b/src/app/views/DiffView.h
@@ -6,6 +6,9 @@
 #include <QWidget>
 
 #include <memory>
+#include <vector>
+
+class QContextMenuEvent;
 
 namespace gbm {
 
@@ -30,10 +33,46 @@ public:
 
     void clearDiff();
 
+    /// Offers "Stage Hunk" / "Stage Selected Lines" (or their Unstage
+    /// counterparts) on the context menu. Off by default: the history diff
+    /// view shows a read-only past commit, which cannot be staged.
+    void setStagingEnabled(bool enabled);
+
+    /// Which side of the index the currently shown diff represents: false for
+    /// work tree vs index (the "Stage" case), true for index vs HEAD (the
+    /// "Unstage" case). Determines both the menu wording and the `reverse`
+    /// flag on applyPatchRequested.
+    void setShowingStagedDiff(bool staged);
+
+signals:
+    /// A patch the user asked to apply to the index, built from the hunk or
+    /// line selection under the cursor. See
+    /// UnifiedDiffParser::buildHunkPatch / buildLineSelectionPatch for what
+    /// `patch` contains and how `reverse` pairs with it.
+    void applyPatchRequested(QString patch, bool reverse);
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
 private:
     void render(const ParsedDiff& diff, const QString& onlyPath);
 
+    /// Maps a contiguous run of QTextBlocks back to the hunk they render, so a
+    /// right-click can find which hunk (and which DiffLine, for a selection)
+    /// it landed on without re-parsing the document.
+    struct HunkSpan {
+        int firstLine = 0;  ///< Block number of the hunk's first content line.
+        int lastLine = 0;   ///< Block number of the hunk's last content line.
+        const DiffFile* file = nullptr;
+        const DiffHunk* hunk = nullptr;
+    };
+
+    const HunkSpan* hunkSpanForBlock(int blockNumber) const;
+
     std::shared_ptr<const ParsedDiff> diff_;
+    std::vector<HunkSpan> hunkSpans_;
+    bool stagingEnabled_ = false;
+    bool showingStaged_ = false;
 };
 
 }  // namespace gbm

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -210,6 +210,17 @@ void MainWindow::buildUi() {
 
     stack_->addWidget(repoPage);
 
+    // --- page 2: working copy -------------------------------------------------
+    workingCopyView_ = new WorkingCopyView(this);
+    connect(workingCopyView_, &WorkingCopyView::statusMessage, this, [this](const QString& text) {
+        statusLabel_->setText(text);
+    });
+    connect(workingCopyView_,
+            &WorkingCopyView::errorOccurred,
+            this,
+            [this](const QString& summary, const GitError& error) { showError(summary, error); });
+    stack_->addWidget(workingCopyView_);
+
     // --- status bar ----------------------------------------------------------
     statusLabel_ = new QLabel(QStringLiteral("Ready"), this);
     busyBar_ = new QProgressBar(this);
@@ -253,11 +264,20 @@ void MainWindow::buildMenus() {
         QStringLiteral("Switch to selected branch"), this, &MainWindow::onCheckoutRequested);
     checkoutAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+O")));
 
+    auto* historyAction =
+        viewMenu->addAction(QStringLiteral("History"), this, &MainWindow::onShowHistory);
+    historyAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+1")));
+    auto* workingCopyAction =
+        viewMenu->addAction(QStringLiteral("Working Copy"), this, &MainWindow::onShowWorkingCopy);
+    workingCopyAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+2")));
+
     auto* toolBar = addToolBar(QStringLiteral("Main"));
     toolBar->setMovable(false);
     toolBar->addAction(refreshAction);
     toolBar->addAction(
         QStringLiteral("Repositories"), this, [this] { stack_->setCurrentIndex(0); });
+    toolBar->addAction(historyAction);
+    toolBar->addAction(workingCopyAction);
 }
 
 void MainWindow::loadInitialState() {
@@ -361,6 +381,23 @@ void MainWindow::onCancelScan() {
     statusLabel_->setText(QStringLiteral("Cancelling scan…"));
 }
 
+void MainWindow::onShowHistory() {
+    if (session_) {
+        stack_->setCurrentIndex(1);
+    }
+}
+
+void MainWindow::onShowWorkingCopy() {
+    if (!session_) {
+        return;
+    }
+    stack_->setCurrentIndex(2);
+    // The working-copy panel can go stale while the user is elsewhere -- a
+    // checkout, for instance, does not refresh it -- so ask for a fresh read
+    // on every visit rather than trying to track every place that could.
+    session_->refreshWorkingCopyStatus();
+}
+
 void MainWindow::onRepoActivated(const QModelIndex& index) {
     if (const RepoRecord* record = repoModel_->repoAt(index.row())) {
         openRepository(*record);
@@ -397,6 +434,7 @@ void MainWindow::openRepository(const RepoRecord& record) {
 
     commitModel_->setSession(session_.get());
     diffView_->clearDiff();
+    workingCopyView_->setSession(session_.get());
 
     setWindowTitle(QStringLiteral("%1 — git-branch-manager").arg(session_->displayName()));
     stack_->setCurrentIndex(1);
@@ -416,6 +454,7 @@ void MainWindow::closeRepository() {
     commitModel_->setSession(nullptr);
     refModel_->setRefs(nullptr);
     diffView_->clearDiff();
+    workingCopyView_->setSession(nullptr);
     session_.reset();
     setWindowTitle(QStringLiteral("git-branch-manager"));
     stack_->setCurrentIndex(0);

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -8,6 +8,7 @@
 #include "app/models/RepoListModel.h"
 #include "app/views/DiffView.h"
 #include "app/views/OperationLogView.h"
+#include "app/views/WorkingCopyView.h"
 #include "core/git/GitExecutable.h"
 #include "core/workers/ThreadPool.h"
 
@@ -53,6 +54,8 @@ private slots:
     void onCoreError(const GitError& error);
     void onRepoSearchChanged(const QString& text);
     void onCommitScrolled();
+    void onShowWorkingCopy();
+    void onShowHistory();
 
 private:
     void buildUi();
@@ -84,6 +87,7 @@ private:
     QTableView* fileView_ = nullptr;
     DiffView* diffView_ = nullptr;
     OperationLogView* logView_ = nullptr;
+    WorkingCopyView* workingCopyView_ = nullptr;
 
     QLabel* statusLabel_ = nullptr;
     QLabel* bannerLabel_ = nullptr;

--- a/src/app/views/WorkingCopyView.cpp
+++ b/src/app/views/WorkingCopyView.cpp
@@ -1,0 +1,361 @@
+#include "app/views/WorkingCopyView.h"
+
+#include "app/bridge/RepositorySession.h"
+#include "core/git/ops/CommitOps.h"
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSplitter>
+#include <QVBoxLayout>
+
+namespace gbm {
+
+namespace {
+
+/// "old -> new" for a rename/copy, otherwise just the path.
+QString pathLabel(const WorkingCopyEntry& entry) {
+    if (!entry.oldPath.empty()) {
+        return QString::fromStdString(entry.oldPath) + QStringLiteral("  →  ") +
+               QString::fromStdString(entry.path);
+    }
+    return QString::fromStdString(entry.path);
+}
+
+QListWidgetItem* addEntry(QListWidget* list, const WorkingCopyEntry& entry, const QString& suffix) {
+    auto* item = new QListWidgetItem(pathLabel(entry) + suffix, list);
+    item->setData(Qt::UserRole, QString::fromStdString(entry.path));
+    return item;
+}
+
+}  // namespace
+
+WorkingCopyView::WorkingCopyView(QWidget* parent) : QWidget(parent) {
+    buildUi();
+    rebuildLists();
+}
+
+void WorkingCopyView::buildUi() {
+    auto* outerLayout = new QVBoxLayout(this);
+    outerLayout->setContentsMargins(6, 6, 6, 6);
+
+    summaryLabel_ = new QLabel(tr("No repository open"), this);
+    outerLayout->addWidget(summaryLabel_);
+
+    auto* splitter = new QSplitter(Qt::Horizontal, this);
+
+    auto* leftWidget = new QWidget(splitter);
+    auto* leftLayout = new QVBoxLayout(leftWidget);
+    leftLayout->setContentsMargins(0, 0, 0, 0);
+
+    conflictedGroup_ = new QWidget(leftWidget);
+    auto* conflictedLayout = new QVBoxLayout(conflictedGroup_);
+    conflictedLayout->setContentsMargins(0, 0, 0, 0);
+    conflictedLayout->addWidget(
+        new QLabel(tr("Conflicts — resolve before committing"), conflictedGroup_));
+    conflictedList_ = new QListWidget(conflictedGroup_);
+    conflictedList_->setMaximumHeight(120);
+    conflictedLayout->addWidget(conflictedList_);
+    conflictedGroup_->setVisible(false);
+    leftLayout->addWidget(conflictedGroup_);
+
+    leftLayout->addWidget(new QLabel(tr("Staged Changes"), leftWidget));
+    stagedList_ = new QListWidget(leftWidget);
+    stagedList_->setSelectionMode(QAbstractItemView::SingleSelection);
+    leftLayout->addWidget(stagedList_, 1);
+    unstageAllButton_ = new QPushButton(tr("Unstage All"), leftWidget);
+    leftLayout->addWidget(unstageAllButton_);
+
+    leftLayout->addWidget(new QLabel(tr("Changes"), leftWidget));
+    unstagedList_ = new QListWidget(leftWidget);
+    unstagedList_->setSelectionMode(QAbstractItemView::SingleSelection);
+    leftLayout->addWidget(unstagedList_, 1);
+    stageAllButton_ = new QPushButton(tr("Stage All"), leftWidget);
+    leftLayout->addWidget(stageAllButton_);
+
+    messageEdit_ = new QPlainTextEdit(leftWidget);
+    messageEdit_->setPlaceholderText(tr("Commit message"));
+    messageEdit_->setMaximumHeight(100);
+    leftLayout->addWidget(messageEdit_);
+
+    auto* commitRow = new QHBoxLayout();
+    amendCheck_ = new QCheckBox(tr("Amend"), leftWidget);
+    commitButton_ = new QPushButton(tr("Commit"), leftWidget);
+    commitButton_->setEnabled(false);
+    commitRow->addWidget(amendCheck_);
+    commitRow->addStretch(1);
+    commitRow->addWidget(commitButton_);
+    leftLayout->addLayout(commitRow);
+
+    splitter->addWidget(leftWidget);
+
+    // Hunk- and line-level staging live on this instance's context menu; see
+    // DiffView::setStagingEnabled.
+    diffView_ = new DiffView(splitter);
+    diffView_->setStagingEnabled(true);
+    splitter->addWidget(diffView_);
+    splitter->setStretchFactor(0, 2);
+    splitter->setStretchFactor(1, 3);
+
+    outerLayout->addWidget(splitter, 1);
+
+    connect(stagedList_,
+            &QListWidget::itemSelectionChanged,
+            this,
+            &WorkingCopyView::onStagedSelectionChanged);
+    connect(unstagedList_,
+            &QListWidget::itemSelectionChanged,
+            this,
+            &WorkingCopyView::onUnstagedSelectionChanged);
+    connect(
+        stagedList_, &QListWidget::itemActivated, this, &WorkingCopyView::onStagedItemActivated);
+    connect(unstagedList_,
+            &QListWidget::itemActivated,
+            this,
+            &WorkingCopyView::onUnstagedItemActivated);
+    connect(stageAllButton_, &QPushButton::clicked, this, &WorkingCopyView::onStageAllClicked);
+    connect(unstageAllButton_, &QPushButton::clicked, this, &WorkingCopyView::onUnstageAllClicked);
+    connect(commitButton_, &QPushButton::clicked, this, &WorkingCopyView::onCommitClicked);
+    connect(amendCheck_, &QCheckBox::toggled, this, [this](bool amend) {
+        messageEdit_->setPlaceholderText(amend ? tr("Leave empty to keep the previous message")
+                                               : tr("Commit message"));
+    });
+    connect(
+        diffView_, &DiffView::applyPatchRequested, this, &WorkingCopyView::onApplyPatchRequested);
+}
+
+void WorkingCopyView::setSession(RepositorySession* session) {
+    if (session_ != nullptr) {
+        disconnect(session_, nullptr, this, nullptr);
+    }
+    session_ = session;
+    if (session_ != nullptr) {
+        connect(session_,
+                &RepositorySession::workingCopyStatusUpdated,
+                this,
+                &WorkingCopyView::onWorkingCopyStatusUpdated);
+        connect(session_,
+                &RepositorySession::workingCopyDiffReady,
+                this,
+                &WorkingCopyView::onWorkingCopyDiffReady);
+        connect(session_,
+                &RepositorySession::workingCopyOperationFinished,
+                this,
+                &WorkingCopyView::onWorkingCopyOperationFinished);
+        session_->refreshWorkingCopyStatus();
+    } else {
+        diffView_->clearDiff();
+        messageEdit_->clear();
+        rebuildLists();
+    }
+}
+
+std::optional<WorkingCopyView::Selection> WorkingCopyView::currentSelection() const {
+    if (const auto items = stagedList_->selectedItems(); !items.isEmpty()) {
+        return Selection{items.first()->data(Qt::UserRole).toString().toStdString(), true};
+    }
+    if (const auto items = unstagedList_->selectedItems(); !items.isEmpty()) {
+        return Selection{items.first()->data(Qt::UserRole).toString().toStdString(), false};
+    }
+    return std::nullopt;
+}
+
+void WorkingCopyView::rebuildLists() {
+    // Captured before clearing, so the file the user is looking at can be
+    // re-selected afterwards: a hunk staged from this file must not blank the
+    // diff pane out from under them.
+    const auto previous = currentSelection();
+
+    stagedList_->blockSignals(true);
+    unstagedList_->blockSignals(true);
+    conflictedList_->blockSignals(true);
+    stagedList_->clear();
+    unstagedList_->clear();
+    conflictedList_->clear();
+
+    const WorkingCopyStatusPtr status = session_ ? session_->workingCopyStatus() : nullptr;
+    if (status) {
+        for (const WorkingCopyEntry* entry : status->conflicted()) {
+            addEntry(conflictedList_, *entry, QString());
+        }
+        for (const WorkingCopyEntry* entry : status->staged()) {
+            addEntry(stagedList_, *entry, QString());
+        }
+        for (const WorkingCopyEntry* entry : status->unstaged()) {
+            addEntry(unstagedList_, *entry, QString());
+        }
+        for (const WorkingCopyEntry* entry : status->untracked()) {
+            addEntry(unstagedList_, *entry, tr("  (untracked)"));
+        }
+    }
+
+    stagedList_->blockSignals(false);
+    unstagedList_->blockSignals(false);
+    conflictedList_->blockSignals(false);
+
+    bool reselected = false;
+    if (previous) {
+        for (QListWidget* list : {stagedList_, unstagedList_}) {
+            for (int row = 0; row < list->count(); ++row) {
+                if (list->item(row)->data(Qt::UserRole).toString().toStdString() ==
+                    previous->path) {
+                    list->setCurrentItem(list->item(row));
+                    reselected = true;
+                    break;
+                }
+            }
+            if (reselected) {
+                break;
+            }
+        }
+    }
+    if (previous && !reselected) {
+        diffView_->clearDiff();
+    }
+
+    const bool hasConflicts = conflictedList_->count() > 0;
+    conflictedGroup_->setVisible(hasConflicts);
+
+    if (!status) {
+        summaryLabel_->setText(tr("No repository open"));
+    } else if (status->isClean()) {
+        summaryLabel_->setText(tr("No changes"));
+    } else {
+        summaryLabel_->setText(
+            tr("%1 staged, %2 to review").arg(stagedList_->count()).arg(unstagedList_->count()));
+    }
+
+    commitButton_->setEnabled(stagedList_->count() > 0 && !hasConflicts);
+    stageAllButton_->setEnabled(unstagedList_->count() > 0);
+    unstageAllButton_->setEnabled(stagedList_->count() > 0);
+}
+
+void WorkingCopyView::refreshSelectedDiff() {
+    if (session_ == nullptr) {
+        return;
+    }
+    const auto selection = currentSelection();
+    if (!selection) {
+        diffView_->clearDiff();
+        return;
+    }
+    diffView_->showMessage(tr("Loading changes…"));
+    session_->requestWorkingCopyDiff(selection->path, selection->staged);
+}
+
+void WorkingCopyView::onWorkingCopyStatusUpdated() {
+    rebuildLists();
+}
+
+void WorkingCopyView::onWorkingCopyDiffReady(QString path,
+                                             bool staged,
+                                             std::shared_ptr<const ParsedDiff> diff) {
+    const auto selection = currentSelection();
+    if (!selection || QString::fromStdString(selection->path) != path ||
+        selection->staged != staged) {
+        // The user moved on before this arrived.
+        return;
+    }
+    diffView_->setShowingStagedDiff(staged);
+    diffView_->showDiff(std::move(diff));
+}
+
+void WorkingCopyView::onWorkingCopyOperationFinished(const OperationOutcome& outcome) {
+    if (outcome.succeeded) {
+        emit statusMessage(QString::fromStdString(outcome.summary));
+        // CommitOperation::describe() is exactly "Commit" or "Amend commit";
+        // no other working-copy operation's summary starts that way.
+        if (outcome.summary.rfind("Commit", 0) == 0 || outcome.summary.rfind("Amend", 0) == 0) {
+            messageEdit_->clear();
+            amendCheck_->setChecked(false);
+        }
+        return;
+    }
+    if (outcome.error) {
+        emit errorOccurred(QString::fromStdString(outcome.summary), *outcome.error);
+    }
+}
+
+void WorkingCopyView::onStagedSelectionChanged() {
+    if (stagedList_->selectedItems().isEmpty()) {
+        return;
+    }
+    unstagedList_->blockSignals(true);
+    unstagedList_->clearSelection();
+    unstagedList_->blockSignals(false);
+    refreshSelectedDiff();
+}
+
+void WorkingCopyView::onUnstagedSelectionChanged() {
+    if (unstagedList_->selectedItems().isEmpty()) {
+        return;
+    }
+    stagedList_->blockSignals(true);
+    stagedList_->clearSelection();
+    stagedList_->blockSignals(false);
+    refreshSelectedDiff();
+}
+
+void WorkingCopyView::onStagedItemActivated(QListWidgetItem* item) {
+    if (session_ == nullptr || item == nullptr) {
+        return;
+    }
+    session_->unstageFiles({item->data(Qt::UserRole).toString().toStdString()});
+}
+
+void WorkingCopyView::onUnstagedItemActivated(QListWidgetItem* item) {
+    if (session_ == nullptr || item == nullptr) {
+        return;
+    }
+    session_->stageFiles({item->data(Qt::UserRole).toString().toStdString()});
+}
+
+void WorkingCopyView::onStageAllClicked() {
+    if (session_ == nullptr) {
+        return;
+    }
+    std::vector<std::string> paths;
+    paths.reserve(static_cast<std::size_t>(unstagedList_->count()));
+    for (int row = 0; row < unstagedList_->count(); ++row) {
+        paths.push_back(unstagedList_->item(row)->data(Qt::UserRole).toString().toStdString());
+    }
+    if (!paths.empty()) {
+        session_->stageFiles(std::move(paths));
+    }
+}
+
+void WorkingCopyView::onUnstageAllClicked() {
+    if (session_ == nullptr) {
+        return;
+    }
+    std::vector<std::string> paths;
+    paths.reserve(static_cast<std::size_t>(stagedList_->count()));
+    for (int row = 0; row < stagedList_->count(); ++row) {
+        paths.push_back(stagedList_->item(row)->data(Qt::UserRole).toString().toStdString());
+    }
+    if (!paths.empty()) {
+        session_->unstageFiles(std::move(paths));
+    }
+}
+
+void WorkingCopyView::onCommitClicked() {
+    if (session_ == nullptr) {
+        return;
+    }
+    CommitRequest request;
+    request.message = messageEdit_->toPlainText().toStdString();
+    request.amend = amendCheck_->isChecked();
+    session_->commitChanges(request);
+}
+
+void WorkingCopyView::onApplyPatchRequested(QString patch, bool reverse) {
+    if (session_ == nullptr) {
+        return;
+    }
+    session_->applyPatch(patch.toStdString(), reverse);
+}
+
+}  // namespace gbm

--- a/src/app/views/WorkingCopyView.h
+++ b/src/app/views/WorkingCopyView.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "app/views/DiffView.h"
+#include "core/base/Error.h"
+#include "core/git/OperationRunner.h"
+
+#include <QWidget>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+class QCheckBox;
+class QLabel;
+class QListWidget;
+class QListWidgetItem;
+class QPlainTextEdit;
+class QPushButton;
+
+namespace gbm {
+
+class RepositorySession;
+
+/// The working-copy panel: status, stage/unstage by file, hunk and line, and
+/// commit/amend -- M1's working-copy slice wired into one view. Hunk- and
+/// line-level staging live in the embedded DiffView's context menu; this
+/// class owns whole-file staging, the two status lists, and the commit box.
+class WorkingCopyView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WorkingCopyView(QWidget* parent = nullptr);
+
+    /// Attaches to a repository, or detaches (and clears everything) when
+    /// `session` is null.
+    void setSession(RepositorySession* session);
+
+signals:
+    void statusMessage(QString message);
+    void errorOccurred(QString summary, GitError error);
+
+private slots:
+    void onWorkingCopyStatusUpdated();
+    void onWorkingCopyDiffReady(QString path, bool staged, std::shared_ptr<const ParsedDiff> diff);
+    void onWorkingCopyOperationFinished(const OperationOutcome& outcome);
+    void onStagedSelectionChanged();
+    void onUnstagedSelectionChanged();
+    void onStagedItemActivated(QListWidgetItem* item);
+    void onUnstagedItemActivated(QListWidgetItem* item);
+    void onStageAllClicked();
+    void onUnstageAllClicked();
+    void onCommitClicked();
+    void onApplyPatchRequested(QString patch, bool reverse);
+
+private:
+    void buildUi();
+    void rebuildLists();
+    void refreshSelectedDiff();
+
+    struct Selection {
+        std::string path;
+        bool staged = false;
+    };
+
+    /// The path + side currently selected across the two lists (at most one
+    /// list ever has a selection at a time -- see onStaged/UnstagedSelectionChanged).
+    std::optional<Selection> currentSelection() const;
+
+    RepositorySession* session_ = nullptr;
+
+    QLabel* summaryLabel_ = nullptr;
+    QWidget* conflictedGroup_ = nullptr;
+    QListWidget* conflictedList_ = nullptr;
+    QListWidget* stagedList_ = nullptr;
+    QListWidget* unstagedList_ = nullptr;
+    QPushButton* stageAllButton_ = nullptr;
+    QPushButton* unstageAllButton_ = nullptr;
+    DiffView* diffView_ = nullptr;
+    QPlainTextEdit* messageEdit_ = nullptr;
+    QCheckBox* amendCheck_ = nullptr;
+    QPushButton* commitButton_ = nullptr;
+};
+
+}  // namespace gbm

--- a/tests/ui/ModelsTest.cpp
+++ b/tests/ui/ModelsTest.cpp
@@ -8,21 +8,14 @@
 // The other thing pinned down here is the non-blocking `data()` contract. On a
 // 500k-row history, one synchronous read inside `data()` would be called once per
 // visible cell per frame, so a counter proves it never happens.
-#include "app/bridge/RepositorySession.h"
 #include "app/models/CommitListModel.h"
 #include "app/models/GraphColumnDelegate.h"
 #include "app/models/RefTreeModel.h"
 #include "app/models/RepoListModel.h"
-#include "core/git/GitExecutable.h"
 #include "core/graph/GraphBuilder.h"
-#include "core/workers/ThreadPool.h"
 
 #include <QAbstractItemModelTester>
-#include <QDir>
-#include <QFile>
-#include <QProcess>
 #include <QSignalSpy>
-#include <QTemporaryDir>
 #include <QtTest>
 
 #include <vector>
@@ -77,16 +70,6 @@ RefSnapshotPtr makeRefs() {
     return snapshot;
 }
 
-bool runGit(const QString& gitExecutable, const QString& dir, const QStringList& args) {
-    QProcess process;
-    process.setWorkingDirectory(dir);
-    process.start(gitExecutable, args);
-    if (!process.waitForFinished(10000)) {
-        return false;
-    }
-    return process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0;
-}
-
 }  // namespace
 
 class ModelsTest : public QObject {
@@ -102,7 +85,6 @@ private slots:
     void commitListModelNeverBlocksInData();
     void graphDelegateWidthShrinksForLinearHistory();
     void graphDelegatePaletteCoversEveryLaneColor();
-    void repositorySessionTracksWorkingCopyStagingAndCommit();
 };
 
 void ModelsTest::repoListModelSatisfiesTheModelContract() {
@@ -288,115 +270,6 @@ void ModelsTest::graphDelegatePaletteCoversEveryLaneColor() {
     }
     // Out-of-range indices wrap rather than producing an invalid colour.
     QVERIFY(GraphColumnDelegate::laneColor(200).isValid());
-}
-
-void ModelsTest::repositorySessionTracksWorkingCopyStagingAndCommit() {
-    // Exercises the RepositorySession plumbing added for the working-copy
-    // panel end to end, against a real git binary and a real repository --
-    // the same "no usable git" skip RealRepoTest uses, since this app-layer
-    // test cannot assume one is installed either.
-    auto detected = GitExecutable::detect();
-    if (!detected) {
-        QSKIP("no usable git found");
-    }
-    const QString gitExecutable = QString::fromStdString(detected->executable.string());
-
-    QTemporaryDir tempDir;
-    QVERIFY(tempDir.isValid());
-    const QString dir = tempDir.path();
-
-    QVERIFY(runGit(gitExecutable, dir, {"init", "--quiet", "--initial-branch=main"}));
-    QVERIFY(runGit(gitExecutable, dir, {"config", "user.email", "test@example.invalid"}));
-    QVERIFY(runGit(gitExecutable, dir, {"config", "user.name", "Test"}));
-    QVERIFY(runGit(gitExecutable, dir, {"config", "commit.gpgsign", "false"}));
-
-    auto writeFile = [&dir](const QString& name, const QString& content) {
-        QFile file(QDir(dir).filePath(name));
-        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
-        file.write(content.toUtf8());
-    };
-
-    writeFile(QStringLiteral("a.txt"), QStringLiteral("one\n"));
-    QVERIFY(runGit(gitExecutable, dir, {"add", "a.txt"}));
-    QVERIFY(runGit(gitExecutable, dir, {"commit", "--quiet", "-m", "c1"}));
-
-    // An unstaged modification for the session to discover.
-    writeFile(QStringLiteral("a.txt"), QStringLiteral("one\ntwo\n"));
-
-    ThreadPool pool("model-test-reads", 2);
-    const RepoPaths paths(
-        dir.toStdString(), (dir + QStringLiteral("/.git")).toStdString(), std::string());
-    RepositorySession session(*detected, paths, pool);
-
-    bool statusUpdated = false;
-    connect(&session, &RepositorySession::workingCopyStatusUpdated, &session, [&] {
-        statusUpdated = true;
-    });
-    bool sawError = false;
-    connect(&session, &RepositorySession::errorOccurred, &session, [&](const GitError&) {
-        sawError = true;
-    });
-
-    session.refreshWorkingCopyStatus();
-    QTRY_VERIFY(statusUpdated);
-    QVERIFY(!sawError);
-
-    auto status = session.workingCopyStatus();
-    QVERIFY(status);
-    QCOMPARE(status->unstaged().size(), std::size_t{1});
-    QCOMPARE(QString::fromStdString(status->unstaged().front()->path), QStringLiteral("a.txt"));
-    QVERIFY(status->staged().empty());
-
-    // Stage the file and wait for both the completion signal and the
-    // automatic status refresh it triggers.
-    bool stageFinished = false;
-    OperationOutcome stageOutcome;
-    connect(&session,
-            &RepositorySession::workingCopyOperationFinished,
-            &session,
-            [&](const OperationOutcome& outcome) {
-                stageFinished = true;
-                stageOutcome = outcome;
-            });
-    statusUpdated = false;
-    session.stageFiles({"a.txt"});
-    QTRY_VERIFY(stageFinished);
-    QVERIFY2(stageOutcome.succeeded,
-             stageOutcome.error ? stageOutcome.error->detail.c_str() : "stage failed");
-    QTRY_VERIFY(statusUpdated);
-
-    status = session.workingCopyStatus();
-    QVERIFY(status);
-    QCOMPARE(status->staged().size(), std::size_t{1});
-    QVERIFY(status->unstaged().empty());
-
-    // Commit it, which should also move HEAD -- confirmed via a fresh, clean
-    // working-copy status afterwards.
-    disconnect(&session, &RepositorySession::workingCopyOperationFinished, &session, nullptr);
-    bool commitFinished = false;
-    OperationOutcome commitOutcome;
-    connect(&session,
-            &RepositorySession::workingCopyOperationFinished,
-            &session,
-            [&](const OperationOutcome& outcome) {
-                commitFinished = true;
-                commitOutcome = outcome;
-            });
-    statusUpdated = false;
-
-    CommitRequest request;
-    request.message = "Add second line";
-    session.commitChanges(request);
-    QTRY_VERIFY(commitFinished);
-    QVERIFY2(commitOutcome.succeeded,
-             commitOutcome.error ? commitOutcome.error->detail.c_str() : "commit failed");
-    QTRY_VERIFY(statusUpdated);
-
-    status = session.workingCopyStatus();
-    QVERIFY(status);
-    QVERIFY(status->isClean());
-
-    QVERIFY(runGit(gitExecutable, dir, {"log", "-1", "--format=%s"}));
 }
 
 QTEST_MAIN(ModelsTest)

--- a/tests/ui/ModelsTest.cpp
+++ b/tests/ui/ModelsTest.cpp
@@ -8,14 +8,21 @@
 // The other thing pinned down here is the non-blocking `data()` contract. On a
 // 500k-row history, one synchronous read inside `data()` would be called once per
 // visible cell per frame, so a counter proves it never happens.
+#include "app/bridge/RepositorySession.h"
 #include "app/models/CommitListModel.h"
 #include "app/models/GraphColumnDelegate.h"
 #include "app/models/RefTreeModel.h"
 #include "app/models/RepoListModel.h"
+#include "core/git/GitExecutable.h"
 #include "core/graph/GraphBuilder.h"
+#include "core/workers/ThreadPool.h"
 
 #include <QAbstractItemModelTester>
+#include <QDir>
+#include <QFile>
+#include <QProcess>
 #include <QSignalSpy>
+#include <QTemporaryDir>
 #include <QtTest>
 
 #include <vector>
@@ -70,6 +77,16 @@ RefSnapshotPtr makeRefs() {
     return snapshot;
 }
 
+bool runGit(const QString& gitExecutable, const QString& dir, const QStringList& args) {
+    QProcess process;
+    process.setWorkingDirectory(dir);
+    process.start(gitExecutable, args);
+    if (!process.waitForFinished(10000)) {
+        return false;
+    }
+    return process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0;
+}
+
 }  // namespace
 
 class ModelsTest : public QObject {
@@ -85,6 +102,7 @@ private slots:
     void commitListModelNeverBlocksInData();
     void graphDelegateWidthShrinksForLinearHistory();
     void graphDelegatePaletteCoversEveryLaneColor();
+    void repositorySessionTracksWorkingCopyStagingAndCommit();
 };
 
 void ModelsTest::repoListModelSatisfiesTheModelContract() {
@@ -270,6 +288,115 @@ void ModelsTest::graphDelegatePaletteCoversEveryLaneColor() {
     }
     // Out-of-range indices wrap rather than producing an invalid colour.
     QVERIFY(GraphColumnDelegate::laneColor(200).isValid());
+}
+
+void ModelsTest::repositorySessionTracksWorkingCopyStagingAndCommit() {
+    // Exercises the RepositorySession plumbing added for the working-copy
+    // panel end to end, against a real git binary and a real repository --
+    // the same "no usable git" skip RealRepoTest uses, since this app-layer
+    // test cannot assume one is installed either.
+    auto detected = GitExecutable::detect();
+    if (!detected) {
+        QSKIP("no usable git found");
+    }
+    const QString gitExecutable = QString::fromStdString(detected->executable.string());
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString dir = tempDir.path();
+
+    QVERIFY(runGit(gitExecutable, dir, {"init", "--quiet", "--initial-branch=main"}));
+    QVERIFY(runGit(gitExecutable, dir, {"config", "user.email", "test@example.invalid"}));
+    QVERIFY(runGit(gitExecutable, dir, {"config", "user.name", "Test"}));
+    QVERIFY(runGit(gitExecutable, dir, {"config", "commit.gpgsign", "false"}));
+
+    auto writeFile = [&dir](const QString& name, const QString& content) {
+        QFile file(QDir(dir).filePath(name));
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        file.write(content.toUtf8());
+    };
+
+    writeFile(QStringLiteral("a.txt"), QStringLiteral("one\n"));
+    QVERIFY(runGit(gitExecutable, dir, {"add", "a.txt"}));
+    QVERIFY(runGit(gitExecutable, dir, {"commit", "--quiet", "-m", "c1"}));
+
+    // An unstaged modification for the session to discover.
+    writeFile(QStringLiteral("a.txt"), QStringLiteral("one\ntwo\n"));
+
+    ThreadPool pool("model-test-reads", 2);
+    const RepoPaths paths(
+        dir.toStdString(), (dir + QStringLiteral("/.git")).toStdString(), std::string());
+    RepositorySession session(*detected, paths, pool);
+
+    bool statusUpdated = false;
+    connect(&session, &RepositorySession::workingCopyStatusUpdated, &session, [&] {
+        statusUpdated = true;
+    });
+    bool sawError = false;
+    connect(&session, &RepositorySession::errorOccurred, &session, [&](const GitError&) {
+        sawError = true;
+    });
+
+    session.refreshWorkingCopyStatus();
+    QTRY_VERIFY(statusUpdated);
+    QVERIFY(!sawError);
+
+    auto status = session.workingCopyStatus();
+    QVERIFY(status);
+    QCOMPARE(status->unstaged().size(), std::size_t{1});
+    QCOMPARE(QString::fromStdString(status->unstaged().front()->path), QStringLiteral("a.txt"));
+    QVERIFY(status->staged().empty());
+
+    // Stage the file and wait for both the completion signal and the
+    // automatic status refresh it triggers.
+    bool stageFinished = false;
+    OperationOutcome stageOutcome;
+    connect(&session,
+            &RepositorySession::workingCopyOperationFinished,
+            &session,
+            [&](const OperationOutcome& outcome) {
+                stageFinished = true;
+                stageOutcome = outcome;
+            });
+    statusUpdated = false;
+    session.stageFiles({"a.txt"});
+    QTRY_VERIFY(stageFinished);
+    QVERIFY2(stageOutcome.succeeded,
+             stageOutcome.error ? stageOutcome.error->detail.c_str() : "stage failed");
+    QTRY_VERIFY(statusUpdated);
+
+    status = session.workingCopyStatus();
+    QVERIFY(status);
+    QCOMPARE(status->staged().size(), std::size_t{1});
+    QVERIFY(status->unstaged().empty());
+
+    // Commit it, which should also move HEAD -- confirmed via a fresh, clean
+    // working-copy status afterwards.
+    disconnect(&session, &RepositorySession::workingCopyOperationFinished, &session, nullptr);
+    bool commitFinished = false;
+    OperationOutcome commitOutcome;
+    connect(&session,
+            &RepositorySession::workingCopyOperationFinished,
+            &session,
+            [&](const OperationOutcome& outcome) {
+                commitFinished = true;
+                commitOutcome = outcome;
+            });
+    statusUpdated = false;
+
+    CommitRequest request;
+    request.message = "Add second line";
+    session.commitChanges(request);
+    QTRY_VERIFY(commitFinished);
+    QVERIFY2(commitOutcome.succeeded,
+             commitOutcome.error ? commitOutcome.error->detail.c_str() : "commit failed");
+    QTRY_VERIFY(statusUpdated);
+
+    status = session.workingCopyStatus();
+    QVERIFY(status);
+    QVERIFY(status->isClean());
+
+    QVERIFY(runGit(gitExecutable, dir, {"log", "-1", "--format=%s"}));
 }
 
 QTEST_MAIN(ModelsTest)


### PR DESCRIPTION
Wires the M1 core-layer working-copy pieces (status, StageOps, CommitOps) into the Qt app, closing out M1's UI slice:

- RepositorySession: refreshWorkingCopyStatus/requestWorkingCopyDiff/ stageFiles/unstageFiles/applyPatch/commitChanges, following the existing worker-thread -> QueuedConnection -> signal pattern. Staging and commit operations auto-refresh the status snapshot (and, for a commit, refs and the history graph) on success.
- DiffView: tracks each hunk's QTextBlock span during render and adds a staging-aware context menu -- "Stage/Unstage Hunk" always, plus "Stage/Unstage Selected Lines" when the text selection falls inside one hunk's body -- built on the existing buildHunkPatch/buildLineSelectionPatch.
- WorkingCopyView: new panel with staged/unstaged/untracked/conflicted file lists (double-click to toggle stage, Stage All/Unstage All), a commit message box with Amend, and an embedded staging-enabled DiffView. Restores the selected file across a status refresh so staging a hunk doesn't blank the pane the user is looking at.
- MainWindow: new "Working Copy" page (Ctrl+2) alongside History (Ctrl+1).

Branch create/rename/delete (also under M1) already had UI via the existing ref tree and Branch menu.

Added a RepositorySession-level Qt test (against a real git binary) covering refresh -> stage -> commit -> clean-status, on top of the existing core integration tests.