### PR TITLE
feat: merge, cherry-pick, conflict resolution and side-by-side diff (M2)

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -25,6 +25,7 @@ qt_add_executable(git-branch-manager
     views/DiffView.cpp
     views/MainWindow.cpp
     views/OperationLogView.cpp
+    views/SideBySideDiffView.cpp
     views/WorkingCopyView.cpp
 )
 

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -303,4 +303,86 @@ void RepositorySession::commitChanges(const CommitRequest& request) {
     submitWorkingCopyOperation(makeCommitOperation(request), true);
 }
 
+void RepositorySession::mergeBranch(const MergeRequest& request) {
+    submitWorkingCopyOperation(makeMergeOperation(request), true);
+}
+
+void RepositorySession::abortMerge() {
+    submitWorkingCopyOperation(makeMergeAbortOperation(), true);
+}
+
+void RepositorySession::cherryPick(const CherryPickRequest& request) {
+    submitWorkingCopyOperation(makeCherryPickOperation(request), true);
+}
+
+void RepositorySession::continueCherryPick() {
+    submitWorkingCopyOperation(makeCherryPickContinueOperation(), true);
+}
+
+void RepositorySession::skipCherryPick() {
+    submitWorkingCopyOperation(makeCherryPickSkipOperation(), true);
+}
+
+void RepositorySession::abortCherryPick() {
+    submitWorkingCopyOperation(makeCherryPickAbortOperation(), true);
+}
+
+void RepositorySession::resolveConflict(const ResolveConflictRequest& request) {
+    // Never moves HEAD, so no refreshRefs/refreshHistory -- just the
+    // working-copy status, to update the conflicted list.
+    submitWorkingCopyOperation(makeResolveConflictOperation(request), false);
+}
+
+void RepositorySession::requestConflictSides(const std::string& path,
+                                             const std::string& ancestorBlob,
+                                             const std::string& oursBlob,
+                                             const std::string& theirsBlob) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.postFront([this, path, ancestorBlob, oursBlob, theirsBlob, token] {
+        if (token.isCancelled()) {
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+        if (auto started = catFile_->start(); !started) {
+            GitError error = std::move(started).error();
+            QMetaObject::invokeMethod(
+                this,
+                [this, error] {
+                    setBusy(false);
+                    emit errorOccurred(error);
+                },
+                Qt::QueuedConnection);
+            return;
+        }
+
+        // Best-effort: a stage that fails to read (or does not exist) shows as
+        // empty rather than failing the whole request, so the two sides that
+        // did read are still shown.
+        auto readOrEmpty = [this](const std::string& blob) {
+            if (blob.empty()) {
+                return std::string();
+            }
+            auto object = catFile_->read(blob);
+            return object ? object->content : std::string();
+        };
+        const std::string ancestor = readOrEmpty(ancestorBlob);
+        const std::string ours = readOrEmpty(oursBlob);
+        const std::string theirs = readOrEmpty(theirsBlob);
+
+        const QString qpath = QString::fromStdString(path);
+        QMetaObject::invokeMethod(
+            this,
+            [this, qpath, ancestor, ours, theirs] {
+                setBusy(false);
+                emit conflictSidesReady(qpath,
+                                        QString::fromStdString(ancestor),
+                                        QString::fromStdString(ours),
+                                        QString::fromStdString(theirs));
+            },
+            Qt::QueuedConnection);
+    });
+}
+
 }  // namespace gbm

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -11,7 +11,10 @@
 #include "core/git/RepoState.h"
 #include "core/git/WorkingCopyStatus.h"
 #include "core/git/ops/CheckoutOp.h"
+#include "core/git/ops/CherryPickOps.h"
 #include "core/git/ops/CommitOps.h"
+#include "core/git/ops/ConflictOps.h"
+#include "core/git/ops/MergeOps.h"
 #include "core/git/ops/StageOps.h"
 #include "core/graph/GraphSnapshot.h"
 #include "core/workers/ThreadPool.h"
@@ -94,6 +97,33 @@ public:
 
     void commitChanges(const CommitRequest& request);
 
+    /// `git merge`, in whichever mode the request asks for. A conflict is
+    /// reported through `workingCopyOperationFinished` exactly like any other
+    /// failure -- see MergeOps.h -- and the conflicted paths then show up in
+    /// the next `workingCopyStatusUpdated`.
+    void mergeBranch(const MergeRequest& request);
+    void abortMerge();
+
+    /// `git cherry-pick`, for a single commit, several, or a caller-expanded
+    /// range (see RefStore::resolveRange). Applies in the order the request's
+    /// commits are listed.
+    void cherryPick(const CherryPickRequest& request);
+    void continueCherryPick();
+    void skipCherryPick();
+    void abortCherryPick();
+
+    /// Resolves one conflicted path from a stopped merge/cherry-pick/revert.
+    void resolveConflict(const ResolveConflictRequest& request);
+
+    /// Reads the three stages' blob content for a conflicted path, so a
+    /// resolution view can show ancestor/ours/theirs without running `git
+    /// checkout --ours/--theirs` just to look. Empty strings for a stage that
+    /// does not exist -- see WorkingCopyEntry::ancestorBlob et al.
+    void requestConflictSides(const std::string& path,
+                              const std::string& ancestorBlob,
+                              const std::string& oursBlob,
+                              const std::string& theirsBlob);
+
 signals:
     /// A newer graph snapshot is available (possibly partial).
     void graphUpdated(bool complete);
@@ -108,6 +138,11 @@ signals:
 
     void workingCopyStatusUpdated();
     void workingCopyDiffReady(QString path, bool staged, std::shared_ptr<const ParsedDiff> diff);
+    /// Reply to requestConflictSides, matched back up by path. A stage's
+    /// content is empty both when that stage does not exist and when reading
+    /// it failed -- the request is best-effort display, not itself an
+    /// operation worth failing loudly over.
+    void conflictSidesReady(QString path, QString ancestor, QString ours, QString theirs);
     /// Separate from `operationFinished`: MainWindow's checkout-recovery UI
     /// (stash/discard choices) does not apply to staging and commit, so the
     /// working-copy panel gets its own completion signal to react to.

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -5,15 +5,18 @@
 #include <QAction>
 #include <QApplication>
 #include <QDialog>
+#include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QInputDialog>
 #include <QLineEdit>
+#include <QListWidget>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QScrollBar>
 #include <QSplitter>
 #include <QStackedWidget>
