### PR TITLE
feat: interactive rebase, reset/restore/clean, blame, file/line history, reflog and undo (M4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ decade of history** — hundreds of thousands of commits, tens of thousands of f
 and often thousands of stale refs. It manages many such repositories at once,
 discovered under folders you nominate.
 
-> **Status: M0–M3 implemented.** History browsing, the Fork-style graph,
+> **Status: M0–M4 implemented.** History browsing, the Fork-style graph,
 > repository discovery with caching, diff viewing, branch switching, the working
-> copy, merge/cherry-pick/conflict resolution, and worktrees/stash/tags/fetch/
-> pull/push all work end to end on all three platforms. Interactive rebase and
-> the rest are designed for but not yet implemented — see [Roadmap](#roadmap).
+> copy, merge/cherry-pick/conflict resolution, worktrees/stash/tags/fetch/
+> pull/push, interactive rebase, reset/restore/clean, blame, file and line
+> history, and the reflog/undo journal all work end to end on all three
+> platforms. Submodules, bisect and the rest are designed for but not yet
+> implemented — see [Roadmap](#roadmap).
 
 ## What works today
 
@@ -35,6 +37,20 @@ discovered under folders you nominate.
   `--force-with-lease`, never a bare `--force`.
 - **An operation log** recording every Git command, its exit code, duration and
   full stderr, with a copy button.
+- **Interactive rebase**: reorder, drop, squash and fixup commits from an
+  editable plan (no external editor process — see
+  [Design decisions](#design-decisions-worth-knowing)), plus `edit` stops that
+  hand off to the existing amend flow; conflicts, `--skip` and `--abort` are
+  Continue/Skip/Abort banner controls shared with cherry-pick.
+- **Reset, restore and clean**: soft/mixed/hard reset to any commit, unstage
+  or discard changes per path, and a preview-before-you-delete untracked-file
+  clean.
+- **Blame, and file/line history**: per-line attribution (`git blame
+  --line-porcelain`), a file's commit history across renames (`--follow`), and
+  a specific line range's history (`log -L`).
+- **Reflog browser and undo**: every `HEAD` movement, and a one-click "Undo
+  last operation" backed by the operation runner's own undo journal rather
+  than a reflog guess.
 
 ## Measured behaviour
 
@@ -86,6 +102,16 @@ Other decisions that are easy to get wrong:
   deterministic enough to golden-test.
 - **Every cap is visible.** The 48-lane limit, the 2 MB diff limit and the row limit
   each surface a message. Silent truncation would be worse than being slow.
+- **No interactive editor process, anywhere.** There is no terminal to run one in,
+  so `git commit --amend`, a no-ff merge and squash/fixup all always pass a
+  message explicitly (`--no-edit` or otherwise) rather than opening `$EDITOR`.
+  Interactive rebase carries the idea furthest: the todo list is built and
+  edited in the UI, then `GIT_SEQUENCE_EDITOR` is pointed at `cp` with the
+  built plan as its first argument, so git's own "run the editor" step becomes
+  a copy instead of a blocked child process. `cp` needs nothing bundled — Git
+  for Windows carries its own coreutils and prepends them to `PATH` for
+  exactly this kind of child process — so it works unmodified on all three
+  platforms.
 - **A cancelled scan never deletes anything.** It commits what it found and skips
   the mark-missing sweep, because most of the tree was never visited.
 
@@ -201,7 +227,7 @@ git config core.untrackedCache true
 | **M1 — done** | Working copy: status with fsmonitor, stage/unstage by file, hunk and line, commit and amend, branch create/rename/delete |
 | **M2 — done** | Merge (ff / no-ff / squash), cherry-pick single, multi and range with preview, conflict resolution across all three index stages, side-by-side diff |
 | **M3 — done** | Worktree manager, stash, tags, fetch/pull/push with askpass helpers and `--force-with-lease` by default, signed installers |
-| M4 | Interactive rebase, reset/restore/clean, blame, file and line history, reflog browser and undo |
+| **M4 — done** | Interactive rebase, reset/restore/clean, blame, file and line history, reflog browser and undo |
 | M5 | Submodules, bisect, LFS, patch import/export, themes, accessibility |
 
 ## Licence

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -28,6 +28,9 @@ RepositorySession::RepositorySession(GitInstallation installation,
     stashStore_ = std::make_unique<StashStore>(*runner_, paths_);
     worktreeStore_ = std::make_unique<WorktreeStore>(*runner_, paths_);
     remoteStore_ = std::make_unique<RemoteStore>(*runner_, paths_);
+    blameStore_ = std::make_unique<BlameStore>(*runner_, paths_);
+    fileHistoryStore_ = std::make_unique<FileHistoryStore>(*runner_, paths_);
+    reflogStore_ = std::make_unique<ReflogStore>(*runner_, paths_);
 
     askpass_ = new AskpassWatcher(this);
     connect(
@@ -637,6 +640,206 @@ void RepositorySession::provideCredential(const QString& secret) {
 
 void RepositorySession::cancelCredential() {
     askpass_->cancel();
+}
+
+// --- M4: reset / restore / clean --------------------------------------------
+
+void RepositorySession::resetTo(const ResetRequest& request) {
+    submitWorkingCopyOperation(makeResetOperation(request), true);
+}
+
+void RepositorySession::restorePaths(const RestoreRequest& request) {
+    submitWorkingCopyOperation(makeRestoreOperation(request), false);
+}
+
+void RepositorySession::requestCleanPreview(bool includeIgnored) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, includeIgnored, token] {
+        CleanPreviewer previewer(*runner_, paths_);
+        auto preview = previewer.preview(includeIgnored, token);
+        if (preview) {
+            auto entries = *preview;
+            QMetaObject::invokeMethod(
+                this,
+                [this, entries = std::move(entries)] { emit cleanPreviewReady(entries); },
+                Qt::QueuedConnection);
+        } else if (preview.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(preview).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::cleanUntracked(const CleanRequest& request) {
+    submitWorkingCopyOperation(makeCleanOperation(request), false);
+}
+
+// --- M4: rebase --------------------------------------------------------------
+
+void RepositorySession::requestRebasePlan(const std::string& upstream) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, upstream, token] {
+        RebasePlanner planner(*runner_, paths_);
+        auto plan = planner.plan(upstream, token);
+        if (plan) {
+            auto entries = *plan;
+            QMetaObject::invokeMethod(
+                this,
+                [this, entries = std::move(entries)] { emit rebasePlanReady(entries); },
+                Qt::QueuedConnection);
+        } else if (plan.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(plan).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::startInteractiveRebase(const RebaseInteractiveRequest& request) {
+    submitWorkingCopyOperation(makeRebaseInteractiveOperation(request), true);
+}
+
+void RepositorySession::startRebase(const RebaseRequest& request) {
+    submitWorkingCopyOperation(makeRebaseOperation(request), true);
+}
+
+void RepositorySession::continueRebase() {
+    submitWorkingCopyOperation(makeRebaseContinueOperation(), true);
+}
+
+void RepositorySession::skipRebase() {
+    submitWorkingCopyOperation(makeRebaseSkipOperation(), true);
+}
+
+void RepositorySession::abortRebase() {
+    submitWorkingCopyOperation(makeRebaseAbortOperation(), true);
+}
+
+// --- M4: blame -----------------------------------------------------------------
+
+void RepositorySession::requestBlame(const std::string& path,
+                                     const std::string& revision,
+                                     int startLine,
+                                     int endLine) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.postFront([this, path, revision, startLine, endLine, token] {
+        if (token.isCancelled()) {
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+        auto result = blameStore_->blame(path, revision, startLine, endLine, token);
+        if (result) {
+            auto resultPtr = *result;
+            QMetaObject::invokeMethod(
+                this, [this, resultPtr] { emit blameReady(resultPtr); }, Qt::QueuedConnection);
+        } else if (result.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(result).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+// --- M4: file and line history ------------------------------------------------
+
+void RepositorySession::requestFileHistory(const std::string& path,
+                                           const std::string& startRevision) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.postFront([this, path, startRevision, token] {
+        if (token.isCancelled()) {
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+        auto entries = fileHistoryStore_->fileHistory(path, startRevision, token);
+        if (entries) {
+            auto result = *entries;
+            QMetaObject::invokeMethod(
+                this,
+                [this, result = std::move(result)] { emit fileHistoryReady(result); },
+                Qt::QueuedConnection);
+        } else if (entries.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(entries).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::requestLineHistory(const std::string& path,
+                                           int startLine,
+                                           int endLine,
+                                           const std::string& startRevision) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.postFront([this, path, startLine, endLine, startRevision, token] {
+        if (token.isCancelled()) {
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+        auto chunks =
+            fileHistoryStore_->lineHistory(path, startLine, endLine, startRevision, token);
+        if (chunks) {
+            auto result = *chunks;
+            QMetaObject::invokeMethod(
+                this,
+                [this, result = std::move(result)] { emit lineHistoryReady(result); },
+                Qt::QueuedConnection);
+        } else if (chunks.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(chunks).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+// --- M4: reflog and undo --------------------------------------------------------
+
+void RepositorySession::requestReflog(const std::string& ref) {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, ref, token] {
+        auto entries = reflogStore_->list(ref, token);
+        if (entries) {
+            auto result = *entries;
+            QMetaObject::invokeMethod(
+                this,
+                [this, result = std::move(result)] { emit reflogReady(result); },
+                Qt::QueuedConnection);
+        } else if (entries.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(entries).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::undoLastOperation() {
+    const auto& journal = operations_->undoJournal();
+    if (journal.empty()) {
+        return;
+    }
+    const auto& last = journal.back();
+    UndoRequest request;
+    request.headBefore = last.headBefore;
+    request.branchBefore = last.branchBefore;
+    submitWorkingCopyOperation(makeUndoOperation(request), true);
 }
 
 }  // namespace gbm

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -3,12 +3,15 @@
 #include "app/bridge/AskpassWatcher.h"
 #include "app/bridge/SnapshotHolder.h"
 #include "core/base/CancellationToken.h"
+#include "core/git/BlameStore.h"
 #include "core/git/CatFileBatch.h"
 #include "core/git/DiffService.h"
+#include "core/git/FileHistoryStore.h"
 #include "core/git/GitExecutable.h"
 #include "core/git/HistoryProvider.h"
 #include "core/git/OperationRunner.h"
 #include "core/git/RefStore.h"
+#include "core/git/ReflogStore.h"
 #include "core/git/RepoState.h"
 #include "core/git/WorkingCopyStatus.h"
 #include "core/git/ops/CheckoutOp.h"
@@ -16,10 +19,13 @@
 #include "core/git/ops/CommitOps.h"
 #include "core/git/ops/ConflictOps.h"
 #include "core/git/ops/MergeOps.h"
+#include "core/git/ops/RebaseOps.h"
 #include "core/git/ops/RemoteOps.h"
+#include "core/git/ops/ResetOps.h"
 #include "core/git/ops/StageOps.h"
 #include "core/git/ops/StashOps.h"
 #include "core/git/ops/TagOps.h"
+#include "core/git/ops/UndoOps.h"
 #include "core/git/ops/WorktreeOps.h"
 #include "core/graph/GraphSnapshot.h"
 #include "core/workers/ThreadPool.h"
@@ -185,6 +191,53 @@ public:
     void provideCredential(const QString& secret);
     void cancelCredential();
 
+    // --- M4: reset / restore / clean --------------------------------------
+
+    /// `git reset`. Hard also refreshes the working-copy status, since it
+    /// rewrites the work tree.
+    void resetTo(const ResetRequest& request);
+    void restorePaths(const RestoreRequest& request);
+    void requestCleanPreview(bool includeIgnored);
+    void cleanUntracked(const CleanRequest& request);
+
+    // --- M4: rebase ------------------------------------------------------
+
+    void requestRebasePlan(const std::string& upstream);
+    void startInteractiveRebase(const RebaseInteractiveRequest& request);
+    void startRebase(const RebaseRequest& request);
+    void continueRebase();
+    void skipRebase();
+    void abortRebase();
+
+    // --- M4: blame ---------------------------------------------------------
+
+    void requestBlame(const std::string& path,
+                      const std::string& revision,
+                      int startLine,
+                      int endLine);
+
+    // --- M4: file and line history -------------------------------------------
+
+    void requestFileHistory(const std::string& path, const std::string& startRevision);
+    void requestLineHistory(const std::string& path,
+                            int startLine,
+                            int endLine,
+                            const std::string& startRevision);
+
+    // --- M4: reflog and undo -----------------------------------------------
+
+    void requestReflog(const std::string& ref);
+
+    /// What OperationRunner recorded HEAD as being before each mutating
+    /// operation. Cheap; safe to call often (e.g. to decide whether an "Undo"
+    /// menu item is enabled).
+    const std::vector<OperationRunner::UndoEntry>& undoJournal() const {
+        return operations_->undoJournal();
+    }
+
+    /// Reverses the most recent journal entry -- see UndoOps.h.
+    void undoLastOperation();
+
 signals:
     /// A newer graph snapshot is available (possibly partial).
     void graphUpdated(bool complete);
@@ -218,6 +271,15 @@ signals:
     /// call provideCredential()/cancelCredential() in response.
     void credentialRequested(QString prompt);
 
+    // --- M4 ----------------------------------------------------------------
+
+    void cleanPreviewReady(std::vector<CleanEntry> entries);
+    void rebasePlanReady(std::vector<RebaseTodoEntry> entries);
+    void blameReady(BlameResultPtr result);
+    void fileHistoryReady(std::vector<FileHistoryEntry> entries);
+    void lineHistoryReady(std::vector<LineHistoryChunk> chunks);
+    void reflogReady(std::vector<ReflogEntry> entries);
+
 private:
     void setBusy(bool busy);
     /// Runs a staging/commit Operation and, on success, refreshes whatever it
@@ -247,6 +309,9 @@ private:
     std::unique_ptr<StashStore> stashStore_;
     std::unique_ptr<WorktreeStore> worktreeStore_;
     std::unique_ptr<RemoteStore> remoteStore_;
+    std::unique_ptr<BlameStore> blameStore_;
+    std::unique_ptr<FileHistoryStore> fileHistoryStore_;
+    std::unique_ptr<ReflogStore> reflogStore_;
     AskpassWatcher* askpass_ = nullptr;
 
     SnapshotHolder<GraphSnapshot> graph_;

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -6,6 +6,8 @@
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
+#include <QComboBox>
+#include <QDateTime>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QDir>
@@ -18,6 +20,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
+#include <QPlainTextEdit>
 #include <QProgressBar>
 #include <QPushButton>
 #include <QRadioButton>
@@ -151,13 +154,37 @@ void MainWindow::buildUi() {
     auto* repoLayout = new QVBoxLayout(repoPage);
     repoLayout->setContentsMargins(0, 0, 0, 0);
 
-    bannerLabel_ = new QLabel(repoPage);
+    auto* bannerRow = new QWidget(repoPage);
+    bannerRow->setStyleSheet(QStringLiteral("QWidget { background: #7a4d00; }"));
+    auto* bannerLayout = new QHBoxLayout(bannerRow);
+    bannerLayout->setContentsMargins(6, 4, 6, 4);
+
+    bannerLabel_ = new QLabel(bannerRow);
     bannerLabel_->setVisible(false);
     bannerLabel_->setWordWrap(true);
     // Unmissable by design: a repository stuck mid-rebase must never look normal.
-    bannerLabel_->setStyleSheet(
-        QStringLiteral("QLabel { background: #7a4d00; color: white; padding: 6px; }"));
-    repoLayout->addWidget(bannerLabel_);
+    bannerLabel_->setStyleSheet(QStringLiteral("QLabel { color: white; }"));
+    bannerLayout->addWidget(bannerLabel_, 1);
+
+    // Continue/Skip/Abort for whichever sequencer operation (merge, cherry-pick,
+    // revert or rebase) RepoState reports in progress -- see
+    // updateSequencerControls. Not every operation offers all three: a plain
+    // merge has no --skip, for instance.
+    bannerContinueButton_ = new QPushButton(QStringLiteral("Continue"), bannerRow);
+    bannerSkipButton_ = new QPushButton(QStringLiteral("Skip"), bannerRow);
+    bannerAbortButton_ = new QPushButton(QStringLiteral("Abort"), bannerRow);
+    bannerContinueButton_->setVisible(false);
+    bannerSkipButton_->setVisible(false);
+    bannerAbortButton_->setVisible(false);
+    connect(bannerContinueButton_, &QPushButton::clicked, this, &MainWindow::onBannerContinue);
+    connect(bannerSkipButton_, &QPushButton::clicked, this, &MainWindow::onBannerSkip);
+    connect(bannerAbortButton_, &QPushButton::clicked, this, &MainWindow::onBannerAbort);
+    bannerLayout->addWidget(bannerContinueButton_);
+    bannerLayout->addWidget(bannerSkipButton_);
+    bannerLayout->addWidget(bannerAbortButton_);
+
+    bannerRow->setVisible(false);
+    repoLayout->addWidget(bannerRow);
 
     auto* outerSplitter = new QSplitter(Qt::Horizontal, repoPage);
 
@@ -211,6 +238,11 @@ void MainWindow::buildUi() {
     fileView_->setSelectionBehavior(QAbstractItemView::SelectRows);
     fileView_->verticalHeader()->setVisible(false);
     fileView_->setShowGrid(false);
+    fileView_->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(fileView_,
+            &QTableView::customContextMenuRequested,
+            this,
+            &MainWindow::onFileContextMenuRequested);
     detailSplitter->addWidget(fileView_);
 
     diffView_ = new DiffView(detailSplitter);
@@ -297,6 +329,27 @@ void MainWindow::buildMenus() {
                               this,
                               &MainWindow::onCherryPickRequested);
     cherryPickAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+C")));
+    branchMenu->addSeparator();
+    branchMenu->addAction(QStringLiteral("Rebase current branch onto selected commit…"),
+                          this,
+                          &MainWindow::onRebaseRequested);
+    branchMenu->addAction(QStringLiteral("Interactive rebase onto selected commit…"),
+                          this,
+                          &MainWindow::onInteractiveRebaseRequested);
+    branchMenu->addSeparator();
+    branchMenu->addAction(QStringLiteral("Reset current branch to selected commit…"),
+                          this,
+                          &MainWindow::onResetBranchRequested);
+
+    auto* repoMenu = menuBar()->addMenu(QStringLiteral("Reposi&tory"));
+    undoAction_ = repoMenu->addAction(
+        QStringLiteral("Undo last operation"), this, &MainWindow::onUndoLastOperation);
+    undoAction_->setEnabled(false);
+    repoMenu->addSeparator();
+    repoMenu->addAction(QStringLiteral("Reflog…"), this, &MainWindow::onShowReflog);
+    repoMenu->addSeparator();
+    repoMenu->addAction(
+        QStringLiteral("Clean untracked files…"), this, &MainWindow::onCleanUntracked);
 
     auto* historyAction =
         viewMenu->addAction(QStringLiteral("History"), this, &MainWindow::onShowHistory);
@@ -650,22 +703,45 @@ void MainWindow::closeRepository() {
     session_.reset();
     setWindowTitle(QStringLiteral("git-branch-manager"));
     stack_->setCurrentIndex(0);
-    bannerLabel_->setVisible(false);
+    bannerLabel_->parentWidget()->setVisible(false);
 }
 
 void MainWindow::updateStateBanner() {
     if (!session_) {
-        bannerLabel_->setVisible(false);
+        bannerLabel_->parentWidget()->setVisible(false);
+        if (undoAction_) {
+            undoAction_->setEnabled(false);
+        }
         return;
     }
+    if (undoAction_) {
+        undoAction_->setEnabled(!session_->undoJournal().empty());
+    }
+
     const RepoState state = session_->state();
     const std::string description = state.describe();
+    updateSequencerControls(state);
     if (description.empty()) {
-        bannerLabel_->setVisible(false);
+        bannerLabel_->parentWidget()->setVisible(false);
         return;
     }
     bannerLabel_->setText(QString::fromStdString(description));
-    bannerLabel_->setVisible(true);
+    bannerLabel_->parentWidget()->setVisible(true);
+}
+
+void MainWindow::updateSequencerControls(const RepoState& state) {
+    // A plain merge has no --skip (there is only one thing to resolve), and
+    // "continuing" it is just committing, which the working-copy panel already
+    // does -- so Continue is not offered for it either. Revert is detected (for
+    // the banner text) but has no continue/skip/abort operation behind it yet,
+    // so it gets no buttons rather than ones that would run the wrong command.
+    const bool isRebase = (state.flags & (RepoState::RebaseMerge | RepoState::RebaseApply)) != 0;
+    const bool isCherryPick = (state.flags & RepoState::CherryPick) != 0;
+    const bool isMerge = (state.flags & RepoState::Merge) != 0;
+
+    bannerContinueButton_->setVisible(isRebase || isCherryPick);
+    bannerSkipButton_->setVisible(isRebase || isCherryPick);
+    bannerAbortButton_->setVisible(isRebase || isCherryPick || isMerge);
 }
 
 void MainWindow::onGraphUpdated(bool complete) {
@@ -1693,6 +1769,676 @@ void MainWindow::onCredentialRequested(QString prompt) {
         session_->provideCredential(dialog.value());
     } else {
         session_->cancelCredential();
+    }
+}
+
+// --- M4: sequencer controls (Continue/Skip/Abort on the banner) ------------
+
+void MainWindow::onBannerContinue() {
+    if (!session_) {
+        return;
+    }
+    const RepoState state = session_->state();
+    statusLabel_->setText(QStringLiteral("Continuing…"));
+    if ((state.flags & (RepoState::RebaseMerge | RepoState::RebaseApply)) != 0) {
+        runWithFeedback([this] { session_->continueRebase(); });
+    } else if ((state.flags & RepoState::CherryPick) != 0) {
+        runWithFeedback([this] { session_->continueCherryPick(); });
+    }
+}
+
+void MainWindow::onBannerSkip() {
+    if (!session_) {
+        return;
+    }
+    const RepoState state = session_->state();
+    statusLabel_->setText(QStringLiteral("Skipping…"));
+    if ((state.flags & (RepoState::RebaseMerge | RepoState::RebaseApply)) != 0) {
+        runWithFeedback([this] { session_->skipRebase(); });
+    } else if ((state.flags & RepoState::CherryPick) != 0) {
+        runWithFeedback([this] { session_->skipCherryPick(); });
+    }
+}
+
+void MainWindow::onBannerAbort() {
+    if (!session_) {
+        return;
+    }
+    const auto confirmed =
+        QMessageBox::warning(this,
+                             QStringLiteral("Abort?"),
+                             QStringLiteral("This unwinds the operation in progress back to "
+                                            "where it started."),
+                             QMessageBox::Yes | QMessageBox::Cancel,
+                             QMessageBox::Cancel);
+    if (confirmed != QMessageBox::Yes) {
+        return;
+    }
+
+    const RepoState state = session_->state();
+    statusLabel_->setText(QStringLiteral("Aborting…"));
+    if ((state.flags & (RepoState::RebaseMerge | RepoState::RebaseApply)) != 0) {
+        runWithFeedback([this] { session_->abortRebase(); });
+    } else if ((state.flags & RepoState::CherryPick) != 0) {
+        runWithFeedback([this] { session_->abortCherryPick(); });
+    } else if ((state.flags & RepoState::Merge) != 0) {
+        runWithFeedback([this] { session_->abortMerge(); });
+    }
+}
+
+// --- M4: reset / rebase -----------------------------------------------------
+
+void MainWindow::onResetBranchRequested() {
+    if (!session_) {
+        return;
+    }
+    const QModelIndexList selected = commitView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        return;
+    }
+    const ObjectId target = commitModel_->oidAt(selected.first().row());
+    if (target.isNull()) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Reset branch"));
+    auto* layout = new QVBoxLayout(&dialog);
+    layout->addWidget(new QLabel(QStringLiteral("Reset the current branch to %1:")
+                                     .arg(QString::fromStdString(target.shortHex())),
+                                 &dialog));
+
+    auto* soft = new QRadioButton(QStringLiteral("Soft (keep the index and work tree)"), &dialog);
+    auto* mixed =
+        new QRadioButton(QStringLiteral("Mixed (keep the work tree, unstage everything)"), &dialog);
+    auto* hard = new QRadioButton(
+        QStringLiteral("Hard (discard the index and work tree — destructive)"), &dialog);
+    mixed->setChecked(true);
+    layout->addWidget(soft);
+    layout->addWidget(mixed);
+    layout->addWidget(hard);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    layout->addWidget(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    const ResetMode mode = soft->isChecked()   ? ResetMode::Soft
+                           : hard->isChecked() ? ResetMode::Hard
+                                               : ResetMode::Mixed;
+    if (mode == ResetMode::Hard) {
+        const auto confirmed = QMessageBox::warning(
+            this,
+            QStringLiteral("Hard reset?"),
+            QStringLiteral("This permanently discards uncommitted changes, and any commits not "
+                           "reachable from %1.")
+                .arg(QString::fromStdString(target.shortHex())),
+            QMessageBox::Discard | QMessageBox::Cancel,
+            QMessageBox::Cancel);
+        if (confirmed != QMessageBox::Discard) {
+            return;
+        }
+    }
+
+    ResetRequest request;
+    request.target = target.hex();
+    request.mode = mode;
+    statusLabel_->setText(QStringLiteral("Resetting…"));
+    runWithFeedback([this, request] { session_->resetTo(request); });
+}
+
+void MainWindow::onRebaseRequested() {
+    if (!session_) {
+        return;
+    }
+    const QModelIndexList selected = commitView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        return;
+    }
+    const ObjectId upstream = commitModel_->oidAt(selected.first().row());
+    if (upstream.isNull()) {
+        return;
+    }
+
+    const auto confirmed =
+        QMessageBox::question(this,
+                              QStringLiteral("Rebase"),
+                              QStringLiteral("Rebase the current branch onto %1?")
+                                  .arg(QString::fromStdString(upstream.shortHex())),
+                              QMessageBox::Yes | QMessageBox::Cancel,
+                              QMessageBox::Cancel);
+    if (confirmed != QMessageBox::Yes) {
+        return;
+    }
+
+    RebaseRequest request;
+    request.upstream = upstream.hex();
+    statusLabel_->setText(QStringLiteral("Rebasing…"));
+    armWorkingCopyChoiceHandler(
+        [this, request](bool stashFirst) mutable {
+            request.stashFirst = stashFirst;
+            session_->startRebase(request);
+        },
+        false);
+}
+
+void MainWindow::onInteractiveRebaseRequested() {
+    if (!session_) {
+        return;
+    }
+    const QModelIndexList selected = commitView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        return;
+    }
+    const ObjectId upstream = commitModel_->oidAt(selected.first().row());
+    if (upstream.isNull()) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Interactive rebase"));
+    auto* layout = new QVBoxLayout(&dialog);
+    layout->addWidget(new QLabel(QStringLiteral("Commits to replay onto %1, oldest first:")
+                                     .arg(QString::fromStdString(upstream.shortHex())),
+                                 &dialog));
+
+    auto* table = new QTableWidget(&dialog);
+    table->setColumnCount(3);
+    table->setHorizontalHeaderLabels(
+        {QStringLiteral("Action"), QStringLiteral("Commit"), QStringLiteral("Subject")});
+    table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setSelectionMode(QAbstractItemView::SingleSelection);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->verticalHeader()->setVisible(false);
+    layout->addWidget(table, 1);
+
+    // Shared with every lambda below rather than read back from the table
+    // widget: the combo boxes are the only place the action lives once edited,
+    // but reordering rebuilds the whole table, so the todo list itself is the
+    // one source of truth.
+    auto todo = std::make_shared<std::vector<RebaseTodoEntry>>();
+
+    auto actionLabel = [](RebaseTodoEntry::Action action) {
+        switch (action) {
+            case RebaseTodoEntry::Action::Pick:
+                return QStringLiteral("pick");
+            case RebaseTodoEntry::Action::Edit:
+                return QStringLiteral("edit");
+            case RebaseTodoEntry::Action::Squash:
+                return QStringLiteral("squash");
+            case RebaseTodoEntry::Action::Fixup:
+                return QStringLiteral("fixup");
+            case RebaseTodoEntry::Action::Drop:
+                return QStringLiteral("drop");
+        }
+        return QStringLiteral("pick");
+    };
+    auto actionFromLabel = [](const QString& text) {
+        if (text == QStringLiteral("edit")) {
+            return RebaseTodoEntry::Action::Edit;
+        }
+        if (text == QStringLiteral("squash")) {
+            return RebaseTodoEntry::Action::Squash;
+        }
+        if (text == QStringLiteral("fixup")) {
+            return RebaseTodoEntry::Action::Fixup;
+        }
+        if (text == QStringLiteral("drop")) {
+            return RebaseTodoEntry::Action::Drop;
+        }
+        return RebaseTodoEntry::Action::Pick;
+    };
+
+    std::function<void()> refreshTable = [table, todo, actionLabel, actionFromLabel] {
+        table->setRowCount(static_cast<int>(todo->size()));
+        for (int row = 0; row < static_cast<int>(todo->size()); ++row) {
+            const RebaseTodoEntry& entry = (*todo)[static_cast<std::size_t>(row)];
+            auto* combo = new QComboBox(table);
+            combo->addItems({QStringLiteral("pick"),
+                             QStringLiteral("edit"),
+                             QStringLiteral("squash"),
+                             QStringLiteral("fixup"),
+                             QStringLiteral("drop")});
+            combo->setCurrentText(actionLabel(entry.action));
+            QObject::connect(combo,
+                             &QComboBox::currentTextChanged,
+                             table,
+                             [todo, row, actionFromLabel](const QString& text) {
+                                 (*todo)[static_cast<std::size_t>(row)].action =
+                                     actionFromLabel(text);
+                             });
+            table->setCellWidget(row, 0, combo);
+            table->setItem(row, 1, new QTableWidgetItem(QString::fromStdString(entry.shortOid)));
+            table->setItem(row, 2, new QTableWidgetItem(QString::fromStdString(entry.subject)));
+        }
+    };
+
+    connect(session_.get(),
+            &RepositorySession::rebasePlanReady,
+            &dialog,
+            [todo, refreshTable](std::vector<RebaseTodoEntry> entries) {
+                *todo = std::move(entries);
+                refreshTable();
+            });
+    session_->requestRebasePlan(upstream.hex());
+
+    auto* upButton = new QPushButton(QStringLiteral("Move Up"), &dialog);
+    auto* downButton = new QPushButton(QStringLiteral("Move Down"), &dialog);
+    connect(upButton, &QPushButton::clicked, &dialog, [table, todo, refreshTable] {
+        const int row = table->currentRow();
+        if (row <= 0) {
+            return;
+        }
+        std::swap((*todo)[static_cast<std::size_t>(row)],
+                  (*todo)[static_cast<std::size_t>(row - 1)]);
+        refreshTable();
+        table->selectRow(row - 1);
+    });
+    connect(downButton, &QPushButton::clicked, &dialog, [table, todo, refreshTable] {
+        const int row = table->currentRow();
+        if (row < 0 || row + 1 >= static_cast<int>(todo->size())) {
+            return;
+        }
+        std::swap((*todo)[static_cast<std::size_t>(row)],
+                  (*todo)[static_cast<std::size_t>(row + 1)]);
+        refreshTable();
+        table->selectRow(row + 1);
+    });
+    auto* moveRow = new QHBoxLayout();
+    moveRow->addWidget(upButton);
+    moveRow->addWidget(downButton);
+    moveRow->addStretch(1);
+    layout->addLayout(moveRow);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    buttons->button(QDialogButtonBox::Ok)->setText(QStringLiteral("Start Rebase"));
+    layout->addWidget(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+    dialog.resize(560, 420);
+    if (dialog.exec() != QDialog::Accepted || todo->empty()) {
+        return;
+    }
+
+    RebaseInteractiveRequest request;
+    request.upstream = upstream.hex();
+    request.todo = *todo;
+    statusLabel_->setText(QStringLiteral("Rebasing…"));
+    armWorkingCopyChoiceHandler(
+        [this, request](bool stashFirst) mutable {
+            request.stashFirst = stashFirst;
+            session_->startInteractiveRebase(request);
+        },
+        false);
+}
+
+// --- M4: clean ---------------------------------------------------------------
+
+void MainWindow::onCleanUntracked() {
+    if (!session_) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Clean untracked files"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    auto* includeIgnored = new QCheckBox(QStringLiteral("Also remove ignored files"), &dialog);
+    layout->addWidget(includeIgnored);
+
+    auto* list = new QListWidget(&dialog);
+    layout->addWidget(list, 1);
+
+    connect(session_.get(),
+            &RepositorySession::cleanPreviewReady,
+            &dialog,
+            [list](std::vector<CleanEntry> entries) {
+                list->clear();
+                for (const CleanEntry& entry : entries) {
+                    auto* item = new QListWidgetItem(
+                        QString::fromStdString(entry.path) +
+                            (entry.isDirectory ? QStringLiteral("/") : QString()),
+                        list);
+                    item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+                    item->setCheckState(Qt::Checked);
+                    item->setData(Qt::UserRole, QString::fromStdString(entry.path));
+                }
+            });
+    auto reload = [this, includeIgnored] {
+        session_->requestCleanPreview(includeIgnored->isChecked());
+    };
+    connect(includeIgnored, &QCheckBox::toggled, &dialog, [reload](bool) { reload(); });
+    reload();
+
+    auto* buttonRow = new QHBoxLayout();
+    auto* removeButton = new QPushButton(QStringLiteral("Remove"), &dialog);
+    auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+    buttonRow->addStretch(1);
+    buttonRow->addWidget(removeButton);
+    buttonRow->addWidget(closeButton);
+    layout->addLayout(buttonRow);
+
+    connect(removeButton, &QPushButton::clicked, &dialog, [this, list, includeIgnored, &dialog] {
+        std::vector<std::string> paths;
+        for (int i = 0; i < list->count(); ++i) {
+            auto* item = list->item(i);
+            if (item->checkState() == Qt::Checked) {
+                paths.push_back(item->data(Qt::UserRole).toString().toStdString());
+            }
+        }
+        if (paths.empty()) {
+            return;
+        }
+        const auto confirmed =
+            QMessageBox::warning(&dialog,
+                                 QStringLiteral("Remove untracked files?"),
+                                 QStringLiteral("This permanently deletes %1 item(s). This "
+                                                "cannot be undone.")
+                                     .arg(paths.size()),
+                                 QMessageBox::Discard | QMessageBox::Cancel,
+                                 QMessageBox::Cancel);
+        if (confirmed != QMessageBox::Discard) {
+            return;
+        }
+        CleanRequest request;
+        request.paths = paths;
+        request.includeIgnored = includeIgnored->isChecked();
+        runWithFeedback([this, request] { session_->cleanUntracked(request); });
+        dialog.accept();
+    });
+    connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+
+    dialog.resize(480, 400);
+    dialog.exec();
+}
+
+// --- M4: reflog and undo -----------------------------------------------------
+
+void MainWindow::onShowReflog() {
+    if (!session_) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Reflog"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    auto* table = new QTableWidget(&dialog);
+    table->setColumnCount(3);
+    table->setHorizontalHeaderLabels(
+        {QStringLiteral("Commit"), QStringLiteral("When"), QStringLiteral("Action")});
+    table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setSelectionMode(QAbstractItemView::SingleSelection);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->verticalHeader()->setVisible(false);
+    layout->addWidget(table, 1);
+
+    connect(
+        session_.get(),
+        &RepositorySession::reflogReady,
+        &dialog,
+        [table](std::vector<ReflogEntry> entries) {
+            table->setRowCount(static_cast<int>(entries.size()));
+            for (int row = 0; row < static_cast<int>(entries.size()); ++row) {
+                const ReflogEntry& entry = entries[static_cast<std::size_t>(row)];
+                auto* oidItem = new QTableWidgetItem(QString::fromStdString(entry.oid.shortHex()));
+                oidItem->setData(Qt::UserRole, QString::fromStdString(entry.oid.hex()));
+                table->setItem(row, 0, oidItem);
+                table->setItem(
+                    row,
+                    1,
+                    new QTableWidgetItem(
+                        QDateTime::fromSecsSinceEpoch(entry.who.when).toString(Qt::ISODate)));
+                table->setItem(row, 2, new QTableWidgetItem(QString::fromStdString(entry.message)));
+            }
+        });
+    session_->requestReflog("");
+
+    auto* buttonRow = new QHBoxLayout();
+    auto* resetButton = new QPushButton(QStringLiteral("Reset to here (hard)…"), &dialog);
+    auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+    buttonRow->addStretch(1);
+    buttonRow->addWidget(resetButton);
+    buttonRow->addWidget(closeButton);
+    layout->addLayout(buttonRow);
+
+    connect(resetButton, &QPushButton::clicked, &dialog, [this, table, &dialog] {
+        const auto selectedRows = table->selectionModel()->selectedRows();
+        if (selectedRows.isEmpty()) {
+            return;
+        }
+        const QString oid =
+            table->item(selectedRows.first().row(), 0)->data(Qt::UserRole).toString();
+        const auto confirmed =
+            QMessageBox::warning(&dialog,
+                                 QStringLiteral("Hard reset?"),
+                                 QStringLiteral("This permanently discards uncommitted changes "
+                                                "and moves the current branch to %1.")
+                                     .arg(oid.left(10)),
+                                 QMessageBox::Discard | QMessageBox::Cancel,
+                                 QMessageBox::Cancel);
+        if (confirmed != QMessageBox::Discard) {
+            return;
+        }
+        ResetRequest request;
+        request.target = oid.toStdString();
+        request.mode = ResetMode::Hard;
+        runWithFeedback([this, request] { session_->resetTo(request); });
+        dialog.accept();
+    });
+    connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+
+    dialog.resize(560, 420);
+    dialog.exec();
+}
+
+void MainWindow::onUndoLastOperation() {
+    if (!session_ || session_->undoJournal().empty()) {
+        return;
+    }
+    const auto& entry = session_->undoJournal().back();
+    const auto confirmed = QMessageBox::question(
+        this,
+        QStringLiteral("Undo?"),
+        QStringLiteral("Undo \"%1\"? This resets the current branch back to where it stood "
+                       "before.")
+            .arg(QString::fromStdString(entry.description)),
+        QMessageBox::Yes | QMessageBox::Cancel,
+        QMessageBox::Cancel);
+    if (confirmed != QMessageBox::Yes) {
+        return;
+    }
+    statusLabel_->setText(QStringLiteral("Undoing…"));
+    runWithFeedback([this] { session_->undoLastOperation(); });
+}
+
+// --- M4: blame, file and line history ---------------------------------------
+
+void MainWindow::onFileContextMenuRequested(const QPoint& pos) {
+    if (!session_ || fileView_->model() == nullptr) {
+        return;
+    }
+    const QModelIndex index = fileView_->indexAt(pos);
+    if (!index.isValid()) {
+        return;
+    }
+    const QString path = fileView_->model()->data(index, Qt::DisplayRole).toString();
+    const QModelIndexList selectedCommit = commitView_->selectionModel()->selectedRows();
+    if (selectedCommit.isEmpty()) {
+        return;
+    }
+    const ObjectId commit = commitModel_->oidAt(selectedCommit.first().row());
+    if (commit.isNull()) {
+        return;
+    }
+
+    QMenu menu(this);
+    QAction* blameAction = menu.addAction(QStringLiteral("Blame this file"));
+    QAction* historyAction = menu.addAction(QStringLiteral("File history"));
+    QAction* lineHistoryAction = menu.addAction(QStringLiteral("Line history for a range…"));
+    QAction* chosen = menu.exec(fileView_->viewport()->mapToGlobal(pos));
+    if (chosen == nullptr) {
+        return;
+    }
+
+    const std::string stdPath = path.toStdString();
+    const std::string revision = commit.hex();
+
+    if (chosen == blameAction) {
+        auto connection = std::make_shared<QMetaObject::Connection>();
+        *connection = connect(
+            session_.get(),
+            &RepositorySession::blameReady,
+            this,
+            [this, connection, path](BlameResultPtr result) {
+                QObject::disconnect(*connection);
+                if (!result) {
+                    return;
+                }
+                QDialog dialog(this);
+                dialog.setWindowTitle(QStringLiteral("Blame: %1").arg(path));
+                auto* layout = new QVBoxLayout(&dialog);
+                auto* table = new QTableWidget(&dialog);
+                table->setColumnCount(4);
+                table->setHorizontalHeaderLabels({QStringLiteral("Commit"),
+                                                  QStringLiteral("Author"),
+                                                  QStringLiteral("Line"),
+                                                  QStringLiteral("Content")});
+                table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+                table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+                table->verticalHeader()->setVisible(false);
+                table->setRowCount(static_cast<int>(result->lines.size()));
+                for (int row = 0; row < static_cast<int>(result->lines.size()); ++row) {
+                    const BlameLine& line = result->lines[static_cast<std::size_t>(row)];
+                    table->setItem(
+                        row,
+                        0,
+                        new QTableWidgetItem(QString::fromStdString(line.commitOid.shortHex())));
+                    table->setItem(
+                        row, 1, new QTableWidgetItem(QString::fromStdString(line.authorName)));
+                    table->setItem(row, 2, new QTableWidgetItem(QString::number(line.finalLine)));
+                    table->setItem(
+                        row, 3, new QTableWidgetItem(QString::fromStdString(line.content)));
+                }
+                layout->addWidget(table);
+                auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+                connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+                layout->addWidget(closeButton);
+                dialog.resize(720, 480);
+                dialog.exec();
+            });
+        session_->requestBlame(stdPath, revision, 0, 0);
+        return;
+    }
+
+    if (chosen == historyAction) {
+        auto connection = std::make_shared<QMetaObject::Connection>();
+        *connection = connect(
+            session_.get(),
+            &RepositorySession::fileHistoryReady,
+            this,
+            [this, connection, path](std::vector<FileHistoryEntry> entries) {
+                QObject::disconnect(*connection);
+                QDialog dialog(this);
+                dialog.setWindowTitle(QStringLiteral("History: %1").arg(path));
+                auto* layout = new QVBoxLayout(&dialog);
+                auto* table = new QTableWidget(&dialog);
+                table->setColumnCount(4);
+                table->setHorizontalHeaderLabels({QStringLiteral("Commit"),
+                                                  QStringLiteral("Author"),
+                                                  QStringLiteral("Status"),
+                                                  QStringLiteral("Subject")});
+                table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+                table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+                table->verticalHeader()->setVisible(false);
+                table->setRowCount(static_cast<int>(entries.size()));
+                for (int row = 0; row < static_cast<int>(entries.size()); ++row) {
+                    const FileHistoryEntry& entry = entries[static_cast<std::size_t>(row)];
+                    table->setItem(
+                        row, 0, new QTableWidgetItem(QString::fromStdString(entry.oid.shortHex())));
+                    table->setItem(
+                        row, 1, new QTableWidgetItem(QString::fromStdString(entry.author.name)));
+                    QString status = QString::fromStdString(entry.status);
+                    if (!entry.renamedFrom.empty()) {
+                        status += QStringLiteral(" (from %1)")
+                                      .arg(QString::fromStdString(entry.renamedFrom));
+                    }
+                    table->setItem(row, 2, new QTableWidgetItem(status));
+                    table->setItem(
+                        row, 3, new QTableWidgetItem(QString::fromStdString(entry.subject)));
+                }
+                layout->addWidget(table);
+                auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+                connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+                layout->addWidget(closeButton);
+                dialog.resize(720, 480);
+                dialog.exec();
+            });
+        session_->requestFileHistory(stdPath, revision);
+        return;
+    }
+
+    if (chosen == lineHistoryAction) {
+        bool ok = false;
+        const int startLine = QInputDialog::getInt(this,
+                                                   QStringLiteral("Line history"),
+                                                   QStringLiteral("Start line:"),
+                                                   1,
+                                                   1,
+                                                   1000000,
+                                                   1,
+                                                   &ok);
+        if (!ok) {
+            return;
+        }
+        const int endLine = QInputDialog::getInt(this,
+                                                 QStringLiteral("Line history"),
+                                                 QStringLiteral("End line:"),
+                                                 startLine,
+                                                 startLine,
+                                                 1000000,
+                                                 1,
+                                                 &ok);
+        if (!ok) {
+            return;
+        }
+
+        auto connection = std::make_shared<QMetaObject::Connection>();
+        *connection =
+            connect(session_.get(),
+                    &RepositorySession::lineHistoryReady,
+                    this,
+                    [this, connection, path](std::vector<LineHistoryChunk> chunks) {
+                        QObject::disconnect(*connection);
+                        QDialog dialog(this);
+                        dialog.setWindowTitle(QStringLiteral("Line history: %1").arg(path));
+                        auto* layout = new QVBoxLayout(&dialog);
+                        auto* text = new QPlainTextEdit(&dialog);
+                        text->setReadOnly(true);
+                        text->setLineWrapMode(QPlainTextEdit::NoWrap);
+                        QString content;
+                        for (const LineHistoryChunk& chunk : chunks) {
+                            content += QStringLiteral("commit %1 — %2\n%3\n\n")
+                                           .arg(QString::fromStdString(chunk.oid.shortHex()))
+                                           .arg(QString::fromStdString(chunk.subject))
+                                           .arg(QString::fromStdString(chunk.diffText));
+                        }
+                        text->setPlainText(content);
+                        layout->addWidget(text);
+                        auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+                        connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+                        layout->addWidget(closeButton);
+                        dialog.resize(720, 480);
+                        dialog.exec();
+                    });
+        session_->requestLineHistory(stdPath, startLine, endLine, revision);
     }
 }
 

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -21,7 +21,9 @@
 #include <functional>
 #include <memory>
 
+class QAction;
 class QLineEdit;
+class QPushButton;
 class QSplitter;
 class QStackedWidget;
 class QProgressBar;
@@ -77,6 +79,18 @@ private slots:
     void onRefContextMenuRequested(const QPoint& pos);
     void onCredentialRequested(QString prompt);
 
+    // --- M4 ---------------------------------------------------------------
+    void onResetBranchRequested();
+    void onRebaseRequested();
+    void onInteractiveRebaseRequested();
+    void onBannerContinue();
+    void onBannerSkip();
+    void onBannerAbort();
+    void onCleanUntracked();
+    void onShowReflog();
+    void onUndoLastOperation();
+    void onFileContextMenuRequested(const QPoint& pos);
+
 private:
     void buildUi();
     void buildMenus();
@@ -105,6 +119,10 @@ private:
     void runWithFeedback(std::function<void()> submit,
                          std::function<void(OperationChoice::Kind)> onChoice = nullptr);
 
+    /// Shows or hides the Continue/Skip/Abort banner buttons appropriately for
+    /// whichever sequencer operation RepoState reports, if any.
+    void updateSequencerControls(const RepoState& state);
+
     GitInstallation installation_;
 
     /// Read pool for history, diffs and metadata. Sized to leave a core for the UI.
@@ -130,6 +148,10 @@ private:
 
     QLabel* statusLabel_ = nullptr;
     QLabel* bannerLabel_ = nullptr;
+    QPushButton* bannerContinueButton_ = nullptr;
+    QPushButton* bannerSkipButton_ = nullptr;
+    QPushButton* bannerAbortButton_ = nullptr;
+    QAction* undoAction_ = nullptr;
     QProgressBar* busyBar_ = nullptr;
 
     /// Coalesces a burst of scroll events into a single `probeVisibleRepos()`

--- a/src/app/views/WorkingCopyView.cpp
+++ b/src/app/views/WorkingCopyView.cpp
@@ -4,6 +4,7 @@
 #include "app/views/SideBySideDiffView.h"
 #include "core/git/ops/CommitOps.h"
 #include "core/git/ops/ConflictOps.h"
+#include "core/git/ops/ResetOps.h"
 
 #include <QCheckBox>
 #include <QDialog>
@@ -11,6 +12,8 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidget>
+#include <QMenu>
+#include <QMessageBox>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSplitter>
@@ -30,9 +33,17 @@ QString pathLabel(const WorkingCopyEntry& entry) {
     return QString::fromStdString(entry.path);
 }
 
-QListWidgetItem* addEntry(QListWidget* list, const WorkingCopyEntry& entry, const QString& suffix) {
+/// Qt::UserRole+1 on an unstaged-list item: whether it is untracked, i.e. has
+/// no HEAD/index content for `git restore` to discard back to.
+constexpr int kUntrackedRole = Qt::UserRole + 1;
+
+QListWidgetItem* addEntry(QListWidget* list,
+                          const WorkingCopyEntry& entry,
+                          const QString& suffix,
+                          bool untracked = false) {
     auto* item = new QListWidgetItem(pathLabel(entry) + suffix, list);
     item->setData(Qt::UserRole, QString::fromStdString(entry.path));
+    item->setData(kUntrackedRole, untracked);
     return item;
 }
 
@@ -77,6 +88,7 @@ void WorkingCopyView::buildUi() {
     leftLayout->addWidget(new QLabel(tr("Changes"), leftWidget));
     unstagedList_ = new QListWidget(leftWidget);
     unstagedList_->setSelectionMode(QAbstractItemView::SingleSelection);
+    unstagedList_->setContextMenuPolicy(Qt::CustomContextMenu);
     leftLayout->addWidget(unstagedList_, 1);
     stageAllButton_ = new QPushButton(tr("Stage All"), leftWidget);
     leftLayout->addWidget(stageAllButton_);
@@ -140,6 +152,42 @@ void WorkingCopyView::buildUi() {
             &QListWidget::itemActivated,
             this,
             &WorkingCopyView::onConflictedItemActivated);
+    connect(
+        unstagedList_, &QListWidget::customContextMenuRequested, this, [this](const QPoint& pos) {
+            auto* item = unstagedList_->itemAt(pos);
+            if (item == nullptr || session_ == nullptr) {
+                return;
+            }
+            // `git restore` has nothing to discard an untracked file back
+            // to -- there is no HEAD/index content for it -- so it is left
+            // out of the menu rather than offering an action that would
+            // just fail.
+            if (item->data(kUntrackedRole).toBool()) {
+                return;
+            }
+            const std::string path = item->data(Qt::UserRole).toString().toStdString();
+
+            QMenu menu(unstagedList_);
+            QAction* discardAction = menu.addAction(tr("Discard Changes…"));
+            if (menu.exec(unstagedList_->viewport()->mapToGlobal(pos)) != discardAction) {
+                return;
+            }
+            const auto confirmed =
+                QMessageBox::warning(this,
+                                     tr("Discard changes?"),
+                                     tr("This permanently discards your uncommitted changes "
+                                        "to \"%1\".")
+                                         .arg(QString::fromStdString(path)),
+                                     QMessageBox::Discard | QMessageBox::Cancel,
+                                     QMessageBox::Cancel);
+            if (confirmed != QMessageBox::Discard) {
+                return;
+            }
+            RestoreRequest request;
+            request.paths = {path};
+            request.staged = false;
+            session_->restorePaths(request);
+        });
     connect(sideBySideToggle_, &QCheckBox::toggled, this, [this](bool sideBySide) {
         diffStack_->setCurrentWidget(sideBySide ? static_cast<QWidget*>(sideBySideView_)
                                                 : static_cast<QWidget*>(diffView_));
@@ -217,7 +265,7 @@ void WorkingCopyView::rebuildLists() {
             addEntry(unstagedList_, *entry, QString());
         }
         for (const WorkingCopyEntry* entry : status->untracked()) {
-            addEntry(unstagedList_, *entry, tr("  (untracked)"));
+            addEntry(unstagedList_, *entry, tr("  (untracked)"), true);
         }
     }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -8,14 +8,17 @@ add_library(gbm_core STATIC
     base/ThreadCheck.cpp
 
     git/AskpassHelper.cpp
+    git/BlameStore.cpp
     git/CatFileBatch.cpp
     git/CommitMeta.cpp
     git/DiffService.cpp
+    git/FileHistoryStore.cpp
     git/GitExecutable.cpp
     git/HistoryProvider.cpp
     git/OperationRunner.cpp
     git/ProcessRunner.cpp
     git/RefStore.cpp
+    git/ReflogStore.cpp
     git/RepoState.cpp
     git/SideBySideDiff.cpp
     git/UnifiedDiffParser.cpp
@@ -26,10 +29,13 @@ add_library(gbm_core STATIC
     git/ops/CommitOps.cpp
     git/ops/ConflictOps.cpp
     git/ops/MergeOps.cpp
+    git/ops/RebaseOps.cpp
     git/ops/RemoteOps.cpp
+    git/ops/ResetOps.cpp
     git/ops/StageOps.cpp
     git/ops/StashOps.cpp
     git/ops/TagOps.cpp
+    git/ops/UndoOps.cpp
     git/ops/WorktreeOps.cpp
 
     graph/GraphAsciiRenderer.cpp

--- a/src/core/git/BlameStore.cpp
+++ b/src/core/git/BlameStore.cpp
@@ -13,9 +13,8 @@ bool looksLikeObjectHex(std::string_view token) {
     if (token.size() != 40 && token.size() != 64) {
         return false;
     }
-    return std::all_of(token.begin(), token.end(), [](unsigned char c) {
-        return std::isxdigit(c) != 0;
-    });
+    return std::all_of(
+        token.begin(), token.end(), [](unsigned char c) { return std::isxdigit(c) != 0; });
 }
 
 }  // namespace
@@ -58,9 +57,8 @@ GitResult<BlameResultPtr> BlameStore::blame(const std::string& path,
     std::size_t pos = 0;
     while (pos < text.size()) {
         const std::size_t lineEnd = text.find('\n', pos);
-        const std::string_view line =
-            text.substr(pos, lineEnd == std::string_view::npos ? std::string_view::npos
-                                                                : lineEnd - pos);
+        const std::string_view line = text.substr(
+            pos, lineEnd == std::string_view::npos ? std::string_view::npos : lineEnd - pos);
         pos = lineEnd == std::string_view::npos ? text.size() : lineEnd + 1;
 
         if (line.empty()) {
@@ -87,7 +85,8 @@ GitResult<BlameResultPtr> BlameStore::blame(const std::string& path,
             if (sp2 != std::string_view::npos) {
                 const std::size_t sp3 = line.find(' ', sp2 + 1);
                 const std::string_view finalStr = line.substr(
-                    sp2 + 1, sp3 == std::string_view::npos ? std::string_view::npos : sp3 - sp2 - 1);
+                    sp2 + 1,
+                    sp3 == std::string_view::npos ? std::string_view::npos : sp3 - sp2 - 1);
                 entry.finalLine = std::atoi(std::string(finalStr).c_str());
             }
             blameResult->lines.push_back(std::move(entry));

--- a/src/core/git/BlameStore.cpp
+++ b/src/core/git/BlameStore.cpp
@@ -1,0 +1,122 @@
+#include "core/git/BlameStore.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+bool looksLikeObjectHex(std::string_view token) {
+    if (token.size() != 40 && token.size() != 64) {
+        return false;
+    }
+    return std::all_of(token.begin(), token.end(), [](unsigned char c) {
+        return std::isxdigit(c) != 0;
+    });
+}
+
+}  // namespace
+
+BlameStore::BlameStore(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<BlameResultPtr> BlameStore::blame(const std::string& path,
+                                            const std::string& revision,
+                                            int startLine,
+                                            int endLine,
+                                            CancellationToken token) {
+    if (path.empty()) {
+        return fail(GitError::Code::InvalidArgument, "No file selected to blame");
+    }
+
+    std::vector<std::string> args{"blame", "--line-porcelain"};
+    if (startLine > 0 && endLine > 0) {
+        args.emplace_back("-L");
+        args.push_back(std::to_string(startLine) + "," + std::to_string(endLine));
+    }
+    if (!revision.empty()) {
+        args.push_back(revision);
+    }
+    args.emplace_back("--");
+    args.push_back(path);
+
+    GitCommand command(paths_.commandDir(), std::move(args));
+    command.timeout = std::chrono::seconds(120);
+
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    auto blameResult = std::make_shared<BlameResult>();
+    blameResult->truncated = result->out.size() > kMaxBytes;
+    const std::string_view text(result->out.data(), std::min(result->out.size(), kMaxBytes));
+
+    std::size_t pos = 0;
+    while (pos < text.size()) {
+        const std::size_t lineEnd = text.find('\n', pos);
+        const std::string_view line =
+            text.substr(pos, lineEnd == std::string_view::npos ? std::string_view::npos
+                                                                : lineEnd - pos);
+        pos = lineEnd == std::string_view::npos ? text.size() : lineEnd + 1;
+
+        if (line.empty()) {
+            continue;
+        }
+
+        if (line.front() == '\t') {
+            if (!blameResult->lines.empty()) {
+                blameResult->lines.back().content = std::string(line.substr(1));
+            }
+            continue;
+        }
+
+        const std::size_t sp1 = line.find(' ');
+        const std::string_view firstToken = line.substr(0, sp1);
+
+        if (sp1 != std::string_view::npos && looksLikeObjectHex(firstToken)) {
+            BlameLine entry;
+            entry.commitOid = ObjectId::fromHex(firstToken);
+            const std::size_t sp2 = line.find(' ', sp1 + 1);
+            const std::string_view origStr = line.substr(
+                sp1 + 1, sp2 == std::string_view::npos ? std::string_view::npos : sp2 - sp1 - 1);
+            entry.originalLine = std::atoi(std::string(origStr).c_str());
+            if (sp2 != std::string_view::npos) {
+                const std::size_t sp3 = line.find(' ', sp2 + 1);
+                const std::string_view finalStr = line.substr(
+                    sp2 + 1, sp3 == std::string_view::npos ? std::string_view::npos : sp3 - sp2 - 1);
+                entry.finalLine = std::atoi(std::string(finalStr).c_str());
+            }
+            blameResult->lines.push_back(std::move(entry));
+            continue;
+        }
+
+        if (blameResult->lines.empty()) {
+            continue;
+        }
+        BlameLine& current = blameResult->lines.back();
+
+        if (line.starts_with("author ")) {
+            current.authorName = std::string(line.substr(7));
+        } else if (line.starts_with("author-mail ")) {
+            std::string mail(line.substr(12));
+            if (mail.size() >= 2 && mail.front() == '<' && mail.back() == '>') {
+                mail = mail.substr(1, mail.size() - 2);
+            }
+            current.authorEmail = std::move(mail);
+        } else if (line.starts_with("author-time ")) {
+            current.authorTime = std::strtoll(std::string(line.substr(12)).c_str(), nullptr, 10);
+        } else if (line.starts_with("summary ")) {
+            current.summary = std::string(line.substr(8));
+        } else if (line == "boundary") {
+            current.boundary = true;
+        }
+    }
+
+    return BlameResultPtr(blameResult);
+}
+
+}  // namespace gbm

--- a/src/core/git/BlameStore.h
+++ b/src/core/git/BlameStore.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/base/ObjectId.h"
+#include "core/git/IProcessRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+/// One line of `git blame` output.
+struct BlameLine {
+    ObjectId commitOid;
+    std::string authorName;
+    std::string authorEmail;
+    std::int64_t authorTime = 0;
+    std::string summary;    ///< The commit's subject line.
+    int finalLine = 0;      ///< 1-based line number in the revision being blamed.
+    int originalLine = 0;   ///< 1-based line number in the commit that introduced it.
+    std::string content;    ///< The line itself, without its trailing newline.
+    bool boundary = false;  ///< True at a shallow/grafted history's edge.
+};
+
+struct BlameResult {
+    std::vector<BlameLine> lines;
+    /// True when the output was truncated by kMaxBytes -- a generated or binary
+    /// file blamed by mistake should not allocate unboundedly.
+    bool truncated = false;
+};
+
+using BlameResultPtr = std::shared_ptr<const BlameResult>;
+
+/// Runs and parses `git blame`. Read-only, like RefStore, so it is never routed
+/// through OperationRunner.
+class BlameStore {
+public:
+    /// Above this many bytes of `--line-porcelain` output, parsing stops rather
+    /// than continuing unboundedly -- see DiffService's diff cap for the same
+    /// reasoning.
+    static constexpr std::size_t kMaxBytes = 16u * 1024u * 1024u;
+
+    BlameStore(IProcessRunner& runner, RepoPaths paths);
+
+    /// Blames `path` as of `revision` (empty means the working tree). `startLine`
+    /// and `endLine` are 1-based and inclusive; either being zero blames the
+    /// whole file.
+    GitResult<BlameResultPtr> blame(const std::string& path,
+                                    const std::string& revision,
+                                    int startLine,
+                                    int endLine,
+                                    CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+}  // namespace gbm

--- a/src/core/git/FileHistoryStore.cpp
+++ b/src/core/git/FileHistoryStore.cpp
@@ -1,0 +1,189 @@
+#include "core/git/FileHistoryStore.h"
+
+#include <charconv>
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+/// Marks the start of a commit's record in log output whose remainder (name
+/// status lines, or a -L hunk) is otherwise free-form and could start with
+/// almost anything. `\x01` cannot appear in a subject line or a diff, so it is
+/// an unambiguous separator without needing `-z` and NUL-splitting.
+constexpr char kRecordMarker = '\x01';
+
+std::vector<std::string_view> splitLines(std::string_view text) {
+    std::vector<std::string_view> lines;
+    std::size_t start = 0;
+    while (start <= text.size()) {
+        const std::size_t at = text.find('\n', start);
+        lines.push_back(
+            text.substr(start, at == std::string_view::npos ? std::string_view::npos : at - start));
+        if (at == std::string_view::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return lines;
+}
+
+/// Splits a "%H\t%an\t%ae\t%at\t%s" record (marker already stripped) into its
+/// five fields, tolerating a subject that itself contains tabs.
+struct CommitFields {
+    ObjectId oid;
+    Signature author;
+    std::string subject;
+};
+
+CommitFields parseCommitFields(std::string_view record) {
+    CommitFields fields;
+    std::size_t pos = 0;
+    for (int col = 0; col < 5; ++col) {
+        const std::size_t tab = record.find('\t', pos);
+        const std::string_view value =
+            record.substr(pos, tab == std::string_view::npos ? std::string_view::npos : tab - pos);
+        switch (col) {
+            case 0:
+                fields.oid = ObjectId::fromHex(value);
+                break;
+            case 1:
+                fields.author.name = std::string(value);
+                break;
+            case 2:
+                fields.author.email = std::string(value);
+                break;
+            case 3: {
+                std::int64_t ts = 0;
+                std::from_chars(value.data(), value.data() + value.size(), ts);
+                fields.author.when = ts;
+                break;
+            }
+            case 4:
+                fields.subject = std::string(value);
+                break;
+        }
+        if (tab == std::string_view::npos) {
+            break;
+        }
+        pos = tab + 1;
+    }
+    return fields;
+}
+
+}  // namespace
+
+FileHistoryStore::FileHistoryStore(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<std::vector<FileHistoryEntry>> FileHistoryStore::fileHistory(
+    const std::string& path, const std::string& startRevision, CancellationToken token) {
+    if (path.empty()) {
+        return fail(GitError::Code::InvalidArgument, "No file selected");
+    }
+
+    std::vector<std::string> args{
+        "log", "--follow", "--name-status", "--format=\x01%H\x09%an\x09%ae\x09%at\x09%s"};
+    if (!startRevision.empty()) {
+        args.push_back(startRevision);
+    }
+    args.emplace_back("--");
+    args.push_back(path);
+
+    GitCommand command(paths_.commandDir(), std::move(args));
+    command.timeout = std::chrono::seconds(60);
+
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    std::vector<FileHistoryEntry> entries;
+    for (std::string_view line : splitLines(result->out)) {
+        if (line.empty()) {
+            continue;
+        }
+        if (line.front() == kRecordMarker) {
+            const CommitFields fields = parseCommitFields(line.substr(1));
+            FileHistoryEntry entry;
+            entry.oid = fields.oid;
+            entry.author = fields.author;
+            entry.subject = fields.subject;
+            entries.push_back(std::move(entry));
+            continue;
+        }
+        if (entries.empty()) {
+            continue;
+        }
+        // A name-status line: "<status>\t<path>" or "R###\t<old>\t<new>".
+        const std::size_t tab = line.find('\t');
+        if (tab == std::string_view::npos) {
+            continue;
+        }
+        const std::string_view status = line.substr(0, tab);
+        entries.back().status = std::string(status);
+        if (!status.empty() && (status.front() == 'R' || status.front() == 'C')) {
+            const std::string_view rest = line.substr(tab + 1);
+            const std::size_t tab2 = rest.find('\t');
+            if (tab2 != std::string_view::npos) {
+                entries.back().renamedFrom = std::string(rest.substr(0, tab2));
+            }
+        }
+    }
+    return entries;
+}
+
+GitResult<std::vector<LineHistoryChunk>> FileHistoryStore::lineHistory(
+    const std::string& path,
+    int startLine,
+    int endLine,
+    const std::string& startRevision,
+    CancellationToken token) {
+    if (path.empty() || startLine <= 0 || endLine < startLine) {
+        return fail(GitError::Code::InvalidArgument, "Invalid line range");
+    }
+
+    std::vector<std::string> args{
+        "log",
+        "-L",
+        std::to_string(startLine) + "," + std::to_string(endLine) + ":" + path,
+        "--format=\x01%H\x09%an\x09%ae\x09%at\x09%s"};
+    if (!startRevision.empty()) {
+        args.push_back(startRevision);
+    }
+
+    GitCommand command(paths_.commandDir(), std::move(args));
+    command.timeout = std::chrono::seconds(60);
+
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    std::vector<LineHistoryChunk> chunks;
+    for (std::string_view line : splitLines(result->out)) {
+        if (line.empty()) {
+            if (!chunks.empty()) {
+                chunks.back().diffText += '\n';
+            }
+            continue;
+        }
+        if (line.front() == kRecordMarker) {
+            const CommitFields fields = parseCommitFields(line.substr(1));
+            LineHistoryChunk chunk;
+            chunk.oid = fields.oid;
+            chunk.author = fields.author;
+            chunk.subject = fields.subject;
+            chunks.push_back(std::move(chunk));
+            continue;
+        }
+        if (chunks.empty()) {
+            continue;
+        }
+        chunks.back().diffText += line;
+        chunks.back().diffText += '\n';
+    }
+    return chunks;
+}
+
+}  // namespace gbm

--- a/src/core/git/FileHistoryStore.h
+++ b/src/core/git/FileHistoryStore.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/base/ObjectId.h"
+#include "core/git/CommitMeta.h"
+#include "core/git/IProcessRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+/// One commit that touched a file, from `git log --follow`.
+struct FileHistoryEntry {
+    ObjectId oid;
+    Signature author;
+    std::string subject;
+    /// Raw `--name-status` code: A, M, D, or R### / C### for a rename/copy.
+    std::string status;
+    /// The path this file had before the commit, set only when `status` starts
+    /// with R or C -- `git log --follow` keeps walking under the old name.
+    std::string renamedFrom;
+};
+
+/// One commit's hunk from `git log -L`, covering a specific line range rather
+/// than the whole file.
+struct LineHistoryChunk {
+    ObjectId oid;
+    Signature author;
+    std::string subject;
+    /// The diff/hunk text git prints for this commit's change to the range, as
+    /// it comes from git -- headers, `@@` markers and all.
+    std::string diffText;
+};
+
+/// File- and line-level history: `git log --follow` and `git log -L`. Read-only,
+/// like RefStore.
+class FileHistoryStore {
+public:
+    FileHistoryStore(IProcessRunner& runner, RepoPaths paths);
+
+    /// Commits that touched `path`, newest first, following renames across
+    /// history the way `git log --follow` does. `startRevision` empty means
+    /// HEAD.
+    GitResult<std::vector<FileHistoryEntry>> fileHistory(const std::string& path,
+                                                         const std::string& startRevision,
+                                                         CancellationToken token);
+
+    /// Commits that touched lines `startLine..endLine` (1-based, inclusive) of
+    /// `path`, newest first.
+    GitResult<std::vector<LineHistoryChunk>> lineHistory(const std::string& path,
+                                                         int startLine,
+                                                         int endLine,
+                                                         const std::string& startRevision,
+                                                         CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+}  // namespace gbm

--- a/src/core/git/ReflogStore.cpp
+++ b/src/core/git/ReflogStore.cpp
@@ -1,0 +1,93 @@
+#include "core/git/ReflogStore.h"
+
+#include <charconv>
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+/// Parses "<ref>@{N}" into N, the same trick StashStore uses for `%gd`.
+int parseReflogIndex(std::string_view gd) {
+    const auto open = gd.find('{');
+    const auto close = gd.find('}', open);
+    if (open == std::string_view::npos || close == std::string_view::npos) {
+        return 0;
+    }
+    int value = 0;
+    const std::string_view digits = gd.substr(open + 1, close - open - 1);
+    std::from_chars(digits.data(), digits.data() + digits.size(), value);
+    return value;
+}
+
+}  // namespace
+
+ReflogStore::ReflogStore(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<std::vector<ReflogEntry>> ReflogStore::list(const std::string& ref,
+                                                       CancellationToken token) {
+    std::vector<std::string> args{
+        "reflog", "show", "--format=%H%x09%gd%x09%an%x09%ae%x09%at%x09%gs"};
+    args.push_back(ref.empty() ? "HEAD" : ref);
+
+    GitCommand command(paths_.commandDir(), std::move(args));
+    command.timeout = std::chrono::seconds(60);
+
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    std::vector<ReflogEntry> entries;
+    std::size_t start = 0;
+    while (start <= result->out.size()) {
+        const std::size_t at = result->out.find('\n', start);
+        const std::string_view line(result->out.data() + start,
+                                    (at == std::string::npos ? result->out.size() : at) - start);
+        if (!line.empty()) {
+            ReflogEntry entry;
+            std::size_t pos = 0;
+            for (int col = 0; col < 6; ++col) {
+                const std::size_t tab = line.find('\t', pos);
+                const std::string_view value =
+                    line.substr(pos, tab == std::string_view::npos ? std::string_view::npos : tab - pos);
+                switch (col) {
+                    case 0:
+                        entry.oid = ObjectId::fromHex(value);
+                        break;
+                    case 1:
+                        entry.index = parseReflogIndex(value);
+                        break;
+                    case 2:
+                        entry.who.name = std::string(value);
+                        break;
+                    case 3:
+                        entry.who.email = std::string(value);
+                        break;
+                    case 4: {
+                        std::int64_t ts = 0;
+                        std::from_chars(value.data(), value.data() + value.size(), ts);
+                        entry.who.when = ts;
+                        break;
+                    }
+                    case 5:
+                        entry.message = std::string(value);
+                        break;
+                }
+                if (tab == std::string_view::npos) {
+                    break;
+                }
+                pos = tab + 1;
+            }
+            entries.push_back(std::move(entry));
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return entries;
+}
+
+}  // namespace gbm

--- a/src/core/git/ReflogStore.cpp
+++ b/src/core/git/ReflogStore.cpp
@@ -26,7 +26,7 @@ ReflogStore::ReflogStore(IProcessRunner& runner, RepoPaths paths)
     : runner_(runner), paths_(std::move(paths)) {}
 
 GitResult<std::vector<ReflogEntry>> ReflogStore::list(const std::string& ref,
-                                                       CancellationToken token) {
+                                                      CancellationToken token) {
     std::vector<std::string> args{
         "reflog", "show", "--format=%H%x09%gd%x09%an%x09%ae%x09%at%x09%gs"};
     args.push_back(ref.empty() ? "HEAD" : ref);
@@ -50,8 +50,8 @@ GitResult<std::vector<ReflogEntry>> ReflogStore::list(const std::string& ref,
             std::size_t pos = 0;
             for (int col = 0; col < 6; ++col) {
                 const std::size_t tab = line.find('\t', pos);
-                const std::string_view value =
-                    line.substr(pos, tab == std::string_view::npos ? std::string_view::npos : tab - pos);
+                const std::string_view value = line.substr(
+                    pos, tab == std::string_view::npos ? std::string_view::npos : tab - pos);
                 switch (col) {
                     case 0:
                         entry.oid = ObjectId::fromHex(value);

--- a/src/core/git/ReflogStore.h
+++ b/src/core/git/ReflogStore.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/base/ObjectId.h"
+#include "core/git/CommitMeta.h"
+#include "core/git/IProcessRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+/// One entry from `git reflog`, e.g. what `HEAD@{N}` refers to.
+struct ReflogEntry {
+    int index = 0;  ///< N in `<ref>@{N}`; 0 is the most recent.
+    ObjectId oid;
+    std::string message;  ///< The raw reflog subject, e.g. "commit: fix typo".
+    Signature who;
+};
+
+/// Reads `git reflog`. Read-only, like RefStore.
+class ReflogStore {
+public:
+    ReflogStore(IProcessRunner& runner, RepoPaths paths);
+
+    /// `ref` empty means HEAD.
+    GitResult<std::vector<ReflogEntry>> list(const std::string& ref, CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+}  // namespace gbm

--- a/src/core/git/ops/RebaseOps.cpp
+++ b/src/core/git/ops/RebaseOps.cpp
@@ -1,0 +1,401 @@
+#include "core/git/ops/RebaseOps.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+std::string actionVerb(RebaseTodoEntry::Action action) {
+    switch (action) {
+        case RebaseTodoEntry::Action::Pick:
+            return "pick";
+        case RebaseTodoEntry::Action::Edit:
+            return "edit";
+        case RebaseTodoEntry::Action::Squash:
+            return "squash";
+        case RebaseTodoEntry::Action::Fixup:
+            return "fixup";
+        case RebaseTodoEntry::Action::Drop:
+            return "drop";
+    }
+    return "pick";
+}
+
+std::string serializeTodo(const std::vector<RebaseTodoEntry>& todo) {
+    std::string text;
+    for (const auto& entry : todo) {
+        text += actionVerb(entry.action);
+        text += ' ';
+        text += entry.shortOid.empty() ? entry.oid.hex() : entry.shortOid;
+        text += ' ';
+        text += entry.subject;
+        text += '\n';
+    }
+    return text;
+}
+
+/// Writes `content` to a fresh temp file and returns its path, or an empty path
+/// on failure.
+std::filesystem::path writeTempFile(const std::string& content) {
+    std::error_code ec;
+    const auto dir = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+        return {};
+    }
+    static std::atomic<std::uint64_t> counter{0};
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto path = dir / ("gbm-rebase-todo-" + std::to_string(now) + "-" +
+                             std::to_string(counter.fetch_add(1)) + ".txt");
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        return {};
+    }
+    out << content;
+    out.close();
+    return path;
+}
+
+/// A single-quoted POSIX shell literal. Git always runs the sequence/message
+/// editor command through a shell, and a temp directory containing spaces is
+/// routine on Windows ("...\Local\Temp"), so the path must be quoted rather
+/// than passed bare.
+std::string shellQuote(const std::filesystem::path& path) {
+    std::string quoted = "'";
+    for (char c : path.string()) {
+        if (c == '\'') {
+            quoted += "'\\''";
+        } else {
+            quoted += c;
+        }
+    }
+    quoted += "'";
+    return quoted;
+}
+
+/// `cp` stands in for an interactive editor: git invokes `$GIT_SEQUENCE_EDITOR
+/// <path-to-its-generated-todo>`, so setting it to `cp <ourfile>` makes that
+/// invocation copy our pre-built plan over git's own before the sequencer reads
+/// it back. `cp` needs nothing bundled: Git for Windows carries its own
+/// coreutils and prepends them to PATH for exactly this kind of child process,
+/// so this works unmodified on all three platforms -- see the CLI-only-backend
+/// note in the README for why we lean on git's own toolchain rather than
+/// shipping anything ourselves.
+void applyRebaseEnv(GitCommand& command, const std::filesystem::path& todoFile) {
+    command.envOverrides.emplace_back("GIT_SEQUENCE_EDITOR", "cp " + shellQuote(todoFile));
+    // No terminal is available to write a squash/fixup message either, so the
+    // default (git's own concatenation of the combined commits) is always
+    // accepted, exactly as MergeOps does for a no-ff merge commit's message.
+    command.envOverrides.emplace_back("GIT_EDITOR", "true");
+}
+
+void addDirtyWorkTreeChoices(OperationOutcome& outcome, const std::string& verb) {
+    outcome.choices.push_back({OperationChoice::Kind::StashAndRetry,
+                               "Stash changes and " + verb,
+                               "Your changes are saved to a stash first, and can be restored "
+                               "afterwards.",
+                               false});
+    outcome.choices.push_back(
+        {OperationChoice::Kind::Abort, "Cancel", "Do not rebase.", false});
+}
+
+class RebaseInteractiveOperation final : public Operation {
+public:
+    explicit RebaseInteractiveOperation(RebaseInteractiveRequest request)
+        : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        return "Interactive rebase onto " +
+               (request_.onto.empty() ? request_.upstream : request_.onto);
+    }
+
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.upstream.empty()) {
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "No base commit selected to rebase onto");
+            return outcome;
+        }
+        if (request_.todo.empty()) {
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "There are no commits to rebase");
+            return outcome;
+        }
+
+        if (request_.stashFirst) {
+            GitCommand stash(paths.commandDir(),
+                             {"stash",
+                              "push",
+                              "--include-untracked",
+                              "-m",
+                              "git-branch-manager: before rebase"});
+            stash.timeout = std::chrono::seconds(600);
+            auto stashed = runner.run(stash, token);
+            if (!stashed) {
+                outcome.error = std::move(stashed).error();
+                outcome.summary = "Could not stash your changes, so nothing was rebased";
+                return outcome;
+            }
+        }
+
+        const auto todoFile = writeTempFile(serializeTodo(request_.todo));
+        if (todoFile.empty()) {
+            outcome.error =
+                GitError(GitError::Code::Io, "Could not write a temporary rebase plan");
+            return outcome;
+        }
+        struct TempFileGuard {
+            std::filesystem::path path;
+            ~TempFileGuard() {
+                std::error_code ec;
+                std::filesystem::remove(path, ec);
+            }
+        } guard{todoFile};
+
+        std::vector<std::string> args{"rebase", "-i"};
+        if (!request_.onto.empty()) {
+            args.emplace_back("--onto");
+            args.push_back(request_.onto);
+        }
+        args.push_back(request_.upstream);
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        applyRebaseEnv(command, todoFile);
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (result) {
+            outcome.succeeded = true;
+            outcome.summary =
+                "Rebased onto " + (request_.onto.empty() ? request_.upstream : request_.onto);
+            return outcome;
+        }
+
+        GitError error = std::move(result).error();
+        outcome.summary = error.message;
+
+        if (error.code == GitError::Code::DirtyWorkTree) {
+            addDirtyWorkTreeChoices(outcome, "rebase");
+        }
+        // As with a conflicting merge or cherry-pick, this is git stopping
+        // exactly where it should -- the conflict is recorded in the index, and
+        // the remaining todo stays queued in rebase-merge/ for --continue,
+        // --skip or --abort to work through.
+        if (error.code == GitError::Code::Conflict) {
+            outcome.summary = "Rebase stopped with conflicts to resolve";
+        }
+
+        outcome.error = std::move(error);
+        return outcome;
+    }
+
+private:
+    RebaseInteractiveRequest request_;
+};
+
+class RebaseOperation final : public Operation {
+public:
+    explicit RebaseOperation(RebaseRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        return "Rebase onto " + (request_.onto.empty() ? request_.upstream : request_.onto);
+    }
+
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.upstream.empty()) {
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "No base commit selected to rebase onto");
+            return outcome;
+        }
+
+        if (request_.stashFirst) {
+            GitCommand stash(paths.commandDir(),
+                             {"stash",
+                              "push",
+                              "--include-untracked",
+                              "-m",
+                              "git-branch-manager: before rebase"});
+            stash.timeout = std::chrono::seconds(600);
+            auto stashed = runner.run(stash, token);
+            if (!stashed) {
+                outcome.error = std::move(stashed).error();
+                outcome.summary = "Could not stash your changes, so nothing was rebased";
+                return outcome;
+            }
+        }
+
+        std::vector<std::string> args{"rebase"};
+        if (!request_.onto.empty()) {
+            args.emplace_back("--onto");
+            args.push_back(request_.onto);
+        }
+        args.push_back(request_.upstream);
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (result) {
+            outcome.succeeded = true;
+            outcome.summary =
+                "Rebased onto " + (request_.onto.empty() ? request_.upstream : request_.onto);
+            return outcome;
+        }
+
+        GitError error = std::move(result).error();
+        outcome.summary = error.message;
+
+        if (error.code == GitError::Code::DirtyWorkTree) {
+            addDirtyWorkTreeChoices(outcome, "rebase");
+        }
+        if (error.code == GitError::Code::Conflict) {
+            outcome.summary = "Rebase stopped with conflicts to resolve";
+        }
+
+        outcome.error = std::move(error);
+        return outcome;
+    }
+
+private:
+    RebaseRequest request_;
+};
+
+/// Shared by --continue/--skip/--abort: same shape, different verb, all legal
+/// only while a rebase is actually in progress.
+class RebaseControlOperation final : public Operation {
+public:
+    enum class Verb { Continue, Skip, Abort };
+
+    RebaseControlOperation(Verb verb, std::string description)
+        : verb_(verb), description_(std::move(description)) {}
+
+    std::string describe() const override { return description_; }
+
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        const char* flag =
+            verb_ == Verb::Continue ? "--continue" : verb_ == Verb::Skip ? "--skip" : "--abort";
+        GitCommand command(paths.commandDir(), {"rebase", flag});
+        if (verb_ == Verb::Continue) {
+            // A squash/fixup step resumed by --continue can still need to write
+            // the combined message; see applyRebaseEnv above for why this is
+            // always "accept the default" rather than left to open an editor.
+            command.envOverrides.emplace_back("GIT_EDITOR", "true");
+        }
+        command.timeout =
+            verb_ == Verb::Abort ? std::chrono::seconds(120) : std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            GitError error = std::move(result).error();
+            outcome.summary = error.message;
+            if (error.code == GitError::Code::Conflict) {
+                outcome.summary = "Rebase stopped with conflicts to resolve";
+            }
+            outcome.error = std::move(error);
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = description_;
+        return outcome;
+    }
+
+private:
+    Verb verb_;
+    std::string description_;
+};
+
+}  // namespace
+
+RebasePlanner::RebasePlanner(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<std::vector<RebaseTodoEntry>> RebasePlanner::plan(const std::string& upstream,
+                                                            CancellationToken token) {
+    if (upstream.empty()) {
+        return fail(GitError::Code::InvalidArgument, "No base commit selected to rebase onto");
+    }
+
+    GitCommand command(paths_.commandDir(),
+                       {"log", "--format=%H%x09%h%x09%s", "--reverse", upstream + "..HEAD"});
+    command.timeout = std::chrono::seconds(60);
+
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    std::vector<RebaseTodoEntry> entries;
+    std::size_t start = 0;
+    while (start <= result->out.size()) {
+        const std::size_t at = result->out.find('\n', start);
+        const std::string_view line(result->out.data() + start,
+                                    (at == std::string::npos ? result->out.size() : at) - start);
+        if (!line.empty()) {
+            const std::size_t firstTab = line.find('\t');
+            const std::size_t secondTab =
+                firstTab == std::string_view::npos ? std::string_view::npos
+                                                   : line.find('\t', firstTab + 1);
+            if (firstTab != std::string_view::npos && secondTab != std::string_view::npos) {
+                RebaseTodoEntry entry;
+                entry.oid = ObjectId::fromHex(line.substr(0, firstTab));
+                entry.shortOid = std::string(line.substr(firstTab + 1, secondTab - firstTab - 1));
+                entry.subject = std::string(line.substr(secondTab + 1));
+                entries.push_back(std::move(entry));
+            }
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return entries;
+}
+
+std::unique_ptr<Operation> makeRebaseInteractiveOperation(RebaseInteractiveRequest request) {
+    return std::make_unique<RebaseInteractiveOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeRebaseOperation(RebaseRequest request) {
+    return std::make_unique<RebaseOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeRebaseContinueOperation() {
+    return std::make_unique<RebaseControlOperation>(RebaseControlOperation::Verb::Continue,
+                                                     "Continue rebase");
+}
+
+std::unique_ptr<Operation> makeRebaseSkipOperation() {
+    return std::make_unique<RebaseControlOperation>(RebaseControlOperation::Verb::Skip,
+                                                     "Skip commit");
+}
+
+std::unique_ptr<Operation> makeRebaseAbortOperation() {
+    return std::make_unique<RebaseControlOperation>(RebaseControlOperation::Verb::Abort,
+                                                     "Abort rebase");
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/RebaseOps.cpp
+++ b/src/core/git/ops/RebaseOps.cpp
@@ -100,8 +100,7 @@ void addDirtyWorkTreeChoices(OperationOutcome& outcome, const std::string& verb)
                                "Your changes are saved to a stash first, and can be restored "
                                "afterwards.",
                                false});
-    outcome.choices.push_back(
-        {OperationChoice::Kind::Abort, "Cancel", "Do not rebase.", false});
+    outcome.choices.push_back({OperationChoice::Kind::Abort, "Cancel", "Do not rebase.", false});
 }
 
 class RebaseInteractiveOperation final : public Operation {
@@ -150,12 +149,13 @@ public:
 
         const auto todoFile = writeTempFile(serializeTodo(request_.todo));
         if (todoFile.empty()) {
-            outcome.error =
-                GitError(GitError::Code::Io, "Could not write a temporary rebase plan");
+            outcome.error = GitError(GitError::Code::Io, "Could not write a temporary rebase plan");
             return outcome;
         }
+
         struct TempFileGuard {
             std::filesystem::path path;
+
             ~TempFileGuard() {
                 std::error_code ec;
                 std::filesystem::remove(path, ec);
@@ -296,8 +296,9 @@ public:
                          CancellationToken token) override {
         OperationOutcome outcome;
 
-        const char* flag =
-            verb_ == Verb::Continue ? "--continue" : verb_ == Verb::Skip ? "--skip" : "--abort";
+        const char* flag = verb_ == Verb::Continue ? "--continue"
+                           : verb_ == Verb::Skip   ? "--skip"
+                                                   : "--abort";
         GitCommand command(paths.commandDir(), {"rebase", flag});
         if (verb_ == Verb::Continue) {
             // A squash/fixup step resumed by --continue can still need to write
@@ -356,9 +357,9 @@ GitResult<std::vector<RebaseTodoEntry>> RebasePlanner::plan(const std::string& u
                                     (at == std::string::npos ? result->out.size() : at) - start);
         if (!line.empty()) {
             const std::size_t firstTab = line.find('\t');
-            const std::size_t secondTab =
-                firstTab == std::string_view::npos ? std::string_view::npos
-                                                   : line.find('\t', firstTab + 1);
+            const std::size_t secondTab = firstTab == std::string_view::npos
+                                              ? std::string_view::npos
+                                              : line.find('\t', firstTab + 1);
             if (firstTab != std::string_view::npos && secondTab != std::string_view::npos) {
                 RebaseTodoEntry entry;
                 entry.oid = ObjectId::fromHex(line.substr(0, firstTab));
@@ -385,17 +386,17 @@ std::unique_ptr<Operation> makeRebaseOperation(RebaseRequest request) {
 
 std::unique_ptr<Operation> makeRebaseContinueOperation() {
     return std::make_unique<RebaseControlOperation>(RebaseControlOperation::Verb::Continue,
-                                                     "Continue rebase");
+                                                    "Continue rebase");
 }
 
 std::unique_ptr<Operation> makeRebaseSkipOperation() {
     return std::make_unique<RebaseControlOperation>(RebaseControlOperation::Verb::Skip,
-                                                     "Skip commit");
+                                                    "Skip commit");
 }
 
 std::unique_ptr<Operation> makeRebaseAbortOperation() {
     return std::make_unique<RebaseControlOperation>(RebaseControlOperation::Verb::Abort,
-                                                     "Abort rebase");
+                                                    "Abort rebase");
 }
 
 }  // namespace gbm

--- a/src/core/git/ops/RebaseOps.h
+++ b/src/core/git/ops/RebaseOps.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "core/base/ObjectId.h"
+#include "core/git/OperationRunner.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+/// One line of a rebase todo list.
+///
+/// `Reword` is deliberately not offered: with no terminal or editor available
+/// (see MergeOps's `--no-edit` comment), a reword step would run to completion
+/// silently keeping the original message rather than pausing for a new one --
+/// indistinguishable from Pick. `Edit` is the verb that actually works: the
+/// rebase stops with the commit checked out, and the existing amend flow
+/// (CommitOps) changes its message or contents before Continue.
+struct RebaseTodoEntry {
+    enum class Action { Pick, Edit, Squash, Fixup, Drop };
+    Action action = Action::Pick;
+    ObjectId oid;
+    std::string shortOid;
+    std::string subject;
+};
+
+/// Builds the todo list a plain `git rebase -i <upstream>` would start from --
+/// read-only, so the UI can show and let the user edit it before anything runs.
+class RebasePlanner {
+public:
+    RebasePlanner(IProcessRunner& runner, RepoPaths paths);
+
+    /// `upstream..HEAD`, oldest first: the order the todo list is applied in.
+    GitResult<std::vector<RebaseTodoEntry>> plan(const std::string& upstream,
+                                                 CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+struct RebaseInteractiveRequest {
+    std::string upstream;               ///< Exclusive lower bound: replays upstream..HEAD.
+    std::string onto;                   ///< Optional `--onto`; empty means onto upstream itself.
+    std::vector<RebaseTodoEntry> todo;  ///< The (possibly reordered/edited) plan.
+    bool stashFirst = false;
+};
+
+struct RebaseRequest {
+    std::string upstream;
+    std::string onto;
+    bool stashFirst = false;
+};
+
+/// `git rebase -i`, with the todo list supplied ourselves rather than through an
+/// interactive editor -- see RebaseOps.cpp for how. Stops at the first conflict
+/// or `edit` line exactly as git does; RepoState::RebaseMerge picks it up from
+/// then on.
+std::unique_ptr<Operation> makeRebaseInteractiveOperation(RebaseInteractiveRequest request);
+
+/// Plain, non-interactive `git rebase`: replays every commit unchanged, with no
+/// todo list to edit.
+std::unique_ptr<Operation> makeRebaseOperation(RebaseRequest request);
+
+/// `git rebase --continue`, once every conflict in the current step is resolved
+/// and staged (or, for an `edit` stop, whenever the user is done amending).
+std::unique_ptr<Operation> makeRebaseContinueOperation();
+
+/// `git rebase --skip`: drops the commit that is currently conflicting.
+std::unique_ptr<Operation> makeRebaseSkipOperation();
+
+/// `git rebase --abort`: unwinds back to before the rebase started.
+std::unique_ptr<Operation> makeRebaseAbortOperation();
+
+}  // namespace gbm

--- a/src/core/git/ops/ResetOps.cpp
+++ b/src/core/git/ops/ResetOps.cpp
@@ -11,9 +11,9 @@ public:
     explicit ResetOperation(ResetRequest request) : request_(std::move(request)) {}
 
     std::string describe() const override {
-        const char* label = request_.mode == ResetMode::Soft    ? "Soft reset to "
-                            : request_.mode == ResetMode::Hard  ? "Hard reset to "
-                                                                 : "Reset to ";
+        const char* label = request_.mode == ResetMode::Soft   ? "Soft reset to "
+                            : request_.mode == ResetMode::Hard ? "Hard reset to "
+                                                               : "Reset to ";
         return label + (request_.target.empty() ? "HEAD" : request_.target);
     }
 
@@ -46,7 +46,7 @@ public:
         // A hard reset over a very large tree can legitimately take a while;
         // Cancel is the right control, not a timeout.
         command.timeout = request_.mode == ResetMode::Hard ? std::chrono::milliseconds(0)
-                                                            : std::chrono::seconds(60);
+                                                           : std::chrono::seconds(60);
 
         auto result = runner.run(command, token);
         if (!result) {
@@ -81,7 +81,8 @@ public:
         OperationOutcome outcome;
 
         if (request_.paths.empty()) {
-            outcome.error = GitError(GitError::Code::InvalidArgument, "No paths selected to restore");
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "No paths selected to restore");
             return outcome;
         }
 

--- a/src/core/git/ops/ResetOps.cpp
+++ b/src/core/git/ops/ResetOps.cpp
@@ -1,0 +1,221 @@
+#include "core/git/ops/ResetOps.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+class ResetOperation final : public Operation {
+public:
+    explicit ResetOperation(ResetRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        const char* label = request_.mode == ResetMode::Soft    ? "Soft reset to "
+                            : request_.mode == ResetMode::Hard  ? "Hard reset to "
+                                                                 : "Reset to ";
+        return label + (request_.target.empty() ? "HEAD" : request_.target);
+    }
+
+    /// A hard reset rewrites the whole work tree; interrupting it part-way would
+    /// leave files in an unknown mix of old and new, exactly like a checkout.
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        std::vector<std::string> args{"reset"};
+        switch (request_.mode) {
+            case ResetMode::Soft:
+                args.emplace_back("--soft");
+                break;
+            case ResetMode::Mixed:
+                args.emplace_back("--mixed");
+                break;
+            case ResetMode::Hard:
+                args.emplace_back("--hard");
+                break;
+        }
+        if (!request_.target.empty()) {
+            args.push_back(request_.target);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        // A hard reset over a very large tree can legitimately take a while;
+        // Cancel is the right control, not a timeout.
+        command.timeout = request_.mode == ResetMode::Hard ? std::chrono::milliseconds(0)
+                                                            : std::chrono::seconds(60);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    ResetRequest request_;
+};
+
+class RestoreOperation final : public Operation {
+public:
+    explicit RestoreOperation(RestoreRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        const std::string count = std::to_string(request_.paths.size());
+        return request_.staged ? "Unstage " + count + " path(s)"
+                               : "Discard changes to " + count + " path(s)";
+    }
+
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.paths.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "No paths selected to restore");
+            return outcome;
+        }
+
+        std::vector<std::string> args{"restore"};
+        if (request_.staged) {
+            args.emplace_back("--staged");
+        }
+        if (!request_.source.empty()) {
+            args.emplace_back("--source");
+            args.push_back(request_.source);
+        }
+        args.emplace_back("--");
+        for (const auto& path : request_.paths) {
+            args.push_back(path);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    RestoreRequest request_;
+};
+
+class CleanOperation final : public Operation {
+public:
+    explicit CleanOperation(CleanRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Remove untracked files"; }
+
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        std::vector<std::string> args{"clean", "-f", "-d"};
+        if (request_.includeIgnored) {
+            args.emplace_back("-x");
+        }
+        if (!request_.paths.empty()) {
+            args.emplace_back("--");
+            for (const auto& path : request_.paths) {
+                args.push_back(path);
+            }
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = "Removed untracked files";
+        return outcome;
+    }
+
+private:
+    CleanRequest request_;
+};
+
+}  // namespace
+
+CleanPreviewer::CleanPreviewer(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<std::vector<CleanEntry>> CleanPreviewer::preview(bool includeIgnored,
+                                                           CancellationToken token) {
+    std::vector<std::string> args{"clean", "-n", "-d"};
+    if (includeIgnored) {
+        args.emplace_back("-x");
+    }
+    GitCommand command(paths_.commandDir(), std::move(args));
+    command.timeout = std::chrono::seconds(60);
+
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    // Every line git clean -n prints is "Would remove <path>"; a nested repo it
+    // refuses to touch is reported as "Would skip repository <path>" instead,
+    // and is deliberately not listed here since a plain `-fd` will not remove it
+    // either.
+    static constexpr std::string_view kPrefix = "Would remove ";
+    std::vector<CleanEntry> entries;
+    std::size_t start = 0;
+    while (start <= result->out.size()) {
+        const std::size_t at = result->out.find('\n', start);
+        const std::string_view line(result->out.data() + start,
+                                    (at == std::string::npos ? result->out.size() : at) - start);
+        if (line.starts_with(kPrefix)) {
+            std::string_view rest = line.substr(kPrefix.size());
+            CleanEntry entry;
+            entry.isDirectory = !rest.empty() && rest.back() == '/';
+            if (entry.isDirectory) {
+                rest.remove_suffix(1);
+            }
+            entry.path = std::string(rest);
+            entries.push_back(std::move(entry));
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return entries;
+}
+
+std::unique_ptr<Operation> makeResetOperation(ResetRequest request) {
+    return std::make_unique<ResetOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeRestoreOperation(RestoreRequest request) {
+    return std::make_unique<RestoreOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeCleanOperation(CleanRequest request) {
+    return std::make_unique<CleanOperation>(std::move(request));
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/ResetOps.h
+++ b/src/core/git/ops/ResetOps.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "core/git/OperationRunner.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+enum class ResetMode { Soft, Mixed, Hard };
+
+struct ResetRequest {
+    std::string target;  ///< Ref or oid to reset to. Empty means HEAD.
+    ResetMode mode = ResetMode::Mixed;
+};
+
+/// `git reset --soft|--mixed|--hard <target>`. Hard also overwrites the work
+/// tree, discarding uncommitted changes exactly like ForceDiscard elsewhere --
+/// the caller must already have the user's consent before setting Hard, the
+/// same contract DeleteBranchRequest::force uses.
+std::unique_ptr<Operation> makeResetOperation(ResetRequest request);
+
+struct RestoreRequest {
+    std::vector<std::string> paths;  ///< Must not be empty.
+    /// True: `--staged`, resetting the index from `source` (default HEAD)
+    /// without touching the work tree -- "unstage". False: the work tree is
+    /// overwritten from `source` (default the index) -- "discard changes",
+    /// and is destructive exactly like a hard reset of just these paths.
+    bool staged = false;
+    std::string source;  ///< Optional `--source=<tree-ish>`; empty means the default above.
+};
+
+/// `git restore`.
+std::unique_ptr<Operation> makeRestoreOperation(RestoreRequest request);
+
+struct CleanEntry {
+    std::string path;
+    bool isDirectory = false;
+};
+
+/// Read-only `git clean -n`, so the UI can show exactly what would be removed
+/// before the user commits to it -- a destructive clean never runs unseen.
+class CleanPreviewer {
+public:
+    CleanPreviewer(IProcessRunner& runner, RepoPaths paths);
+
+    GitResult<std::vector<CleanEntry>> preview(bool includeIgnored, CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+struct CleanRequest {
+    /// Empty means the whole work tree; otherwise exactly these paths (what the
+    /// user left checked after reviewing CleanPreviewer::preview).
+    std::vector<std::string> paths;
+    bool includeIgnored = false;  ///< `-x`: also remove files normally ignored.
+};
+
+/// `git clean -fd`.
+std::unique_ptr<Operation> makeCleanOperation(CleanRequest request);
+
+}  // namespace gbm

--- a/src/core/git/ops/UndoOps.cpp
+++ b/src/core/git/ops/UndoOps.cpp
@@ -1,0 +1,68 @@
+#include "core/git/ops/UndoOps.h"
+
+#include "core/git/RefStore.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+class UndoOperation final : public Operation {
+public:
+    explicit UndoOperation(UndoRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Undo"; }
+
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        if (request_.headBefore.isNull()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "Nothing to undo");
+            return outcome;
+        }
+
+        RefStore refs(runner, paths);
+        auto head = refs.readHead(token);
+        if (!head) {
+            outcome.error = std::move(head).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        if (!request_.branchBefore.empty() && head->kind == HeadInfo::Kind::Branch &&
+            head->branchName != request_.branchBefore) {
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument,
+                         "Switch back to \"" + request_.branchBefore + "\" before undoing this");
+            return outcome;
+        }
+
+        GitCommand command(paths.commandDir(), {"reset", "--hard", request_.headBefore.hex()});
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = "Undid the last operation";
+        return outcome;
+    }
+
+private:
+    UndoRequest request_;
+};
+
+}  // namespace
+
+std::unique_ptr<Operation> makeUndoOperation(UndoRequest request) {
+    return std::make_unique<UndoOperation>(std::move(request));
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/UndoOps.h
+++ b/src/core/git/ops/UndoOps.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "core/base/ObjectId.h"
+#include "core/git/OperationRunner.h"
+
+#include <memory>
+#include <string>
+
+namespace gbm {
+
+struct UndoRequest {
+    ObjectId headBefore;       ///< See OperationRunner::UndoEntry.
+    std::string branchBefore;  ///< Empty when HEAD was detached at the time.
+};
+
+/// Reverses one entry from OperationRunner::undoJournal() by hard-resetting
+/// back to where HEAD stood before it ran. Refuses if the checked-out branch
+/// has since changed: undoing "as if the operation never happened" only makes
+/// sense while still on the branch it actually touched.
+std::unique_ptr<Operation> makeUndoOperation(UndoRequest request);
+
+}  // namespace gbm

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -7,12 +7,15 @@
 // touch git itself.
 #include "core/base/CancellationToken.h"
 #include "core/base/FsUtil.h"
+#include "core/git/BlameStore.h"
 #include "core/git/CatFileBatch.h"
 #include "core/git/DiffService.h"
+#include "core/git/FileHistoryStore.h"
 #include "core/git/GitExecutable.h"
 #include "core/git/HistoryProvider.h"
 #include "core/git/OperationRunner.h"
 #include "core/git/RefStore.h"
+#include "core/git/ReflogStore.h"
 #include "core/git/RepoState.h"
 #include "core/git/WorkingCopyStatus.h"
 #include "core/git/ops/BranchOps.h"
@@ -21,10 +24,13 @@
 #include "core/git/ops/CommitOps.h"
 #include "core/git/ops/ConflictOps.h"
 #include "core/git/ops/MergeOps.h"
+#include "core/git/ops/RebaseOps.h"
 #include "core/git/ops/RemoteOps.h"
+#include "core/git/ops/ResetOps.h"
 #include "core/git/ops/StageOps.h"
 #include "core/git/ops/StashOps.h"
 #include "core/git/ops/TagOps.h"
+#include "core/git/ops/UndoOps.h"
 #include "core/git/ops/WorktreeOps.h"
 
 #include <algorithm>
@@ -1768,6 +1774,484 @@ TEST_F(RemoteRepoTest, ForceWithLeaseRefusesAStalePushAndSucceedsAfterRefetching
 
     auto retried = submitAndWait(operations, makePushOperation(forcePush));
     ASSERT_TRUE(retried.succeeded) << (retried.error ? retried.error->detail : "");
+}
+
+// --- M4: reset / restore / clean --------------------------------------------
+
+TEST_F(RealRepoTest, SoftResetMovesHeadButKeepsTheIndexAndWorkTree) {
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+    auto first = run({"rev-parse", "HEAD~1"});
+    ASSERT_TRUE(first);
+
+    OperationRunner operations(*runner_, paths_);
+    ResetRequest request;
+    request.target = first->out;
+    request.mode = ResetMode::Soft;
+    auto outcome = submitAndWait(operations, makeResetOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->out, first->out);
+    // The change from c2 must still be staged.
+    auto staged = run({"diff", "--cached", "--name-only"});
+    ASSERT_TRUE(staged);
+    EXPECT_EQ(staged->out, "a.txt");
+}
+
+TEST_F(RealRepoTest, MixedResetMovesHeadAndUnstagesButKeepsTheWorkTree) {
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+    auto first = run({"rev-parse", "HEAD~1"});
+    ASSERT_TRUE(first);
+
+    OperationRunner operations(*runner_, paths_);
+    ResetRequest request;
+    request.target = first->out;
+    request.mode = ResetMode::Mixed;
+    auto outcome = submitAndWait(operations, makeResetOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto staged = run({"diff", "--cached", "--name-only"});
+    ASSERT_TRUE(staged);
+    EXPECT_TRUE(staged->out.empty());
+    std::ifstream in(repo_ / "a.txt");
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "2\n") << "the work tree must be untouched by a mixed reset";
+}
+
+TEST_F(RealRepoTest, HardResetDiscardsTheIndexAndWorkTree) {
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+    auto first = run({"rev-parse", "HEAD~1"});
+    ASSERT_TRUE(first);
+
+    OperationRunner operations(*runner_, paths_);
+    ResetRequest request;
+    request.target = first->out;
+    request.mode = ResetMode::Hard;
+    auto outcome = submitAndWait(operations, makeResetOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    std::ifstream in(repo_ / "a.txt");
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "1\n");
+}
+
+TEST_F(RealRepoTest, RestoreStagedUnstagesWithoutTouchingTheWorkTree) {
+    commitFile("a.txt", "1\n", "c1");
+    {
+        std::ofstream out(repo_ / "a.txt", std::ios::trunc);
+        out << "2\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+
+    OperationRunner operations(*runner_, paths_);
+    RestoreRequest request;
+    request.paths = {"a.txt"};
+    request.staged = true;
+    auto outcome = submitAndWait(operations, makeRestoreOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto staged = run({"diff", "--cached", "--name-only"});
+    ASSERT_TRUE(staged);
+    EXPECT_TRUE(staged->out.empty());
+    std::ifstream in(repo_ / "a.txt");
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "2\n") << "unstaging must not touch the work tree";
+}
+
+TEST_F(RealRepoTest, RestoreWorkTreeDiscardsUnstagedChanges) {
+    commitFile("a.txt", "1\n", "c1");
+    {
+        std::ofstream out(repo_ / "a.txt", std::ios::trunc);
+        out << "scratch\n";
+    }
+
+    OperationRunner operations(*runner_, paths_);
+    RestoreRequest request;
+    request.paths = {"a.txt"};
+    request.staged = false;
+    auto outcome = submitAndWait(operations, makeRestoreOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    std::ifstream in(repo_ / "a.txt");
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "1\n");
+}
+
+TEST_F(RealRepoTest, CleanPreviewListsUntrackedFilesWithoutRemovingThem) {
+    commitFile("a.txt", "1\n", "c1");
+    {
+        std::ofstream out(repo_ / "scratch.txt");
+        out << "junk\n";
+    }
+
+    CleanPreviewer previewer(*runner_, paths_);
+    auto preview = previewer.preview(false, CancellationToken{});
+    ASSERT_TRUE(preview) << preview.error().message;
+    ASSERT_EQ(preview->size(), 1u);
+    EXPECT_EQ((*preview)[0].path, "scratch.txt");
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "scratch.txt"))
+        << "a preview must never touch the filesystem";
+}
+
+TEST_F(RealRepoTest, CleanRemovesUntrackedFiles) {
+    commitFile("a.txt", "1\n", "c1");
+    {
+        std::ofstream out(repo_ / "scratch.txt");
+        out << "junk\n";
+    }
+
+    OperationRunner operations(*runner_, paths_);
+    CleanRequest request;
+    auto outcome = submitAndWait(operations, makeCleanOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+    EXPECT_FALSE(std::filesystem::exists(repo_ / "scratch.txt"));
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "a.txt")) << "tracked files must be untouched";
+}
+
+// --- M4: interactive and plain rebase ---------------------------------------
+
+TEST_F(RealRepoTest, RebasePlanListsCommitsOldestFirst) {
+    commitFile("base.txt", "base\n", "base");
+    auto base = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(base);
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("b.txt", "2\n", "c2");
+
+    RebasePlanner planner(*runner_, paths_);
+    auto plan = planner.plan(base->out, CancellationToken{});
+    ASSERT_TRUE(plan) << plan.error().message;
+    ASSERT_EQ(plan->size(), 2u);
+    EXPECT_EQ((*plan)[0].subject, "c1");
+    EXPECT_EQ((*plan)[1].subject, "c2");
+    EXPECT_EQ((*plan)[0].action, RebaseTodoEntry::Action::Pick);
+}
+
+TEST_F(RealRepoTest, InteractiveRebaseAppliesReorderingAndDrops) {
+    commitFile("base.txt", "base\n", "base");
+    auto base = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(base);
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("b.txt", "2\n", "c2");
+    commitFile("c.txt", "3\n", "c3");
+
+    RebasePlanner planner(*runner_, paths_);
+    auto plan = planner.plan(base->out, CancellationToken{});
+    ASSERT_TRUE(plan);
+    ASSERT_EQ(plan->size(), 3u);
+
+    // Reorder c2 before c1, and drop c3 entirely.
+    RebaseInteractiveRequest request;
+    request.upstream = base->out;
+    request.todo = {(*plan)[1], (*plan)[0]};
+    request.todo[1].action = RebaseTodoEntry::Action::Pick;
+
+    OperationRunner operations(*runner_, paths_);
+    auto outcome = submitAndWait(operations, makeRebaseInteractiveOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+
+    auto subjects = run({"log", "--format=%s", "--reverse"});
+    ASSERT_TRUE(subjects);
+    EXPECT_EQ(subjects->out, "base\nc2\nc1") << "c2 must now come before c1, and c3 must be gone";
+    EXPECT_FALSE(std::filesystem::exists(repo_ / "c.txt"));
+}
+
+TEST_F(RealRepoTest, InteractiveRebaseSquashesCommitsTogether) {
+    commitFile("base.txt", "base\n", "base");
+    auto base = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(base);
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2 to squash");
+
+    RebasePlanner planner(*runner_, paths_);
+    auto plan = planner.plan(base->out, CancellationToken{});
+    ASSERT_TRUE(plan);
+    ASSERT_EQ(plan->size(), 2u);
+
+    RebaseInteractiveRequest request;
+    request.upstream = base->out;
+    request.todo = *plan;
+    request.todo[1].action = RebaseTodoEntry::Action::Squash;
+
+    OperationRunner operations(*runner_, paths_);
+    auto outcome = submitAndWait(operations, makeRebaseInteractiveOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto count = run({"rev-list", "--count", "HEAD"});
+    ASSERT_TRUE(count);
+    EXPECT_EQ(count->out, "2") << "base + one squashed commit";
+    std::ifstream in(repo_ / "a.txt");
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "2\n");
+}
+
+TEST_F(RealRepoTest, RebaseConflictContinuesAfterResolution) {
+    commitFile("shared.txt", "base\n", "base");
+    auto base = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(base);
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "feature"}));
+
+    RebasePlanner planner(*runner_, paths_);
+    auto plan = planner.plan("main", CancellationToken{});
+    ASSERT_TRUE(plan);
+    ASSERT_EQ(plan->size(), 1u);
+
+    RebaseInteractiveRequest request;
+    request.upstream = "main";
+    request.todo = *plan;
+
+    OperationRunner operations(*runner_, paths_);
+    auto outcome = submitAndWait(operations, makeRebaseInteractiveOperation(request));
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::Conflict);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    ResolveConflictRequest resolve;
+    resolve.path = "shared.txt";
+    resolve.resolution = ConflictResolution::TakeTheirs;
+    auto resolved = submitAndWait(operations, makeResolveConflictOperation(resolve));
+    ASSERT_TRUE(resolved.succeeded) << (resolved.error ? resolved.error->detail : "");
+
+    auto continued = submitAndWait(operations, makeRebaseContinueOperation());
+    ASSERT_TRUE(continued.succeeded) << (continued.error ? continued.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+
+    auto content = run({"cat-file", "-p", "HEAD:shared.txt"});
+    ASSERT_TRUE(content);
+    EXPECT_EQ(content->out, "feature change");
+}
+
+TEST_F(RealRepoTest, RebaseSkipDropsTheConflictingCommitAndMovesOn) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    commitFile("other.txt", "unrelated\n", "unrelated commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "feature"}));
+
+    OperationRunner operations(*runner_, paths_);
+    RebaseRequest request;
+    request.upstream = "main";
+    auto outcome = submitAndWait(operations, makeRebaseOperation(request));
+    ASSERT_FALSE(outcome.succeeded);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    auto skipped = submitAndWait(operations, makeRebaseSkipOperation());
+    ASSERT_TRUE(skipped.succeeded) << (skipped.error ? skipped.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "other.txt"))
+        << "the commit queued after the skipped one must still land";
+}
+
+TEST_F(RealRepoTest, RebaseAbortUnwindsCleanly) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "feature"}));
+    auto beforeRebase = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(beforeRebase);
+
+    OperationRunner operations(*runner_, paths_);
+    RebaseRequest request;
+    request.upstream = "main";
+    auto outcome = submitAndWait(operations, makeRebaseOperation(request));
+    ASSERT_FALSE(outcome.succeeded);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    auto aborted = submitAndWait(operations, makeRebaseAbortOperation());
+    ASSERT_TRUE(aborted.succeeded) << (aborted.error ? aborted.error->detail : "");
+    EXPECT_TRUE(RepoState::read(paths_).isClean());
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->out, beforeRebase->out);
+}
+
+TEST_F(RealRepoTest, PlainRebaseReplaysCommitsOntoANewBaseUnchanged) {
+    commitFile("base.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("a.txt", "1\n", "feature c1");
+    commitFile("b.txt", "2\n", "feature c2");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("other.txt", "unrelated\n", "main commit");
+
+    OperationRunner operations(*runner_, paths_);
+    ASSERT_TRUE(run({"switch", "--quiet", "feature"}));
+    RebaseRequest request;
+    request.upstream = "main";
+    auto outcome = submitAndWait(operations, makeRebaseOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto subjects = run({"log", "--format=%s", "-2"});
+    ASSERT_TRUE(subjects);
+    EXPECT_EQ(subjects->out, "feature c2\nfeature c1")
+        << "messages must be preserved exactly by a non-interactive rebase";
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "other.txt"));
+}
+
+// --- M4: blame ---------------------------------------------------------------
+
+TEST_F(RealRepoTest, BlameAttributesEachLineToTheCommitThatIntroducedIt) {
+    {
+        std::ofstream out(repo_ / "a.txt");
+        out << "line one\nline two\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "first two lines"}));
+    auto first = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(first);
+
+    {
+        std::ofstream out(repo_ / "a.txt", std::ios::app);
+        out << "line three\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "add a third line"}));
+    auto second = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(second);
+
+    BlameStore blame(*runner_, paths_);
+    auto result = blame.blame("a.txt", "", 0, 0, CancellationToken{});
+    ASSERT_TRUE(result) << result.error().message;
+    ASSERT_EQ((*result)->lines.size(), 3u);
+    EXPECT_EQ((*result)->lines[0].commitOid.hex(), first->out);
+    EXPECT_EQ((*result)->lines[1].commitOid.hex(), first->out);
+    EXPECT_EQ((*result)->lines[2].commitOid.hex(), second->out);
+    EXPECT_EQ((*result)->lines[2].content, "line three");
+    EXPECT_EQ((*result)->lines[2].summary, "add a third line");
+}
+
+TEST_F(RealRepoTest, BlameRespectsAnExplicitLineRange) {
+    {
+        std::ofstream out(repo_ / "a.txt");
+        out << "one\ntwo\nthree\nfour\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "four lines"}));
+
+    BlameStore blame(*runner_, paths_);
+    auto result = blame.blame("a.txt", "", 2, 3, CancellationToken{});
+    ASSERT_TRUE(result) << result.error().message;
+    ASSERT_EQ((*result)->lines.size(), 2u);
+    EXPECT_EQ((*result)->lines[0].content, "two");
+    EXPECT_EQ((*result)->lines[1].content, "three");
+}
+
+// --- M4: file and line history ------------------------------------------------
+
+TEST_F(RealRepoTest, FileHistoryFollowsARenameAcrossHistory) {
+    commitFile("old.txt", "content\n", "add old.txt");
+    ASSERT_TRUE(run({"mv", "old.txt", "new.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "rename to new.txt"}));
+    commitFile("new.txt", "content\nmore\n", "edit new.txt");
+
+    FileHistoryStore history(*runner_, paths_);
+    auto entries = history.fileHistory("new.txt", "", CancellationToken{});
+    ASSERT_TRUE(entries) << entries.error().message;
+    ASSERT_EQ(entries->size(), 3u);
+    EXPECT_EQ((*entries)[0].subject, "edit new.txt");
+    EXPECT_EQ((*entries)[1].subject, "rename to new.txt");
+    EXPECT_EQ((*entries)[1].renamedFrom, "old.txt");
+    EXPECT_EQ((*entries)[2].subject, "add old.txt");
+}
+
+TEST_F(RealRepoTest, LineHistoryReturnsAChunkPerCommitTouchingTheRange) {
+    {
+        std::ofstream out(repo_ / "a.txt");
+        out << "one\ntwo\nthree\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "initial"}));
+    {
+        std::ofstream out(repo_ / "a.txt", std::ios::trunc);
+        out << "one\nTWO CHANGED\nthree\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "change line two"}));
+
+    FileHistoryStore history(*runner_, paths_);
+    auto chunks = history.lineHistory("a.txt", 2, 2, "", CancellationToken{});
+    ASSERT_TRUE(chunks) << chunks.error().message;
+    ASSERT_GE(chunks->size(), 1u);
+    EXPECT_EQ((*chunks)[0].subject, "change line two");
+    EXPECT_NE((*chunks)[0].diffText.find("TWO CHANGED"), std::string::npos);
+}
+
+// --- M4: reflog and undo -----------------------------------------------------
+
+TEST_F(RealRepoTest, ReflogListsRecentHeadMovementsNewestFirst) {
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+
+    ReflogStore reflog(*runner_, paths_);
+    auto entries = reflog.list("", CancellationToken{});
+    ASSERT_TRUE(entries) << entries.error().message;
+    ASSERT_GE(entries->size(), 2u);
+    EXPECT_EQ((*entries)[0].index, 0);
+    EXPECT_NE((*entries)[0].message.find("c2"), std::string::npos);
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+    EXPECT_EQ((*entries)[0].oid.hex(), head->out);
+}
+
+TEST_F(RealRepoTest, UndoResetsBackToWhereHeadStoodBeforeTheOperation) {
+    commitFile("a.txt", "1\n", "c1");
+    auto beforeSecondCommit = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(beforeSecondCommit);
+
+    OperationRunner operations(*runner_, paths_);
+    CommitRequest commitRequest;
+    commitRequest.message = "c2";
+    {
+        std::ofstream out(repo_ / "a.txt", std::ios::trunc);
+        out << "2\n";
+    }
+    ASSERT_TRUE(run({"add", "a.txt"}));
+    auto committed = submitAndWait(operations, makeCommitOperation(commitRequest));
+    ASSERT_TRUE(committed.succeeded) << (committed.error ? committed.error->detail : "");
+
+    ASSERT_EQ(operations.undoJournal().size(), 1u);
+    const auto& entry = operations.undoJournal().back();
+    EXPECT_EQ(entry.headBefore.hex(), beforeSecondCommit->out);
+
+    UndoRequest undo;
+    undo.headBefore = entry.headBefore;
+    undo.branchBefore = entry.branchBefore;
+    auto undone = submitAndWait(operations, makeUndoOperation(undo));
+    ASSERT_TRUE(undone.succeeded) << (undone.error ? undone.error->detail : "");
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->out, beforeSecondCommit->out);
+}
+
+TEST_F(RealRepoTest, UndoRefusesAfterSwitchingToADifferentBranch) {
+    commitFile("a.txt", "1\n", "c1");
+
+    OperationRunner operations(*runner_, paths_);
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "other"}));
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+
+    UndoRequest undo;
+    undo.headBefore = ObjectId::fromHex(head->out);
+    undo.branchBefore = "main";
+    auto outcome = submitAndWait(operations, makeUndoOperation(undo));
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
 }
 
 }  // namespace


### PR DESCRIPTION
Core (fully tested, no Qt): RebaseOps builds and edits a rebase todo list in
the UI rather than through an interactive editor -- GIT_SEQUENCE_EDITOR is
pointed at `cp` with the built plan as its argument, so git's own editor step
becomes a copy. ResetOps covers reset/restore/clean, with clean previewed
before anything is deleted. BlameStore, FileHistoryStore and ReflogStore are
read-only stores in the RefStore/StashStore mould. UndoOps reverses one entry
from OperationRunner's existing undo journal.

App: RepositorySession exposes all of the above; MainWindow gets rebase/reset
menu items, an interactive-rebase todo editor, Continue/Skip/Abort banner
controls (previously wired in RepositorySession but never surfaced in the
UI), and blame/file-history/line-history/reflog dialogs reachable from the
commit file list. WorkingCopyView gains a "Discard Changes" action on
unstaged files.

21 new real-git integration tests cover reset modes, restore, clean preview
and execution, interactive rebase (reorder/drop/squash/conflict/skip/abort),
plain rebase, blame, file/line history, reflog, and undo.