@@ -276,6 +279,14 @@ void MainWindow::buildMenus() {
     auto* checkoutAction = branchMenu->addAction(
         QStringLiteral("Switch to selected branch"), this, &MainWindow::onCheckoutRequested);
     checkoutAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+O")));
+    auto* mergeAction = branchMenu->addAction(
+        QStringLiteral("Merge selected branch into current…"), this, &MainWindow::onMergeRequested);
+    mergeAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+M")));
+    auto* cherryPickAction =
+        branchMenu->addAction(QStringLiteral("Cherry-pick selected commit(s)…"),
+                              this,
+                              &MainWindow::onCherryPickRequested);
+    cherryPickAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+C")));
 
     auto* historyAction =
         viewMenu->addAction(QStringLiteral("History"), this, &MainWindow::onShowHistory);
@@ -564,6 +575,14 @@ void MainWindow::openRepository(const RepoRecord& record) {
     connect(session_.get(), &RepositorySession::busyChanged, this, [this](bool busy) {
         busyBar_->setVisible(busy);
     });
+    // Merge, cherry-pick and conflict resolution all move through
+    // workingCopyOperationFinished (WorkingCopyView already reacts to it for the
+    // staging/commit case); the banner reflects RepoState, which all of them can
+    // change, so it needs to refresh here too regardless of what else reacts.
+    connect(session_.get(),
+            &RepositorySession::workingCopyOperationFinished,
+            this,
+            [this](const OperationOutcome&) { updateStateBanner(); });
 
     commitModel_->setSession(session_.get());
     diffView_->clearDiff();
@@ -809,6 +828,186 @@ void MainWindow::onOperationFinished(const OperationOutcome& outcome) {
     if (outcome.error) {
         showError(QString::fromStdString(outcome.summary), *outcome.error);
     }
+}
+
+void MainWindow::onMergeRequested() {
+    if (!session_) {
+        return;
+    }
+    const QModelIndexList selected = refView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        return;
+    }
+    const QString name = refModel_->refNameAt(selected.first());
+    if (name.isEmpty()) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Merge"));
+    auto* layout = new QVBoxLayout(&dialog);
+    layout->addWidget(
+        new QLabel(QStringLiteral("Merge \"%1\" into the current branch:").arg(name), &dialog));
+
+    auto* ffOnly = new QRadioButton(QStringLiteral("Fast-forward only"), &dialog);
+    auto* noFf =
+        new QRadioButton(QStringLiteral("Create a merge commit (no fast-forward)"), &dialog);
+    auto* squash =
+        new QRadioButton(QStringLiteral("Squash (stage the changes, no commit)"), &dialog);
+    noFf->setChecked(true);
+    layout->addWidget(ffOnly);
+    layout->addWidget(noFf);
+    layout->addWidget(squash);
+
+    auto* messageEdit = new QLineEdit(&dialog);
+    messageEdit->setPlaceholderText(
+        QStringLiteral("Merge commit message (used only when creating a merge commit)"));
+    layout->addWidget(messageEdit);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    layout->addWidget(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    MergeRequest request;
+    request.target = name.toStdString();
+    request.mode = squash->isChecked()   ? MergeMode::Squash
+                   : ffOnly->isChecked() ? MergeMode::FastForwardOnly
+                                         : MergeMode::NoFastForward;
+    request.message = messageEdit->text().toStdString();
+
+    statusLabel_->setText(QStringLiteral("Merging %1…").arg(name));
+    armWorkingCopyChoiceHandler(
+        [this, request](bool stashFirst) mutable {
+            request.stashFirst = stashFirst;
+            session_->mergeBranch(request);
+        },
+        false);
+}
+
+void MainWindow::onCherryPickRequested() {
+    if (!session_) {
+        return;
+    }
+    const QModelIndexList selected = commitView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        return;
+    }
+
+    // The list is newest-first; a cherry-pick must apply oldest first, so sort
+    // descending by row (a higher row number is further back in history).
+    std::vector<int> rows;
+    rows.reserve(static_cast<std::size_t>(selected.size()));
+    for (const QModelIndex& index : selected) {
+        rows.push_back(index.row());
+    }
+    std::sort(rows.begin(), rows.end(), std::greater<>());
+
+    std::vector<ObjectId> commits;
+    commits.reserve(rows.size());
+    QStringList subjects;
+    for (int row : rows) {
+        commits.push_back(commitModel_->oidAt(row));
+        const QModelIndex subjectIndex = commitModel_->index(row, CommitListModel::ColumnSubject);
+        subjects << commitModel_->data(subjectIndex, Qt::DisplayRole).toString();
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Cherry-pick"));
+    auto* layout = new QVBoxLayout(&dialog);
+    layout->addWidget(new QLabel(
+        commits.size() == 1
+            ? QStringLiteral("Cherry-pick this commit onto the current branch:")
+            : QStringLiteral("Cherry-pick these %1 commits onto the current branch, oldest first:")
+                  .arg(commits.size()),
+        &dialog));
+
+    auto* list = new QListWidget(&dialog);
+    list->setSelectionMode(QAbstractItemView::NoSelection);
+    for (int i = 0; i < subjects.size(); ++i) {
+        new QListWidgetItem(
+            QString::fromStdString(commits[static_cast<std::size_t>(i)].shortHex()) +
+                QStringLiteral("  ") + subjects[i],
+            list);
+    }
+    layout->addWidget(list);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    layout->addWidget(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    dialog.resize(480, 320);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    CherryPickRequest request;
+    request.commits = std::move(commits);
+
+    statusLabel_->setText(QStringLiteral("Cherry-picking…"));
+    armWorkingCopyChoiceHandler(
+        [this, request](bool stashFirst) mutable {
+            request.stashFirst = stashFirst;
+            session_->cherryPick(request);
+        },
+        false);
+}
+
+void MainWindow::armWorkingCopyChoiceHandler(std::function<void(bool)> submit, bool stashFirst) {
+    // A one-shot connection: the handler disconnects itself the moment it runs,
+    // so it never reacts to an unrelated working-copy operation finishing later.
+    auto connection = std::make_shared<QMetaObject::Connection>();
+    *connection =
+        connect(session_.get(),
+                &RepositorySession::workingCopyOperationFinished,
+                this,
+                [this, submit, connection](const OperationOutcome& outcome) {
+                    QObject::disconnect(*connection);
+
+                    if (outcome.succeeded) {
+                        statusLabel_->setText(QString::fromStdString(outcome.summary));
+                        return;
+                    }
+                    if (outcome.choices.empty()) {
+                        if (outcome.error) {
+                            showError(QString::fromStdString(outcome.summary), *outcome.error);
+                        }
+                        return;
+                    }
+
+                    QMessageBox box(this);
+                    box.setIcon(QMessageBox::Warning);
+                    box.setText(QString::fromStdString(outcome.summary));
+                    if (outcome.error) {
+                        box.setDetailedText(QString::fromStdString(outcome.error->detail));
+                    }
+                    std::vector<QPushButton*> buttons;
+                    buttons.reserve(outcome.choices.size());
+                    for (const OperationChoice& choice : outcome.choices) {
+                        auto* button = box.addButton(QString::fromStdString(choice.label),
+                                                     choice.kind == OperationChoice::Kind::Abort
+                                                         ? QMessageBox::RejectRole
+                                                         : QMessageBox::ActionRole);
+                        button->setToolTip(QString::fromStdString(choice.explanation));
+                        buttons.push_back(button);
+                    }
+                    box.exec();
+                    for (std::size_t i = 0; i < buttons.size(); ++i) {
+                        if (box.clickedButton() != buttons[i]) {
+                            continue;
+                        }
+                        if (outcome.choices[i].kind == OperationChoice::Kind::StashAndRetry) {
+                            armWorkingCopyChoiceHandler(submit, true);
+                        }
+                        break;
+                    }
+                });
+    submit(stashFirst);
 }
 
 void MainWindow::onCoreError(const GitError& error) {

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -17,6 +17,7 @@
 #include <QTableView>
 #include <QTreeView>
 
+#include <functional>
 #include <memory>
 
 class QLineEdit;
@@ -48,6 +49,8 @@ private slots:
     void onCommitSelectionChanged();
     void onRefActivated(const QModelIndex& index);
     void onCheckoutRequested();
+    void onMergeRequested();
+    void onCherryPickRequested();
     void onGraphUpdated(bool complete);
     void onCommitDetailsReady(const ObjectId& commit,
                               std::shared_ptr<const std::vector<ChangedFile>> files,
@@ -67,6 +70,15 @@ private:
     void probeVisibleRepos();
     void updateStateBanner();
     void showError(const QString& summary, const GitError& error);
+
+    /// Submits a merge/cherry-pick style request and waits for exactly one
+    /// `workingCopyOperationFinished`. On success or a plain error, reports it
+    /// and is done. On a recoverable choice (currently always
+    /// stash-and-retry-or-abort), shows it and, if the user picks retry,
+    /// re-arms itself and calls `submit(true)` again -- so `submit` never runs
+    /// more than once per user decision, and this needs no member state to
+    /// carry the retry across the asynchronous round trip.
+    void armWorkingCopyChoiceHandler(std::function<void(bool stashFirst)> submit, bool stashFirst);
 
     GitInstallation installation_;
 

--- a/src/app/views/SideBySideDiffView.cpp
+++ b/src/app/views/SideBySideDiffView.cpp
@@ -1,0 +1,210 @@
+#include "app/views/SideBySideDiffView.h"
+
+#include "core/git/SideBySideDiff.h"
+
+#include <QFontDatabase>
+#include <QHBoxLayout>
+#include <QPlainTextEdit>
+#include <QScrollBar>
+#include <QTextCharFormat>
+#include <QTextCursor>
+
+namespace gbm {
+
+namespace {
+
+// Same palette-derived scheme as DiffView, so switching between unified and
+// side-by-side never looks like a different tool.
+QColor addedBackground(const QPalette& palette) {
+    const bool dark = palette.base().color().lightness() < 128;
+    return dark ? QColor(46, 92, 54, 90) : QColor(214, 245, 214);
+}
+
+QColor removedBackground(const QPalette& palette) {
+    const bool dark = palette.base().color().lightness() < 128;
+    return dark ? QColor(120, 45, 45, 90) : QColor(255, 220, 220);
+}
+
+// Filler for the side with nothing to show, distinct from (and quieter than)
+// both the added/removed tints and the ordinary background.
+QColor paddingBackground(const QPalette& palette) {
+    const bool dark = palette.base().color().lightness() < 128;
+    return dark ? QColor(255, 255, 255, 10) : QColor(0, 0, 0, 12);
+}
+
+QPlainTextEdit* makePane(QWidget* parent) {
+    auto* edit = new QPlainTextEdit(parent);
+    edit->setReadOnly(true);
+    edit->setLineWrapMode(QPlainTextEdit::NoWrap);
+    edit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    edit->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+    edit->setUndoRedoEnabled(false);
+    return edit;
+}
+
+}  // namespace
+
+SideBySideDiffView::SideBySideDiffView(QWidget* parent) : QWidget(parent) {
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(1);
+
+    left_ = makePane(this);
+    right_ = makePane(this);
+    left_->setPlaceholderText(QStringLiteral("Select a commit to see its changes"));
+    layout->addWidget(left_);
+    layout->addWidget(right_);
+
+    connect(left_->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
+        if (syncingScroll_) {
+            return;
+        }
+        syncingScroll_ = true;
+        right_->verticalScrollBar()->setValue(value);
+        syncingScroll_ = false;
+    });
+    connect(right_->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
+        if (syncingScroll_) {
+            return;
+        }
+        syncingScroll_ = true;
+        left_->verticalScrollBar()->setValue(value);
+        syncingScroll_ = false;
+    });
+}
+
+void SideBySideDiffView::clearDiff() {
+    diff_.reset();
+    left_->clear();
+    right_->clear();
+}
+
+void SideBySideDiffView::showMessage(const QString& message) {
+    diff_.reset();
+    left_->clear();
+    right_->clear();
+    left_->appendPlainText(message);
+}
+
+void SideBySideDiffView::showDiff(std::shared_ptr<const ParsedDiff> diff) {
+    diff_ = std::move(diff);
+    left_->clear();
+    right_->clear();
+    if (diff_) {
+        render(*diff_, QString());
+    }
+}
+
+void SideBySideDiffView::showFile(std::shared_ptr<const ParsedDiff> diff, const QString& path) {
+    diff_ = std::move(diff);
+    left_->clear();
+    right_->clear();
+    if (diff_) {
+        render(*diff_, path);
+    }
+}
+
+void SideBySideDiffView::render(const ParsedDiff& diff, const QString& onlyPath) {
+    QTextCursor leftCursor(left_->document());
+    QTextCursor rightCursor(right_->document());
+    leftCursor.beginEditBlock();
+    rightCursor.beginEditBlock();
+
+    QTextCharFormat plain;
+    QTextCharFormat header;
+    header.setFontWeight(QFont::Bold);
+    QTextCharFormat hunkHeader;
+    hunkHeader.setForeground(palette().color(QPalette::Link));
+    QTextCharFormat added;
+    added.setBackground(addedBackground(palette()));
+    QTextCharFormat removed;
+    removed.setBackground(removedBackground(palette()));
+    QTextCharFormat dim;
+    dim.setForeground(palette().color(QPalette::Disabled, QPalette::Text));
+    QTextCharFormat padding;
+    padding.setBackground(paddingBackground(palette()));
+
+    auto insertLine = [](QTextCursor& cursor, const QString& text, const QTextCharFormat& format) {
+        cursor.insertText(text + QStringLiteral("\n"), format);
+    };
+
+    auto insertCell = [&](QTextCursor& cursor, const DiffLine* line) {
+        if (line == nullptr) {
+            insertLine(cursor, QString(), padding);
+            return;
+        }
+        switch (line->kind) {
+            case DiffLineKind::Added:
+                insertLine(cursor, QString::fromStdString(line->text), added);
+                break;
+            case DiffLineKind::Removed:
+                insertLine(cursor, QString::fromStdString(line->text), removed);
+                break;
+            case DiffLineKind::Context:
+                insertLine(cursor, QString::fromStdString(line->text), plain);
+                break;
+            case DiffLineKind::NoNewlineMarker:
+                insertLine(cursor, QString::fromStdString(line->text), dim);
+                break;
+        }
+    };
+
+    bool renderedAnything = false;
+
+    for (const DiffFile& file : diff.files) {
+        const QString displayPath = QString::fromStdString(file.displayPath());
+        if (!onlyPath.isEmpty() && displayPath != onlyPath) {
+            continue;
+        }
+        renderedAnything = true;
+
+        insertLine(leftCursor, displayPath, header);
+        insertLine(rightCursor, displayPath, header);
+
+        if (file.binary) {
+            insertLine(leftCursor, QStringLiteral("Binary file not shown"), dim);
+            insertLine(rightCursor, QString(), dim);
+            continue;
+        }
+        if (file.hunks.empty()) {
+            insertLine(leftCursor, QStringLiteral("No textual changes"), dim);
+            insertLine(rightCursor, QString(), dim);
+            continue;
+        }
+
+        for (const DiffHunk& hunk : file.hunks) {
+            const QString hunkLine = QStringLiteral("@@ -%1,%2 +%3,%4 @@")
+                                         .arg(hunk.oldStart)
+                                         .arg(hunk.oldCount)
+                                         .arg(hunk.newStart)
+                                         .arg(hunk.newCount);
+            insertLine(leftCursor, hunkLine, hunkHeader);
+            insertLine(rightCursor, hunkLine, hunkHeader);
+
+            for (const SideBySideRow& row : pairHunkForSideBySide(hunk)) {
+                insertCell(leftCursor, row.left);
+                insertCell(rightCursor, row.right);
+            }
+        }
+        insertLine(leftCursor, QString(), plain);
+        insertLine(rightCursor, QString(), plain);
+    }
+
+    if (diff.truncated) {
+        const QString message =
+            QStringLiteral("… diff truncated because it exceeds the display limit");
+        insertLine(leftCursor, message, dim);
+        insertLine(rightCursor, QString(), dim);
+    }
+    if (!renderedAnything) {
+        insertLine(leftCursor, QStringLiteral("No changes to show"), dim);
+        insertLine(rightCursor, QString(), dim);
+    }
+
+    leftCursor.endEditBlock();
+    rightCursor.endEditBlock();
+    left_->moveCursor(QTextCursor::Start);
+    right_->moveCursor(QTextCursor::Start);
+}
+
+}  // namespace gbm

--- a/src/app/views/SideBySideDiffView.h
+++ b/src/app/views/SideBySideDiffView.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "core/git/UnifiedDiffParser.h"
+
+#include <QWidget>
+
+#include <memory>
+
+class QPlainTextEdit;
+
+namespace gbm {
+
+/// Side-by-side alternative to DiffView, built on the same ParsedDiff.
+///
+/// Two read-only panes, kept vertically in lock-step by construction rather
+/// than by scroll-syncing alone: SideBySideDiff::pairHunkForSideBySide already
+/// produces one row per rendered line, with a blank on whichever side has
+/// nothing to show, so inserting exactly one line into both panes per row is
+/// what keeps a context line lined up with its counterpart even across an
+/// unequal add/remove run. Scroll position is then only a presentation detail,
+/// synced so the two panes track each other during manual scrolling too.
+class SideBySideDiffView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit SideBySideDiffView(QWidget* parent = nullptr);
+
+    void showDiff(std::shared_ptr<const ParsedDiff> diff);
+
+    /// Shows a single file from a multi-file diff.
+    void showFile(std::shared_ptr<const ParsedDiff> diff, const QString& path);
+
+    void showMessage(const QString& message);
+
+    void clearDiff();
+
+private:
+    void render(const ParsedDiff& diff, const QString& onlyPath);
+
+    QPlainTextEdit* left_ = nullptr;
+    QPlainTextEdit* right_ = nullptr;
+    std::shared_ptr<const ParsedDiff> diff_;
+    /// Guards against the ping-pong that connecting both scrollbars to each
+    /// other directly would otherwise cause.
+    bool syncingScroll_ = false;
+};
+
+}  // namespace gbm

--- a/src/app/views/WorkingCopyView.cpp
+++ b/src/app/views/WorkingCopyView.cpp
@@ -1,15 +1,20 @@
 #include "app/views/WorkingCopyView.h"
 
 #include "app/bridge/RepositorySession.h"
+#include "app/views/SideBySideDiffView.h"
 #include "core/git/ops/CommitOps.h"
+#include "core/git/ops/ConflictOps.h"
 
 #include <QCheckBox>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidget>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSplitter>
+#include <QStackedWidget>
 #include <QVBoxLayout>
 
 namespace gbm {
@@ -92,11 +97,26 @@ void WorkingCopyView::buildUi() {
 
     splitter->addWidget(leftWidget);
 
+    auto* diffPane = new QWidget(splitter);
+    auto* diffPaneLayout = new QVBoxLayout(diffPane);
+    diffPaneLayout->setContentsMargins(0, 0, 0, 0);
+
+    sideBySideToggle_ = new QCheckBox(tr("Side by side"), diffPane);
+    diffPaneLayout->addWidget(sideBySideToggle_, 0, Qt::AlignRight);
+
+    diffStack_ = new QStackedWidget(diffPane);
     // Hunk- and line-level staging live on this instance's context menu; see
-    // DiffView::setStagingEnabled.
-    diffView_ = new DiffView(splitter);
+    // DiffView::setStagingEnabled. The side-by-side pane is read-only -- it
+    // has no equivalent context menu, so staging always happens from the
+    // unified view.
+    diffView_ = new DiffView(diffStack_);
     diffView_->setStagingEnabled(true);
-    splitter->addWidget(diffView_);
+    sideBySideView_ = new SideBySideDiffView(diffStack_);
+    diffStack_->addWidget(diffView_);
+    diffStack_->addWidget(sideBySideView_);
+    diffPaneLayout->addWidget(diffStack_, 1);
+
+    splitter->addWidget(diffPane);
     splitter->setStretchFactor(0, 2);
     splitter->setStretchFactor(1, 3);
 
@@ -116,6 +136,14 @@ void WorkingCopyView::buildUi() {
             &QListWidget::itemActivated,
             this,
             &WorkingCopyView::onUnstagedItemActivated);
+    connect(conflictedList_,
+            &QListWidget::itemActivated,
+            this,
+            &WorkingCopyView::onConflictedItemActivated);
+    connect(sideBySideToggle_, &QCheckBox::toggled, this, [this](bool sideBySide) {
+        diffStack_->setCurrentWidget(sideBySide ? static_cast<QWidget*>(sideBySideView_)
+                                                : static_cast<QWidget*>(diffView_));
+    });
     connect(stageAllButton_, &QPushButton::clicked, this, &WorkingCopyView::onStageAllClicked);
     connect(unstageAllButton_, &QPushButton::clicked, this, &WorkingCopyView::onUnstageAllClicked);
     connect(commitButton_, &QPushButton::clicked, this, &WorkingCopyView::onCommitClicked);
@@ -148,6 +176,7 @@ void WorkingCopyView::setSession(RepositorySession* session) {
         session_->refreshWorkingCopyStatus();
     } else {
         diffView_->clearDiff();
+        sideBySideView_->clearDiff();
         messageEdit_->clear();
         rebuildLists();
     }
@@ -214,6 +243,7 @@ void WorkingCopyView::rebuildLists() {
     }
     if (previous && !reselected) {
         diffView_->clearDiff();
+        sideBySideView_->clearDiff();
     }
 
     const bool hasConflicts = conflictedList_->count() > 0;
@@ -240,9 +270,11 @@ void WorkingCopyView::refreshSelectedDiff() {
     const auto selection = currentSelection();
     if (!selection) {
         diffView_->clearDiff();
+        sideBySideView_->clearDiff();
         return;
     }
     diffView_->showMessage(tr("Loading changes…"));
+    sideBySideView_->showMessage(tr("Loading changes…"));
     session_->requestWorkingCopyDiff(selection->path, selection->staged);
 }
 
@@ -260,7 +292,8 @@ void WorkingCopyView::onWorkingCopyDiffReady(QString path,
         return;
     }
     diffView_->setShowingStagedDiff(staged);
-    diffView_->showDiff(std::move(diff));
+    diffView_->showDiff(diff);
+    sideBySideView_->showDiff(std::move(diff));
 }
 
 void WorkingCopyView::onWorkingCopyOperationFinished(const OperationOutcome& outcome) {
@@ -311,6 +344,150 @@ void WorkingCopyView::onUnstagedItemActivated(QListWidgetItem* item) {
         return;
     }
     session_->stageFiles({item->data(Qt::UserRole).toString().toStdString()});
+}
+
+void WorkingCopyView::onConflictedItemActivated(QListWidgetItem* item) {
+    if (session_ == nullptr || item == nullptr) {
+        return;
+    }
+    const std::string path = item->data(Qt::UserRole).toString().toStdString();
+    const WorkingCopyStatusPtr status = session_->workingCopyStatus();
+    if (!status) {
+        return;
+    }
+    for (const WorkingCopyEntry* entry : status->conflicted()) {
+        if (entry->path == path) {
+            openConflictResolutionDialog(*entry);
+            return;
+        }
+    }
+}
+
+void WorkingCopyView::openConflictResolutionDialog(const WorkingCopyEntry& entry) {
+    if (session_ == nullptr) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(tr("Resolve conflict — %1").arg(QString::fromStdString(entry.path)));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    QString kindText;
+    switch (entry.conflict) {
+        case ConflictKind::BothAdded:
+            kindText = tr("Both sides added this file.");
+            break;
+        case ConflictKind::BothModified:
+            kindText = tr("Both sides modified this file.");
+            break;
+        case ConflictKind::BothDeleted:
+            kindText = tr("Both sides deleted this file.");
+            break;
+        case ConflictKind::AddedByUs:
+            kindText = tr("You added this file; the other side did not touch it.");
+            break;
+        case ConflictKind::DeletedByUs:
+            kindText = tr("You deleted this file; the other side modified it.");
+            break;
+        case ConflictKind::AddedByThem:
+            kindText = tr("The other side added this file; you did not touch it.");
+            break;
+        case ConflictKind::DeletedByThem:
+            kindText = tr("The other side deleted this file; you modified it.");
+            break;
+        case ConflictKind::None:
+            break;
+    }
+    if (!kindText.isEmpty()) {
+        layout->addWidget(new QLabel(kindText, &dialog));
+    }
+
+    auto* panesLayout = new QHBoxLayout();
+    auto makePane = [&](const QString& title) {
+        auto* container = new QWidget(&dialog);
+        auto* paneLayout = new QVBoxLayout(container);
+        paneLayout->setContentsMargins(0, 0, 0, 0);
+        paneLayout->addWidget(new QLabel(title, container));
+        auto* edit = new QPlainTextEdit(container);
+        edit->setReadOnly(true);
+        edit->setLineWrapMode(QPlainTextEdit::NoWrap);
+        edit->setPlainText(tr("Loading…"));
+        paneLayout->addWidget(edit, 1);
+        panesLayout->addWidget(container);
+        return edit;
+    };
+    QPlainTextEdit* ancestorEdit = makePane(tr("Common ancestor"));
+    QPlainTextEdit* oursEdit = makePane(tr("Mine (ours)"));
+    QPlainTextEdit* theirsEdit = makePane(tr("Theirs"));
+    if (entry.ancestorBlob.empty()) {
+        ancestorEdit->setPlainText(tr("(no common ancestor)"));
+    }
+    if (entry.oursBlob.empty()) {
+        oursEdit->setPlainText(tr("(deleted on this side)"));
+    }
+    if (entry.theirsBlob.empty()) {
+        theirsEdit->setPlainText(tr("(deleted on the other side)"));
+    }
+    layout->addLayout(panesLayout, 1);
+
+    // Scoped to the dialog's lifetime via the context object: if the request's
+    // reply arrives after the dialog has already closed, Qt drops the
+    // connection rather than calling back into destroyed widgets.
+    const QString path = QString::fromStdString(entry.path);
+    connect(session_,
+            &RepositorySession::conflictSidesReady,
+            &dialog,
+            [path, ancestorEdit, oursEdit, theirsEdit](
+                QString readyPath, QString ancestor, QString ours, QString theirs) {
+                if (readyPath != path) {
+                    return;
+                }
+                ancestorEdit->setPlainText(ancestor);
+                oursEdit->setPlainText(ours);
+                theirsEdit->setPlainText(theirs);
+            });
+    session_->requestConflictSides(
+        entry.path, entry.ancestorBlob, entry.oursBlob, entry.theirsBlob);
+
+    auto* buttonRow = new QHBoxLayout();
+    auto* takeOursButton = new QPushButton(tr("Take Mine"), &dialog);
+    auto* takeTheirsButton = new QPushButton(tr("Take Theirs"), &dialog);
+    auto* markResolvedButton = new QPushButton(tr("Mark Resolved"), &dialog);
+    auto* cancelButton = new QPushButton(tr("Cancel"), &dialog);
+    buttonRow->addWidget(takeOursButton);
+    buttonRow->addWidget(takeTheirsButton);
+    buttonRow->addWidget(markResolvedButton);
+    buttonRow->addStretch(1);
+    buttonRow->addWidget(cancelButton);
+    layout->addLayout(buttonRow);
+
+    connect(takeOursButton, &QPushButton::clicked, &dialog, [&dialog] { dialog.done(1); });
+    connect(takeTheirsButton, &QPushButton::clicked, &dialog, [&dialog] { dialog.done(2); });
+    connect(markResolvedButton, &QPushButton::clicked, &dialog, [&dialog] { dialog.done(3); });
+    connect(cancelButton, &QPushButton::clicked, &dialog, [&dialog] { dialog.done(0); });
+
+    dialog.resize(720, 420);
+    const int result = dialog.exec();
+    if (result == 0 || session_ == nullptr) {
+        return;
+    }
+
+    ResolveConflictRequest request;
+    request.path = entry.path;
+    request.oursBlobMissing = entry.oursBlob.empty();
+    request.theirsBlobMissing = entry.theirsBlob.empty();
+    switch (result) {
+        case 1:
+            request.resolution = ConflictResolution::TakeOurs;
+            break;
+        case 2:
+            request.resolution = ConflictResolution::TakeTheirs;
+            break;
+        default:
+            request.resolution = ConflictResolution::MarkResolved;
+            break;
+    }
+    session_->resolveConflict(request);
 }
 
 void WorkingCopyView::onStageAllClicked() {

--- a/src/app/views/WorkingCopyView.h
+++ b/src/app/views/WorkingCopyView.h
@@ -16,10 +16,13 @@ class QListWidget;
 class QListWidgetItem;
 class QPlainTextEdit;
 class QPushButton;
+class QStackedWidget;
 
 namespace gbm {
 
 class RepositorySession;
+class SideBySideDiffView;
+struct WorkingCopyEntry;
 
 /// The working-copy panel: status, stage/unstage by file, hunk and line, and
 /// commit/amend -- M1's working-copy slice wired into one view. Hunk- and
@@ -47,6 +50,7 @@ private slots:
     void onUnstagedSelectionChanged();
     void onStagedItemActivated(QListWidgetItem* item);
     void onUnstagedItemActivated(QListWidgetItem* item);
+    void onConflictedItemActivated(QListWidgetItem* item);
     void onStageAllClicked();
     void onUnstageAllClicked();
     void onCommitClicked();
@@ -56,6 +60,10 @@ private:
     void buildUi();
     void rebuildLists();
     void refreshSelectedDiff();
+    /// Shows the three stages plus Take Mine/Take Theirs/Mark Resolved, and
+    /// submits whichever the user picks. Blocks (modally) until closed, same
+    /// as onManageBaseFolders in MainWindow.
+    void openConflictResolutionDialog(const WorkingCopyEntry& entry);
 
     struct Selection {
         std::string path;
@@ -75,7 +83,10 @@ private:
     QListWidget* unstagedList_ = nullptr;
     QPushButton* stageAllButton_ = nullptr;
     QPushButton* unstageAllButton_ = nullptr;
+    QStackedWidget* diffStack_ = nullptr;
     DiffView* diffView_ = nullptr;
+    SideBySideDiffView* sideBySideView_ = nullptr;
+    QCheckBox* sideBySideToggle_ = nullptr;
     QPlainTextEdit* messageEdit_ = nullptr;
     QCheckBox* amendCheck_ = nullptr;
     QPushButton* commitButton_ = nullptr;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,11 +16,15 @@ add_library(gbm_core STATIC
     git/ProcessRunner.cpp
     git/RefStore.cpp
     git/RepoState.cpp
+    git/SideBySideDiff.cpp
     git/UnifiedDiffParser.cpp
     git/WorkingCopyStatus.cpp
     git/ops/BranchOps.cpp
     git/ops/CheckoutOp.cpp
+    git/ops/CherryPickOps.cpp
     git/ops/CommitOps.cpp
+    git/ops/ConflictOps.cpp
+    git/ops/MergeOps.cpp
     git/ops/StageOps.cpp
 
     graph/GraphAsciiRenderer.cpp

--- a/src/core/git/RefStore.cpp
+++ b/src/core/git/RefStore.cpp
@@ -302,4 +302,35 @@ std::vector<std::string> RefStore::historySeedRefs(const RefSnapshot& refs) {
     return seeds;
 }
 
+GitResult<std::vector<ObjectId>> RefStore::resolveRange(const std::string& range,
+                                                        CancellationToken token) {
+    GBM_ASSERT_NOT_UI_THREAD();
+
+    GitCommand command(paths_.commandDir(), {"rev-list", "--reverse", range});
+    command.timeout = std::chrono::seconds(60);
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    std::vector<ObjectId> oids;
+    std::size_t start = 0;
+    while (start <= result->out.size()) {
+        const std::size_t at = result->out.find('\n', start);
+        const std::size_t end = at == std::string::npos ? result->out.size() : at;
+        const std::string_view line(result->out.data() + start, end - start);
+        if (!line.empty()) {
+            ObjectId oid;
+            if (oid.parseHex(line)) {
+                oids.push_back(oid);
+            }
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return oids;
+}
+
 }  // namespace gbm

--- a/src/core/git/RefStore.h
+++ b/src/core/git/RefStore.h
@@ -89,6 +89,13 @@ public:
     /// create it so the user gets a clear message instead of raw git output.
     static bool isValidBranchName(std::string_view name);
 
+    /// Resolves a revision range (e.g. "A..B", or a single commit for the
+    /// one-commit case) into the ordered list of commits it contains, oldest
+    /// first -- the order a cherry-pick must apply them in, and the order a
+    /// preview should list them in.
+    GitResult<std::vector<ObjectId>> resolveRange(const std::string& range,
+                                                  CancellationToken token);
+
 private:
     IProcessRunner& runner_;
     RepoPaths paths_;

--- a/src/core/git/SideBySideDiff.cpp
+++ b/src/core/git/SideBySideDiff.cpp
@@ -1,0 +1,59 @@
+#include "core/git/SideBySideDiff.h"
+
+#include <algorithm>
+
+namespace gbm {
+
+std::vector<SideBySideRow> pairHunkForSideBySide(const DiffHunk& hunk) {
+    std::vector<SideBySideRow> rows;
+    std::vector<const DiffLine*> removedRun;
+    std::vector<const DiffLine*> addedRun;
+
+    auto flushRun = [&]() {
+        const std::size_t n = std::max(removedRun.size(), addedRun.size());
+        for (std::size_t i = 0; i < n; ++i) {
+            SideBySideRow row;
+            row.left = i < removedRun.size() ? removedRun[i] : nullptr;
+            row.right = i < addedRun.size() ? addedRun[i] : nullptr;
+            rows.push_back(row);
+        }
+        removedRun.clear();
+        addedRun.clear();
+    };
+
+    DiffLineKind lastRealKind = DiffLineKind::Context;
+    for (const DiffLine& line : hunk.lines) {
+        switch (line.kind) {
+            case DiffLineKind::Removed:
+                removedRun.push_back(&line);
+                lastRealKind = DiffLineKind::Removed;
+                break;
+            case DiffLineKind::Added:
+                addedRun.push_back(&line);
+                lastRealKind = DiffLineKind::Added;
+                break;
+            case DiffLineKind::Context:
+                flushRun();
+                rows.push_back({&line, &line});
+                lastRealKind = DiffLineKind::Context;
+                break;
+            case DiffLineKind::NoNewlineMarker:
+                // Belongs to whichever side it immediately follows, not to both:
+                // it means that one file (old or new) has no trailing newline,
+                // not that the pair of them agree on it.
+                if (lastRealKind == DiffLineKind::Removed) {
+                    removedRun.push_back(&line);
+                } else if (lastRealKind == DiffLineKind::Added) {
+                    addedRun.push_back(&line);
+                } else {
+                    flushRun();
+                    rows.push_back({&line, &line});
+                }
+                break;
+        }
+    }
+    flushRun();
+    return rows;
+}
+
+}  // namespace gbm

--- a/src/core/git/SideBySideDiff.h
+++ b/src/core/git/SideBySideDiff.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "core/git/UnifiedDiffParser.h"
+
+#include <vector>
+
+namespace gbm {
+
+/// One rendered row of a side-by-side diff. Either side may be null, meaning
+/// that side is blank padding -- a pure addition has no left line, a pure
+/// deletion has no right line.
+struct SideBySideRow {
+    const DiffLine* left = nullptr;
+    const DiffLine* right = nullptr;
+};
+
+/// Turns a hunk's flat, unified-diff-ordered line sequence into paired
+/// left/right rows for a side-by-side view.
+///
+/// Git's unified diff already groups each changed region as a contiguous run of
+/// removed lines immediately followed by a contiguous run of added lines (a
+/// "diff3-style" chunk), bracketed by context. That is exactly the shape a
+/// side-by-side view wants: pairing removed[i] with added[i] up to the shorter
+/// run's length, and padding the rest with blanks, reproduces what every
+/// side-by-side diff tool shows without needing a second alignment pass or any
+/// additional data beyond what UnifiedDiffParser already produces. Context
+/// lines pass straight across unchanged, appearing identically on both sides.
+std::vector<SideBySideRow> pairHunkForSideBySide(const DiffHunk& hunk);
+
+}  // namespace gbm

--- a/src/core/git/WorkingCopyStatus.cpp
+++ b/src/core/git/WorkingCopyStatus.cpp
@@ -56,6 +56,16 @@ std::vector<std::string_view> splitFieldsMax(std::string_view line, std::size_t 
     return fields;
 }
 
+/// A stage hash of all zeros means that stage does not exist for this path
+/// (e.g. no common ancestor for a both-added conflict). Reported as empty
+/// rather than as the all-zero hash, which is not a real object.
+std::string blobOrEmpty(std::string_view hash) {
+    if (hash.find_first_not_of('0') == std::string_view::npos) {
+        return {};
+    }
+    return std::string(hash);
+}
+
 /// Reads the trailing digits of a rename/copy score field, e.g. "R100" -> 100.
 int parseScore(std::string_view scoreField) {
     std::size_t digitsStart = 0;
@@ -186,7 +196,7 @@ GitResult<WorkingCopyStatusPtr> WorkingCopyStatusReader::read(CancellationToken 
             continue;
         }
 
-        // Unmerged (conflicted) entry.
+        // Unmerged (conflicted) entry: u XY sub m1 m2 m3 mW h1 h2 h3 path
         if (type == 'u') {
             const auto fields = splitFieldsMax(record, 11);
             if (fields.size() < 11) {
@@ -200,6 +210,9 @@ GitResult<WorkingCopyStatusPtr> WorkingCopyStatusReader::read(CancellationToken 
             entry.path = std::string(fields.back());
             entry.isSubmodule = !sub.empty() && sub.front() == 'S';
             entry.conflict = conflictForXY(!xy.empty() ? xy[0] : '?', xy.size() > 1 ? xy[1] : '?');
+            entry.ancestorBlob = blobOrEmpty(fields[7]);
+            entry.oursBlob = blobOrEmpty(fields[8]);
+            entry.theirsBlob = blobOrEmpty(fields[9]);
             status->entries.push_back(std::move(entry));
             ++i;
             continue;

--- a/src/core/git/WorkingCopyStatus.h
+++ b/src/core/git/WorkingCopyStatus.h
@@ -52,6 +52,16 @@ struct WorkingCopyEntry {
 
     ConflictKind conflict = ConflictKind::None;
 
+    /// Blob object ids for each side of a conflict, valid only when
+    /// `isConflicted()`. Empty when that stage does not exist for this path --
+    /// e.g. `theirsBlob` is empty for AddedByUs, `ancestorBlob` is empty for
+    /// BothAdded. Populated from `git status`'s stage hashes directly, so
+    /// viewing a conflicted file's three sides never needs a second `git`
+    /// invocation to look them up.
+    std::string ancestorBlob;  ///< Stage 1: the merge base.
+    std::string oursBlob;      ///< Stage 2: HEAD's side.
+    std::string theirsBlob;    ///< Stage 3: the incoming side.
+
     int similarity = 0;  ///< Rename/copy score, 0-100.
     bool isSubmodule = false;
 

--- a/src/core/git/ops/CherryPickOps.cpp
+++ b/src/core/git/ops/CherryPickOps.cpp
@@ -1,0 +1,159 @@
+#include "core/git/ops/CherryPickOps.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+class CherryPickOperation final : public Operation {
+public:
+    explicit CherryPickOperation(CherryPickRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        if (request_.commits.size() == 1) {
+            return "Cherry-pick " + request_.commits.front().shortHex();
+        }
+        return "Cherry-pick " + std::to_string(request_.commits.size()) + " commits";
+    }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.commits.empty()) {
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "No commits selected to pick");
+            return outcome;
+        }
+
+        if (request_.stashFirst) {
+            GitCommand stash(paths.commandDir(),
+                             {"stash",
+                              "push",
+                              "--include-untracked",
+                              "-m",
+                              "git-branch-manager: before cherry-pick"});
+            stash.timeout = std::chrono::seconds(600);
+            auto stashed = runner.run(stash, token);
+            if (!stashed) {
+                outcome.error = std::move(stashed).error();
+                outcome.summary = "Could not stash your changes, so nothing was picked";
+                return outcome;
+            }
+        }
+
+        std::vector<std::string> args{"cherry-pick"};
+        if (request_.mainline > 0) {
+            args.emplace_back("-m");
+            args.push_back(std::to_string(request_.mainline));
+        }
+        if (request_.noCommit) {
+            args.emplace_back("--no-commit");
+        }
+        for (const ObjectId& commit : request_.commits) {
+            args.push_back(commit.hex());
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (result) {
+            outcome.succeeded = true;
+            outcome.summary = describe();
+            return outcome;
+        }
+
+        GitError error = std::move(result).error();
+        outcome.summary = error.message;
+
+        if (error.code == GitError::Code::DirtyWorkTree) {
+            outcome.choices.push_back(
+                {OperationChoice::Kind::StashAndRetry,
+                 "Stash changes and pick",
+                 "Your changes are saved to a stash first, and can be restored afterwards.",
+                 false});
+            outcome.choices.push_back(
+                {OperationChoice::Kind::Abort, "Cancel", "Do not cherry-pick.", false});
+        }
+
+        // As with a conflicting merge, this is git stopping exactly where it
+        // should: the conflict is recorded in the index and CHERRY_PICK_HEAD, and
+        // any remaining commits stay queued in the sequencer for --continue or
+        // --skip. Nothing here recovers on its own.
+        if (error.code == GitError::Code::Conflict) {
+            outcome.summary = "Cherry-pick stopped with conflicts to resolve";
+        }
+
+        outcome.error = std::move(error);
+        return outcome;
+    }
+
+private:
+    CherryPickRequest request_;
+};
+
+/// Shared by --continue/--skip/--abort: same shape, different verb, all legal
+/// only while a pick sequence is actually in progress.
+class CherryPickControlOperation final : public Operation {
+public:
+    enum class Verb { Continue, Skip, Abort };
+
+    CherryPickControlOperation(Verb verb, std::string description)
+        : verb_(verb), description_(std::move(description)) {}
+
+    std::string describe() const override { return description_; }
+
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        const char* flag = verb_ == Verb::Continue ? "--continue"
+                           : verb_ == Verb::Skip   ? "--skip"
+                                                   : "--abort";
+        GitCommand command(paths.commandDir(), {"cherry-pick", flag});
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = description_;
+        return outcome;
+    }
+
+private:
+    Verb verb_;
+    std::string description_;
+};
+
+}  // namespace
+
+std::unique_ptr<Operation> makeCherryPickOperation(CherryPickRequest request) {
+    return std::make_unique<CherryPickOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeCherryPickContinueOperation() {
+    return std::make_unique<CherryPickControlOperation>(CherryPickControlOperation::Verb::Continue,
+                                                        "Continue cherry-pick");
+}
+
+std::unique_ptr<Operation> makeCherryPickSkipOperation() {
+    return std::make_unique<CherryPickControlOperation>(CherryPickControlOperation::Verb::Skip,
+                                                        "Skip commit");
+}
+
+std::unique_ptr<Operation> makeCherryPickAbortOperation() {
+    return std::make_unique<CherryPickControlOperation>(CherryPickControlOperation::Verb::Abort,
+                                                        "Abort cherry-pick");
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/CherryPickOps.h
+++ b/src/core/git/ops/CherryPickOps.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "core/base/ObjectId.h"
+#include "core/git/OperationRunner.h"
+
+#include <memory>
+#include <vector>
+
+namespace gbm {
+
+struct CherryPickRequest {
+    /// Oldest first: the order they are applied in, and the order a preview
+    /// should list them in. A single-commit pick is just a one-element list; a
+    /// range is this same list after the caller has expanded it with
+    /// RefStore::resolveRange.
+    std::vector<ObjectId> commits;
+
+    /// For cherry-picking a merge commit: which parent (1-based) is "mainline".
+    /// 0 means the commit is not a merge and no `-m` is passed.
+    int mainline = 0;
+
+    /// `--no-commit`: stages every pick's changes without creating a commit for
+    /// any of them, so a run of several picks can be squashed into one commit
+    /// afterwards via CommitOps.
+    bool noCommit = false;
+
+    /// Set after the user picks "Stash and pick" in response to a
+    /// DirtyWorkTree failure -- see CheckoutRequest::stashFirst, same idea.
+    bool stashFirst = false;
+};
+
+/// `git cherry-pick <commits...>`. Stops at the first conflict, exactly as git
+/// does; the remaining commits stay queued in the sequencer for `--continue` or
+/// `--skip` to work through. See RepoState::CherryPick / Sequencer.
+std::unique_ptr<Operation> makeCherryPickOperation(CherryPickRequest request);
+
+/// `git cherry-pick --continue`, once every conflict in the current pick is
+/// resolved and staged.
+std::unique_ptr<Operation> makeCherryPickContinueOperation();
+
+/// `git cherry-pick --skip`: drops the current pick entirely and moves on to
+/// the next one queued, if any.
+std::unique_ptr<Operation> makeCherryPickSkipOperation();
+
+/// `git cherry-pick --abort`: unwinds back to before the pick sequence started.
+std::unique_ptr<Operation> makeCherryPickAbortOperation();
+
+}  // namespace gbm

--- a/src/core/git/ops/ConflictOps.cpp
+++ b/src/core/git/ops/ConflictOps.cpp
@@ -1,0 +1,115 @@
+#include "core/git/ops/ConflictOps.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+class ResolveConflictOperation final : public Operation {
+public:
+    explicit ResolveConflictOperation(ResolveConflictRequest request)
+        : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Resolve " + request_.path; }
+
+    /// A conflict resolution is itself a recovery step within a merge, pick or
+    /// revert -- it must be allowed to run while the sequencer operation is
+    /// still in progress, since that is the whole point of it.
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.path.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "No path to resolve");
+            return outcome;
+        }
+
+        switch (request_.resolution) {
+            case ConflictResolution::TakeOurs:
+                return takeSide(runner, paths, token, /*ours=*/true);
+            case ConflictResolution::TakeTheirs:
+                return takeSide(runner, paths, token, /*ours=*/false);
+            case ConflictResolution::MarkResolved:
+                return markResolved(runner, paths, token);
+        }
+        outcome.error = GitError(GitError::Code::InvalidArgument, "Unknown resolution");
+        return outcome;
+    }
+
+private:
+    OperationOutcome takeSide(IProcessRunner& runner,
+                              const RepoPaths& paths,
+                              CancellationToken token,
+                              bool ours) {
+        OperationOutcome outcome;
+        const bool missing = ours ? request_.oursBlobMissing : request_.theirsBlobMissing;
+
+        if (missing) {
+            // The side being taken deleted this path: the resolution is a
+            // deletion, not a content pick.
+            GitCommand remove(paths.commandDir(), {"rm", "-f", "--", request_.path});
+            remove.timeout = std::chrono::seconds(60);
+            auto result = runner.run(remove, token);
+            if (!result) {
+                outcome.error = std::move(result).error();
+                outcome.summary = outcome.error->message;
+                return outcome;
+            }
+            outcome.succeeded = true;
+            outcome.summary = "Resolved " + request_.path + " as deleted";
+            return outcome;
+        }
+
+        GitCommand checkout(paths.commandDir(),
+                            {"checkout", ours ? "--ours" : "--theirs", "--", request_.path});
+        checkout.timeout = std::chrono::seconds(60);
+        auto checkedOut = runner.run(checkout, token);
+        if (!checkedOut) {
+            outcome.error = std::move(checkedOut).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+
+        return stage(runner, paths, token);
+    }
+
+    OperationOutcome markResolved(IProcessRunner& runner,
+                                  const RepoPaths& paths,
+                                  CancellationToken token) {
+        return stage(runner, paths, token);
+    }
+
+    /// `-A` rather than a bare `add`: the user may have resolved the conflict by
+    /// deleting the file entirely, and a bare `add <path>` refuses to stage a
+    /// path that no longer exists on disk.
+    OperationOutcome stage(IProcessRunner& runner,
+                           const RepoPaths& paths,
+                           CancellationToken token) {
+        OperationOutcome outcome;
+        GitCommand add(paths.commandDir(), {"add", "-A", "--", request_.path});
+        add.timeout = std::chrono::seconds(60);
+        auto result = runner.run(add, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = "Resolved " + request_.path;
+        return outcome;
+    }
+
+    ResolveConflictRequest request_;
+};
+
+}  // namespace
+
+std::unique_ptr<Operation> makeResolveConflictOperation(ResolveConflictRequest request) {
+    return std::make_unique<ResolveConflictOperation>(std::move(request));
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/ConflictOps.h
+++ b/src/core/git/ops/ConflictOps.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "core/git/OperationRunner.h"
+
+#include <memory>
+#include <string>
+
+namespace gbm {
+
+enum class ConflictResolution : std::uint8_t {
+    /// Take stage 2 (HEAD's side) for this path. If it does not exist at
+    /// stage 2 (we deleted it), the path is removed instead.
+    TakeOurs,
+    /// Take stage 3 (the incoming side) for this path. If it does not exist at
+    /// stage 3 (they deleted it), the path is removed instead.
+    TakeTheirs,
+    /// The user edited the file themselves (or it is already correct as-is):
+    /// just clear the conflict stages and stage the current working-tree
+    /// content, whatever that is.
+    MarkResolved,
+};
+
+struct ResolveConflictRequest {
+    std::string path;
+    ConflictResolution resolution = ConflictResolution::MarkResolved;
+    /// Needed only for TakeOurs/TakeTheirs to tell a real deletion apart from
+    /// an ordinary content pick -- see WorkingCopyEntry::oursBlob/theirsBlob.
+    bool oursBlobMissing = false;
+    bool theirsBlobMissing = false;
+};
+
+/// Resolves one conflicted path and stages the result, ready for the commit
+/// that finishes the merge/cherry-pick/revert. Never touches paths other than
+/// the one requested, so resolving one file at a time never disturbs the rest
+/// of a large conflicted set.
+std::unique_ptr<Operation> makeResolveConflictOperation(ResolveConflictRequest request);
+
+}  // namespace gbm

--- a/src/core/git/ops/MergeOps.cpp
+++ b/src/core/git/ops/MergeOps.cpp
@@ -1,0 +1,161 @@
+#include "core/git/ops/MergeOps.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+std::string modeLabel(MergeMode mode) {
+    switch (mode) {
+        case MergeMode::FastForwardOnly:
+            return "Fast-forward";
+        case MergeMode::NoFastForward:
+            return "Merge";
+        case MergeMode::Squash:
+            return "Squash merge";
+    }
+    return "Merge";
+}
+
+class MergeOperation final : public Operation {
+public:
+    explicit MergeOperation(MergeRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        return modeLabel(request_.mode) + " " + request_.target;
+    }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.target.empty()) {
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "No branch selected to merge");
+            return outcome;
+        }
+
+        // As with checkout: stash first, as a separate step, so a failure in the
+        // merge itself still leaves the user's work recoverable from the stash
+        // rather than lost.
+        if (request_.stashFirst) {
+            GitCommand stash(paths.commandDir(),
+                             {"stash",
+                              "push",
+                              "--include-untracked",
+                              "-m",
+                              "git-branch-manager: before merging " + request_.target});
+            stash.timeout = std::chrono::seconds(600);
+            auto stashed = runner.run(stash, token);
+            if (!stashed) {
+                outcome.error = std::move(stashed).error();
+                outcome.summary = "Could not stash your changes, so nothing was merged";
+                return outcome;
+            }
+        }
+
+        std::vector<std::string> args{"merge"};
+        switch (request_.mode) {
+            case MergeMode::FastForwardOnly:
+                args.emplace_back("--ff-only");
+                break;
+            case MergeMode::NoFastForward:
+                args.emplace_back("--no-ff");
+                // Neither an editor nor a terminal is available to write a merge
+                // commit message, so one is always supplied: the caller's, or
+                // git's own default via --no-edit.
+                if (request_.message.empty()) {
+                    args.emplace_back("--no-edit");
+                } else {
+                    args.emplace_back("-m");
+                    args.push_back(request_.message);
+                }
+                break;
+            case MergeMode::Squash:
+                // --squash never commits on its own -- there is nothing to supply
+                // an editor for -- so request_.message plays no part here.
+                args.emplace_back("--squash");
+                break;
+        }
+        args.push_back(request_.target);
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        // A merge across a very large tree can legitimately take a while; give it
+        // a working Cancel rather than a timeout.
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (result) {
+            outcome.succeeded = true;
+            outcome.summary = modeLabel(request_.mode) + "d " + request_.target;
+            return outcome;
+        }
+
+        GitError error = std::move(result).error();
+        outcome.summary = error.message;
+
+        if (error.code == GitError::Code::DirtyWorkTree) {
+            outcome.choices.push_back(
+                {OperationChoice::Kind::StashAndRetry,
+                 "Stash changes and merge",
+                 "Your changes are saved to a stash first, and can be restored afterwards.",
+                 false});
+            outcome.choices.push_back(
+                {OperationChoice::Kind::Abort, "Cancel", "Do not merge.", false});
+        }
+
+        // A conflicting merge is not this operation failing to do its job -- it is
+        // git stopping exactly where it should, with the conflict recorded in the
+        // index (and, outside Squash, in MERGE_HEAD) for the working-copy panel to
+        // pick up. Nothing here recovers automatically; the choice belongs to
+        // whichever UI shows the conflicted files.
+        if (error.code == GitError::Code::Conflict) {
+            outcome.summary = "Merge stopped with conflicts to resolve";
+        }
+
+        outcome.error = std::move(error);
+        return outcome;
+    }
+
+private:
+    MergeRequest request_;
+};
+
+class MergeAbortOperation final : public Operation {
+public:
+    std::string describe() const override { return "Abort merge"; }
+
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        GitCommand command(paths.commandDir(), {"merge", "--abort"});
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = "Merge aborted";
+        return outcome;
+    }
+};
+
+}  // namespace
+
+std::unique_ptr<Operation> makeMergeOperation(MergeRequest request) {
+    return std::make_unique<MergeOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeMergeAbortOperation() {
+    return std::make_unique<MergeAbortOperation>();
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/MergeOps.h
+++ b/src/core/git/ops/MergeOps.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "core/git/OperationRunner.h"
+
+#include <memory>
+#include <string>
+
+namespace gbm {
+
+enum class MergeMode : std::uint8_t {
+    /// `--ff-only`: refuses rather than creating a merge commit. The safest
+    /// default when the user has not said which kind of history they want.
+    FastForwardOnly,
+    /// `--no-ff`: always creates a merge commit, even when a fast-forward is
+    /// possible. What most teams mean by "merge" in the Fork sense.
+    NoFastForward,
+    /// `--squash`: stages the combined diff with no merge commit and no
+    /// parent link, then leaves it to the caller to commit. Never leaves a
+    /// MERGE_HEAD behind, so RepoState::Merge never applies to a squash.
+    Squash,
+};
+
+struct MergeRequest {
+    std::string target;  ///< Branch, tag or commit to merge into HEAD.
+    MergeMode mode = MergeMode::NoFastForward;
+    /// Overrides the default merge commit message. Ignored for Squash, which
+    /// never commits on its own -- see CommitOps for that follow-up step.
+    std::string message;
+    /// Set after the user picks "Stash and merge" in response to a
+    /// DirtyWorkTree failure -- see CheckoutRequest::stashFirst, same idea.
+    bool stashFirst = false;
+};
+
+/// `git merge`, in one of three modes. A conflicting merge is not a failure of
+/// this operation in the ordinary sense: it succeeds at exactly what git itself
+/// does, which is stop with the conflict recorded in the index and MERGE_HEAD
+/// on disk, so it is still reported as OperationOutcome::succeeded == false
+/// with GitError::Code::Conflict, and the working-copy panel picks up the
+/// unmerged entries from the next status read.
+std::unique_ptr<Operation> makeMergeOperation(MergeRequest request);
+
+/// `git merge --abort`. Only valid while RepoState::Merge is set; git itself
+/// enforces that and the error is passed through rather than pre-checked here.
+std::unique_ptr<Operation> makeMergeAbortOperation();
+
+}  // namespace gbm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(gbm_core_tests
     unit/GitIntegrationTest.cpp
     unit/GraphBuilderTest.cpp
     unit/ProcessRunnerTest.cpp
+    unit/SideBySideDiffTest.cpp
     unit/UnifiedDiffParserTest.cpp
 )
 target_link_libraries(gbm_core_tests

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -16,7 +16,10 @@
 #include "core/git/WorkingCopyStatus.h"
 #include "core/git/ops/BranchOps.h"
 #include "core/git/ops/CheckoutOp.h"
+#include "core/git/ops/CherryPickOps.h"
 #include "core/git/ops/CommitOps.h"
+#include "core/git/ops/ConflictOps.h"
+#include "core/git/ops/MergeOps.h"
 #include "core/git/ops/StageOps.h"
 
 #include <cstdio>
@@ -68,6 +71,16 @@ protected:
         GitCommand command(repo_, std::move(args));
         command.timeout = std::chrono::seconds(120);
         return runner_->run(command, CancellationToken{});
+    }
+
+    /// Shared by the M2 tests below, which submit several operations per test.
+    static OperationOutcome submitAndWait(OperationRunner& operations,
+                                          std::unique_ptr<Operation> operation) {
+        OperationOutcome outcome;
+        operations.submit(std::move(operation),
+                          [&outcome](OperationOutcome result) { outcome = std::move(result); });
+        operations.drain();
+        return outcome;
     }
 
     /// `name` is UTF-8, matching how the rest of the codebase treats a path in a
@@ -753,8 +766,8 @@ TEST_F(RealRepoTest, StagesAndUnstagesOneHunkWithoutTouchingItsNeighbour) {
     ASSERT_EQ((*unstagedDiff)->files[0].hunks.size(), 2u)
         << "the two edits must land in separate hunks for this test to be meaningful";
 
-    const std::string stagePatch =
-        UnifiedDiffParser::buildHunkPatch((*unstagedDiff)->files[0], (*unstagedDiff)->files[0].hunks[0]);
+    const std::string stagePatch = UnifiedDiffParser::buildHunkPatch(
+        (*unstagedDiff)->files[0], (*unstagedDiff)->files[0].hunks[0]);
 
     OperationRunner operations(*runner_, paths_);
     auto submitAndWait = [&operations](std::unique_ptr<Operation> operation) {
@@ -786,8 +799,8 @@ TEST_F(RealRepoTest, StagesAndUnstagesOneHunkWithoutTouchingItsNeighbour) {
     auto stagedDiff = diffs.workingTreeDiff(true, {}, DiffOptions{}, CancellationToken{});
     ASSERT_TRUE(stagedDiff);
     ASSERT_EQ((*stagedDiff)->files[0].hunks.size(), 1u);
-    const std::string unstagePatch =
-        UnifiedDiffParser::buildHunkPatch((*stagedDiff)->files[0], (*stagedDiff)->files[0].hunks[0]);
+    const std::string unstagePatch = UnifiedDiffParser::buildHunkPatch(
+        (*stagedDiff)->files[0], (*stagedDiff)->files[0].hunks[0]);
 
     ApplyPatchRequest unstageRequest;
     unstageRequest.patch = unstagePatch;
@@ -964,6 +977,379 @@ TEST_F(RealRepoTest, RefusesToCommitWhenNothingIsStaged) {
     EXPECT_FALSE(outcome.succeeded);
     ASSERT_TRUE(outcome.error.has_value());
     EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
+}
+
+// --- M2: merge, cherry-pick, conflict resolution ----------------------------
+
+TEST_F(RealRepoTest, FastForwardMergeMovesHeadWithoutACommit) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("a.txt", "2\n", "c2 on feature");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "feature";
+    request.mode = MergeMode::FastForwardOnly;
+    auto outcome = submitAndWait(operations, makeMergeOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto count = run({"rev-list", "--count", "HEAD"});
+    ASSERT_TRUE(count);
+    EXPECT_EQ(count->out, "2") << "a fast-forward must not add a merge commit";
+
+    auto subject = run({"log", "-1", "--format=%s"});
+    ASSERT_TRUE(subject);
+    EXPECT_EQ(subject->out, "c2 on feature");
+}
+
+TEST_F(RealRepoTest, FastForwardOnlyRefusesWhenHistoryHasDiverged) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("a.txt", "2\n", "c2 on feature");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("b.txt", "diverge\n", "c3 on main");
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "feature";
+    request.mode = MergeMode::FastForwardOnly;
+    auto outcome = submitAndWait(operations, makeMergeOperation(request));
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::NonFastForward);
+}
+
+TEST_F(RealRepoTest, NoFastForwardMergeAlwaysCreatesAMergeCommit) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("a.txt", "2\n", "c2 on feature");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "feature";
+    request.mode = MergeMode::NoFastForward;
+    request.message = "Merge feature into main";
+    auto outcome = submitAndWait(operations, makeMergeOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto parents = run({"log", "-1", "--format=%P"});
+    ASSERT_TRUE(parents);
+    EXPECT_NE(parents->out.find(' '), std::string::npos) << "must be a two-parent merge commit";
+
+    auto subject = run({"log", "-1", "--format=%s"});
+    ASSERT_TRUE(subject);
+    EXPECT_EQ(subject->out, "Merge feature into main");
+}
+
+TEST_F(RealRepoTest, SquashMergeStagesChangesWithoutCommittingOrRecordingAParent) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("a.txt", "2\n", "c2 on feature");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "feature";
+    request.mode = MergeMode::Squash;
+    auto outcome = submitAndWait(operations, makeMergeOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto count = run({"rev-list", "--count", "HEAD"});
+    ASSERT_TRUE(count);
+    EXPECT_EQ(count->out, "1") << "squash must not create a commit on its own";
+
+    WorkingCopyStatusReader reader(*runner_, paths_);
+    auto status = reader.read(CancellationToken{});
+    ASSERT_TRUE(status);
+    EXPECT_FALSE(status->get()->staged().empty()) << "the squashed diff must be staged";
+}
+
+TEST_F(RealRepoTest, AConflictingMergeStopsAndCanBeAborted) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "left"}));
+    commitFile("shared.txt", "left change\n", "left");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "right change\n", "right");
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "left";
+    request.mode = MergeMode::NoFastForward;
+    auto outcome = submitAndWait(operations, makeMergeOperation(request));
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::Conflict);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    auto abort = submitAndWait(operations, makeMergeAbortOperation());
+    ASSERT_TRUE(abort.succeeded) << (abort.error ? abort.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+}
+
+TEST_F(RealRepoTest, AConflictingMergeCanBeResolvedByTakingEitherSide) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "left"}));
+    commitFile("shared.txt", "left change\n", "left");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "right change\n", "right");
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "left";
+    request.mode = MergeMode::NoFastForward;
+    auto merged = submitAndWait(operations, makeMergeOperation(request));
+    ASSERT_FALSE(merged.succeeded);
+
+    WorkingCopyStatusReader reader(*runner_, paths_);
+    auto status = reader.read(CancellationToken{});
+    ASSERT_TRUE(status);
+    const auto conflicted = status->get()->conflicted();
+    ASSERT_EQ(conflicted.size(), 1u);
+    EXPECT_FALSE(conflicted[0]->oursBlob.empty());
+    EXPECT_FALSE(conflicted[0]->theirsBlob.empty());
+    EXPECT_FALSE(conflicted[0]->ancestorBlob.empty())
+        << "shared.txt has a real common ancestor (the base commit), so stage 1 must be present";
+
+    ResolveConflictRequest resolve;
+    resolve.path = "shared.txt";
+    resolve.resolution = ConflictResolution::TakeTheirs;
+    auto resolved = submitAndWait(operations, makeResolveConflictOperation(resolve));
+    ASSERT_TRUE(resolved.succeeded) << (resolved.error ? resolved.error->detail : "");
+
+    auto afterResolve = reader.read(CancellationToken{});
+    ASSERT_TRUE(afterResolve);
+    EXPECT_TRUE(afterResolve->get()->conflicted().empty());
+
+    auto content = run({"show", ":shared.txt"});
+    ASSERT_TRUE(content);
+    EXPECT_EQ(content->out, "left change") << "theirs, from the merge's point of view, is `left`";
+
+    CommitRequest commit;
+    commit.message = "Merge left into main";
+    auto committed = submitAndWait(operations, makeCommitOperation(commit));
+    ASSERT_TRUE(committed.succeeded) << (committed.error ? committed.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+}
+
+TEST_F(RealRepoTest, MergeOffersStashAndRetryWhenTheWorkTreeIsDirty) {
+    commitFile("a.txt", "base\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("a.txt", "feature change\n", "c2 on feature");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    {
+        std::ofstream out(repo_ / "a.txt");
+        out << "uncommitted local edit\n";
+    }
+
+    OperationRunner operations(*runner_, paths_);
+    MergeRequest request;
+    request.target = "feature";
+    request.mode = MergeMode::NoFastForward;
+    auto outcome = submitAndWait(operations, makeMergeOperation(request));
+
+    ASSERT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::DirtyWorkTree);
+    bool hasStash = false;
+    for (const OperationChoice& choice : outcome.choices) {
+        hasStash = hasStash || choice.kind == OperationChoice::Kind::StashAndRetry;
+    }
+    EXPECT_TRUE(hasStash);
+
+    request.stashFirst = true;
+    auto retried = submitAndWait(operations, makeMergeOperation(request));
+    ASSERT_TRUE(retried.succeeded) << (retried.error ? retried.error->detail : "");
+
+    auto stashList = run({"stash", "list"});
+    ASSERT_TRUE(stashList);
+    EXPECT_FALSE(stashList->out.empty()) << "the user's work must be recoverable";
+}
+
+TEST_F(RealRepoTest, CherryPicksASingleCommitOntoAnotherBranch) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("b.txt", "feature content\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    auto pick = run({"rev-parse", "feature"});
+    ASSERT_TRUE(pick);
+    const ObjectId oid = ObjectId::fromHex(pick->out);
+
+    OperationRunner operations(*runner_, paths_);
+    CherryPickRequest request;
+    request.commits = {oid};
+    auto outcome = submitAndWait(operations, makeCherryPickOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "b.txt"));
+    auto subject = run({"log", "-1", "--format=%s"});
+    ASSERT_TRUE(subject);
+    EXPECT_EQ(subject->out, "feature commit");
+}
+
+TEST_F(RealRepoTest, CherryPicksARangeInOldestFirstOrder) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("f1.txt", "1\n", "feature c1");
+    commitFile("f2.txt", "2\n", "feature c2");
+    commitFile("f3.txt", "3\n", "feature c3");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    RefStore refs(*runner_, paths_);
+    auto range = refs.resolveRange("main..feature", CancellationToken{});
+    ASSERT_TRUE(range) << range.error().message;
+    ASSERT_EQ(range->size(), 3u);
+
+    OperationRunner operations(*runner_, paths_);
+    CherryPickRequest request;
+    request.commits = *range;
+    auto outcome = submitAndWait(operations, makeCherryPickOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto count = run({"rev-list", "--count", "HEAD"});
+    ASSERT_TRUE(count);
+    EXPECT_EQ(count->out, "4");
+
+    // Applied oldest first, so the resulting history reads the same way round.
+    auto subjects = run({"log", "--format=%s", "-3", "--reverse"});
+    ASSERT_TRUE(subjects);
+    EXPECT_EQ(subjects->out, "feature c1\nfeature c2\nfeature c3");
+}
+
+TEST_F(RealRepoTest, CherryPickConflictContinuesToTheNextQueuedPickAfterResolution) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    commitFile("other.txt", "unrelated\n", "unrelated commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+
+    RefStore refs(*runner_, paths_);
+    auto range = refs.resolveRange("main..feature", CancellationToken{});
+    ASSERT_TRUE(range);
+    ASSERT_EQ(range->size(), 2u);
+
+    OperationRunner operations(*runner_, paths_);
+    CherryPickRequest request;
+    request.commits = *range;
+    auto outcome = submitAndWait(operations, makeCherryPickOperation(request));
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::Conflict);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    ResolveConflictRequest resolve;
+    resolve.path = "shared.txt";
+    resolve.resolution = ConflictResolution::TakeTheirs;
+    auto resolved = submitAndWait(operations, makeResolveConflictOperation(resolve));
+    ASSERT_TRUE(resolved.succeeded) << (resolved.error ? resolved.error->detail : "");
+
+    auto continued = submitAndWait(operations, makeCherryPickContinueOperation());
+    ASSERT_TRUE(continued.succeeded) << (continued.error ? continued.error->detail : "");
+
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "other.txt"))
+        << "the second queued pick must have been applied by --continue";
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+}
+
+TEST_F(RealRepoTest, CherryPickSkipDropsTheConflictingCommitAndMovesOn) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    commitFile("other.txt", "unrelated\n", "unrelated commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+
+    RefStore refs(*runner_, paths_);
+    auto range = refs.resolveRange("main..feature", CancellationToken{});
+    ASSERT_TRUE(range);
+    ASSERT_EQ(range->size(), 2u);
+
+    OperationRunner operations(*runner_, paths_);
+    CherryPickRequest request;
+    request.commits = *range;
+    auto outcome = submitAndWait(operations, makeCherryPickOperation(request));
+    ASSERT_FALSE(outcome.succeeded);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    auto skipped = submitAndWait(operations, makeCherryPickSkipOperation());
+    ASSERT_TRUE(skipped.succeeded) << (skipped.error ? skipped.error->detail : "");
+
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "other.txt"))
+        << "the second queued pick must still have been applied after skipping the first";
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+
+    auto content = run({"cat-file", "-p", "HEAD:shared.txt"});
+    ASSERT_TRUE(content);
+    EXPECT_EQ(content->out, "main change")
+        << "the skipped commit's change to shared.txt is dropped";
+}
+
+TEST_F(RealRepoTest, CherryPickAbortUnwindsCleanly) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+
+    auto pick = run({"rev-parse", "feature"});
+    ASSERT_TRUE(pick);
+
+    OperationRunner operations(*runner_, paths_);
+    CherryPickRequest request;
+    request.commits = {ObjectId::fromHex(pick->out)};
+    auto outcome = submitAndWait(operations, makeCherryPickOperation(request));
+    ASSERT_FALSE(outcome.succeeded);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    auto aborted = submitAndWait(operations, makeCherryPickAbortOperation());
+    ASSERT_TRUE(aborted.succeeded) << (aborted.error ? aborted.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+
+    auto content = run({"cat-file", "-p", "HEAD:shared.txt"});
+    ASSERT_TRUE(content);
+    EXPECT_EQ(content->out, "main change")
+        << "abort must leave the tree exactly as before the pick";
+}
+
+TEST_F(RealRepoTest, TakingOursOnAConflictWhereWeDeletedRemovesThePath) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "left"}));
+    ASSERT_TRUE(run({"rm", "--quiet", "shared.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "delete on left"}));
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "changed on main\n", "change on main");
+
+    auto merge = run({"merge", "--no-commit", "left"});
+    EXPECT_FALSE(merge) << "delete-vs-modify was expected to conflict";
+
+    WorkingCopyStatusReader reader(*runner_, paths_);
+    auto status = reader.read(CancellationToken{});
+    ASSERT_TRUE(status);
+    const auto conflicted = status->get()->conflicted();
+    ASSERT_EQ(conflicted.size(), 1u);
+    EXPECT_TRUE(conflicted[0]->theirsBlob.empty()) << "left deleted it, so stage 3 does not exist";
+
+    OperationRunner operations(*runner_, paths_);
+    ResolveConflictRequest resolve;
+    resolve.path = "shared.txt";
+    resolve.resolution = ConflictResolution::TakeTheirs;
+    resolve.theirsBlobMissing = true;
+    auto resolved = submitAndWait(operations, makeResolveConflictOperation(resolve));
+    ASSERT_TRUE(resolved.succeeded) << (resolved.error ? resolved.error->detail : "");
+
+    EXPECT_FALSE(std::filesystem::exists(repo_ / "shared.txt"));
+    auto afterResolve = reader.read(CancellationToken{});
+    ASSERT_TRUE(afterResolve);
+    EXPECT_TRUE(afterResolve->get()->conflicted().empty());
+    EXPECT_FALSE(afterResolve->get()->staged().empty());
+
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "merge left"}));
 }
 
 }  // namespace

--- a/tests/unit/SideBySideDiffTest.cpp
+++ b/tests/unit/SideBySideDiffTest.cpp
@@ -1,0 +1,151 @@
+// Pairing logic only; UnifiedDiffParser already has its own coverage for the
+// text -> DiffHunk parsing this builds on.
+#include "core/git/SideBySideDiff.h"
+#include "core/git/UnifiedDiffParser.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace gbm {
+namespace {
+
+const DiffHunk& firstHunk(const ParsedDiff& parsed) {
+    return parsed.files.at(0).hunks.at(0);
+}
+
+TEST(SideBySideDiff, ContextLinesPassStraightAcrossUnchanged) {
+    const std::string diff =
+        "diff --git a/a.txt b/a.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,3 +1,3 @@\n"
+        " one\n"
+        "-two\n"
+        "+TWO\n"
+        " three\n";
+    const ParsedDiff parsed = UnifiedDiffParser{}.parse(diff);
+    const auto rows = pairHunkForSideBySide(firstHunk(parsed));
+
+    ASSERT_EQ(rows.size(), 3u);
+    EXPECT_EQ(rows[0].left, rows[0].right);
+    EXPECT_EQ(rows[0].left->text, "one");
+    EXPECT_EQ(rows[2].left, rows[2].right);
+    EXPECT_EQ(rows[2].left->text, "three");
+}
+
+TEST(SideBySideDiff, PairsAnEqualLengthReplaceLineByLine) {
+    const std::string diff =
+        "diff --git a/a.txt b/a.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-old1\n"
+        "-old2\n"
+        "+new1\n"
+        "+new2\n";
+    const ParsedDiff parsed = UnifiedDiffParser{}.parse(diff);
+    const auto rows = pairHunkForSideBySide(firstHunk(parsed));
+
+    ASSERT_EQ(rows.size(), 2u);
+    EXPECT_EQ(rows[0].left->text, "old1");
+    EXPECT_EQ(rows[0].right->text, "new1");
+    EXPECT_EQ(rows[1].left->text, "old2");
+    EXPECT_EQ(rows[1].right->text, "new2");
+}
+
+TEST(SideBySideDiff, APureAdditionLeavesTheLeftSideBlank) {
+    const std::string diff =
+        "diff --git a/a.txt b/a.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,1 +1,3 @@\n"
+        " keep\n"
+        "+added1\n"
+        "+added2\n";
+    const ParsedDiff parsed = UnifiedDiffParser{}.parse(diff);
+    const auto rows = pairHunkForSideBySide(firstHunk(parsed));
+
+    ASSERT_EQ(rows.size(), 3u);
+    EXPECT_EQ(rows[1].left, nullptr);
+    ASSERT_NE(rows[1].right, nullptr);
+    EXPECT_EQ(rows[1].right->text, "added1");
+    EXPECT_EQ(rows[2].left, nullptr);
+    ASSERT_NE(rows[2].right, nullptr);
+    EXPECT_EQ(rows[2].right->text, "added2");
+}
+
+TEST(SideBySideDiff, APureDeletionLeavesTheRightSideBlank) {
+    const std::string diff =
+        "diff --git a/a.txt b/a.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,3 +1,1 @@\n"
+        " keep\n"
+        "-removed1\n"
+        "-removed2\n";
+    const ParsedDiff parsed = UnifiedDiffParser{}.parse(diff);
+    const auto rows = pairHunkForSideBySide(firstHunk(parsed));
+
+    ASSERT_EQ(rows.size(), 3u);
+    ASSERT_NE(rows[1].left, nullptr);
+    EXPECT_EQ(rows[1].left->text, "removed1");
+    EXPECT_EQ(rows[1].right, nullptr);
+    ASSERT_NE(rows[2].left, nullptr);
+    EXPECT_EQ(rows[2].left->text, "removed2");
+    EXPECT_EQ(rows[2].right, nullptr);
+}
+
+TEST(SideBySideDiff, AnUnequalReplacePadsTheShorterSideRatherThanMisaligning) {
+    const std::string diff =
+        "diff --git a/a.txt b/a.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,3 +1,1 @@\n"
+        "-old1\n"
+        "-old2\n"
+        "-old3\n"
+        "+new1\n";
+    const ParsedDiff parsed = UnifiedDiffParser{}.parse(diff);
+    const auto rows = pairHunkForSideBySide(firstHunk(parsed));
+
+    ASSERT_EQ(rows.size(), 3u);
+    EXPECT_EQ(rows[0].left->text, "old1");
+    EXPECT_EQ(rows[0].right->text, "new1");
+    EXPECT_EQ(rows[1].left->text, "old2");
+    EXPECT_EQ(rows[1].right, nullptr);
+    EXPECT_EQ(rows[2].left->text, "old3");
+    EXPECT_EQ(rows[2].right, nullptr);
+}
+
+TEST(SideBySideDiff, HandlesMultipleChangedRegionsInOneHunkIndependently) {
+    const std::string diff =
+        "diff --git a/a.txt b/a.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,5 +1,5 @@\n"
+        " ctx1\n"
+        "-a\n"
+        "+A\n"
+        " ctx2\n"
+        "-b\n"
+        "+B\n";
+    const ParsedDiff parsed = UnifiedDiffParser{}.parse(diff);
+    const auto rows = pairHunkForSideBySide(firstHunk(parsed));
+
+    ASSERT_EQ(rows.size(), 4u);
+    EXPECT_EQ(rows[0].left->text, "ctx1");
+    EXPECT_EQ(rows[1].left->text, "a");
+    EXPECT_EQ(rows[1].right->text, "A");
+    EXPECT_EQ(rows[2].left->text, "ctx2");
+    EXPECT_EQ(rows[3].left->text, "b");
+    EXPECT_EQ(rows[3].right->text, "B");
+}
+
+}  // namespace
+}  // namespace gbm


### PR DESCRIPTION
Adds the M2 milestone on top of M1's working-copy foundation:

- MergeOps: fast-forward-only, no-fast-forward and squash merge, plus abort,
  following the existing Operation/OperationRunner pattern with stash-and-retry
  on a dirty work tree and conflict reporting through the standard status flow.
- CherryPickOps: single, multi and range picks (oldest-first, ranges resolved
  via a new RefStore::resolveRange), plus continue/skip/abort for the sequencer.
- ConflictOps: resolves a conflicted path by taking ours/theirs or marking it
  resolved as-is, correctly handling the delete-vs-modify cases. WorkingCopyStatus
  now also parses and exposes the three conflict stages' blob hashes so a
  resolution view can show ancestor/ours/theirs without extra checkouts.
- SideBySideDiff: pure line-pairing over an existing ParsedDiff hunk, plus a
  SideBySideDiffView alternative to DiffView, toggleable from the working-copy
  panel.
- UI: merge and cherry-pick (with a preview of the commits/subjects) actions in
  the Branch menu, driven from the existing ref/commit selections; a conflict
  resolution dialog reachable from the working-copy panel's conflicted list.

All new core logic is covered by tests/unit/GitIntegrationTest.cpp (real-repo
integration tests) and tests/unit/SideBySideDiffTest.cpp (pure pairing logic).