### PR TITLE
feat: submodule status, add, init, update, sync and deinit (M5 part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ decade of history** — hundreds of thousands of commits, tens of thousands of f
 and often thousands of stale refs. It manages many such repositories at once,
 discovered under folders you nominate.
 
-> **Status: M0–M4 implemented.** History browsing, the Fork-style graph,
+> **Status: M0–M5 implemented.** History browsing, the Fork-style graph,
 > repository discovery with caching, diff viewing, branch switching, the working
 > copy, merge/cherry-pick/conflict resolution, worktrees/stash/tags/fetch/
 > pull/push, interactive rebase, reset/restore/clean, blame, file and line
-> history, and the reflog/undo journal all work end to end on all three
-> platforms. Submodules, bisect and the rest are designed for but not yet
-> implemented — see [Roadmap](#roadmap).
+> history, the reflog/undo journal, submodules, bisect, LFS, patch import/
+> export, light/dark/system themes and accessible names on the core views all
+> work end to end on all three platforms — see [Roadmap](#roadmap).
 
 ## What works today
 
@@ -51,6 +51,24 @@ discovered under folders you nominate.
 - **Reflog browser and undo**: every `HEAD` movement, and a one-click "Undo
   last operation" backed by the operation runner's own undo journal rather
   than a reflog guess.
+- **Submodules**: status (not-initialized / up-to-date / modified /
+  conflicted) read from `.gitmodules` plus `git submodule status`; add, init,
+  update, sync and deinit.
+- **Bisect**: start with a bad/good range (or neither, marking as you go),
+  good/bad/skip stepping with the next candidate and concluding message
+  surfaced directly, and reset.
+- **Git LFS**: detected rather than assumed; track/untrack patterns, see
+  which files are pointers vs. downloaded, and pull/fetch/prune.
+- **Patch import/export**: `format-patch` an arbitrary commit selection to a
+  folder, `apply` a plain diff to the work tree, and `am` a patch series into
+  commits with its own Continue/Skip/Abort recovery — deliberately not the
+  shared rebase banner, since `git rebase --continue` refuses outright during
+  an `am` session even though the two share an on-disk state directory.
+- **Light/dark/system themes**, persisted and switchable from View > Theme.
+- **Accessible names** on the repository list, commit history, ref tree,
+  changed-files list, diff panes, working-copy lists and the credential
+  prompt, so a screen reader has more than a generic control type to
+  announce.
 
 ## Measured behaviour
 
@@ -228,7 +246,7 @@ git config core.untrackedCache true
 | **M2 — done** | Merge (ff / no-ff / squash), cherry-pick single, multi and range with preview, conflict resolution across all three index stages, side-by-side diff |
 | **M3 — done** | Worktree manager, stash, tags, fetch/pull/push with askpass helpers and `--force-with-lease` by default, signed installers |
 | **M4 — done** | Interactive rebase, reset/restore/clean, blame, file and line history, reflog browser and undo |
-| M5 | Submodules, bisect, LFS, patch import/export, themes, accessibility |
+| **M5 — done** | Submodules, bisect, LFS, patch import/export, themes, accessibility |
 
 ## Licence
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -17,6 +17,7 @@ qt_add_executable(git-branch-manager
     bridge/AskpassWatcher.cpp
     bridge/DiscoveryController.cpp
     bridge/RepositorySession.cpp
+    bridge/ThemeManager.cpp
 
     models/CommitListModel.cpp
     models/GraphColumnDelegate.cpp

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -1075,4 +1075,30 @@ void RepositorySession::pruneLfs(const LfsPruneRequest& request) {
     });
 }
 
+// --- M5: patch import/export ------------------------------------------------
+
+void RepositorySession::exportPatches(const ExportPatchesRequest& request) {
+    submitAndRefresh(makeExportPatchesOperation(request), nullptr);
+}
+
+void RepositorySession::applyPatchFiles(const ApplyPatchFilesRequest& request) {
+    submitWorkingCopyOperation(makeApplyPatchFilesOperation(request), false);
+}
+
+void RepositorySession::importPatches(const ImportPatchesRequest& request) {
+    submitWorkingCopyOperation(makeImportPatchesOperation(request), true);
+}
+
+void RepositorySession::continueImport() {
+    submitWorkingCopyOperation(makeAmContinueOperation(), true);
+}
+
+void RepositorySession::skipImport() {
+    submitWorkingCopyOperation(makeAmSkipOperation(), true);
+}
+
+void RepositorySession::abortImport() {
+    submitWorkingCopyOperation(makeAmAbortOperation(), true);
+}
+
 }  // namespace gbm

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -31,6 +31,7 @@ RepositorySession::RepositorySession(GitInstallation installation,
     blameStore_ = std::make_unique<BlameStore>(*runner_, paths_);
     fileHistoryStore_ = std::make_unique<FileHistoryStore>(*runner_, paths_);
     reflogStore_ = std::make_unique<ReflogStore>(*runner_, paths_);
+    submoduleStore_ = std::make_unique<SubmoduleStore>(*runner_, paths_);
 
     askpass_ = new AskpassWatcher(this);
     connect(
@@ -840,6 +841,79 @@ void RepositorySession::undoLastOperation() {
     request.headBefore = last.headBefore;
     request.branchBefore = last.branchBefore;
     submitWorkingCopyOperation(makeUndoOperation(request), true);
+}
+
+// --- M5: submodules ----------------------------------------------------------
+
+void RepositorySession::refreshSubmodules() {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, token] {
+        auto list = submoduleStore_->list(token);
+        if (list) {
+            submodules_.publish(std::make_shared<std::vector<SubmoduleInfo>>(std::move(*list)));
+            QMetaObject::invokeMethod(
+                this, [this] { emit submodulesUpdated(); }, Qt::QueuedConnection);
+        } else if (list.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(list).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::addSubmodule(const AddSubmoduleRequest& request) {
+    AddSubmoduleRequest wired = request;
+    wired.askpassDir = askpass::makeRequestDir();
+    if (!wired.askpassDir.empty()) {
+        askpass_->start(wired.askpassDir);
+    }
+    submitAndRefresh(makeAddSubmoduleOperation(wired), [this](bool succeeded) {
+        askpass_->stop();
+        if (succeeded) {
+            refreshSubmodules();
+        }
+    });
+}
+
+void RepositorySession::initSubmodules(const SubmodulePathsRequest& request) {
+    submitAndRefresh(makeInitSubmodulesOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshSubmodules();
+        }
+    });
+}
+
+void RepositorySession::updateSubmodules(const UpdateSubmodulesRequest& request) {
+    UpdateSubmodulesRequest wired = request;
+    wired.askpassDir = askpass::makeRequestDir();
+    if (!wired.askpassDir.empty()) {
+        askpass_->start(wired.askpassDir);
+    }
+    submitAndRefresh(makeUpdateSubmodulesOperation(wired), [this](bool succeeded) {
+        askpass_->stop();
+        if (succeeded) {
+            refreshSubmodules();
+        }
+    });
+}
+
+void RepositorySession::syncSubmodules(const SubmodulePathsRequest& request) {
+    submitAndRefresh(makeSyncSubmodulesOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshSubmodules();
+        }
+    });
+}
+
+void RepositorySession::deinitSubmodules(const DeinitSubmodulesRequest& request) {
+    submitAndRefresh(makeDeinitSubmodulesOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshSubmodules();
+        }
+    });
 }
 
 }  // namespace gbm

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -998,7 +998,12 @@ void RepositorySession::refreshLfs() {
 
         if (!available) {
             QMetaObject::invokeMethod(
-                this, [this] { emit lfsUpdated(); setBusy(false); }, Qt::QueuedConnection);
+                this,
+                [this] {
+                    emit lfsUpdated();
+                    setBusy(false);
+                },
+                Qt::QueuedConnection);
             return;
         }
 
@@ -1011,7 +1016,12 @@ void RepositorySession::refreshLfs() {
             lfsFiles_.publish(std::make_shared<std::vector<LfsFileInfo>>(std::move(*files)));
         }
         QMetaObject::invokeMethod(
-            this, [this] { emit lfsUpdated(); setBusy(false); }, Qt::QueuedConnection);
+            this,
+            [this] {
+                emit lfsUpdated();
+                setBusy(false);
+            },
+            Qt::QueuedConnection);
     });
 }
 

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -32,6 +32,7 @@ RepositorySession::RepositorySession(GitInstallation installation,
     fileHistoryStore_ = std::make_unique<FileHistoryStore>(*runner_, paths_);
     reflogStore_ = std::make_unique<ReflogStore>(*runner_, paths_);
     submoduleStore_ = std::make_unique<SubmoduleStore>(*runner_, paths_);
+    bisectStore_ = std::make_unique<BisectStore>(*runner_, paths_);
 
     askpass_ = new AskpassWatcher(this);
     connect(
@@ -912,6 +913,59 @@ void RepositorySession::deinitSubmodules(const DeinitSubmodulesRequest& request)
     submitAndRefresh(makeDeinitSubmodulesOperation(request), [this](bool succeeded) {
         if (succeeded) {
             refreshSubmodules();
+        }
+    });
+}
+
+// --- M5: bisect ----------------------------------------------------------
+
+void RepositorySession::refreshBisectStatus() {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, token] {
+        auto status = bisectStore_->status(token);
+        if (status) {
+            bisectStatus_.publish(std::make_shared<BisectStatus>(std::move(*status)));
+            QMetaObject::invokeMethod(
+                this, [this] { emit bisectStatusUpdated(); }, Qt::QueuedConnection);
+        } else if (status.error().code != GitError::Code::Cancelled) {
+            GitError error = std::move(status).error();
+            QMetaObject::invokeMethod(
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::startBisect(const BisectStartRequest& request) {
+    submitAndRefresh(makeBisectStartOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshBisectStatus();
+        }
+    });
+}
+
+void RepositorySession::markBisect(const BisectMarkRequest& request) {
+    submitAndRefresh(makeBisectMarkOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshBisectStatus();
+        }
+    });
+}
+
+void RepositorySession::skipBisect(const BisectSkipRequest& request) {
+    submitAndRefresh(makeBisectSkipOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshBisectStatus();
+        }
+    });
+}
+
+void RepositorySession::resetBisect(const BisectResetRequest& request) {
+    submitAndRefresh(makeBisectResetOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshBisectStatus();
         }
     });
 }

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -33,6 +33,7 @@ RepositorySession::RepositorySession(GitInstallation installation,
     reflogStore_ = std::make_unique<ReflogStore>(*runner_, paths_);
     submoduleStore_ = std::make_unique<SubmoduleStore>(*runner_, paths_);
     bisectStore_ = std::make_unique<BisectStore>(*runner_, paths_);
+    lfsStore_ = std::make_unique<LfsStore>(*runner_, paths_);
 
     askpass_ = new AskpassWatcher(this);
     connect(
@@ -966,6 +967,110 @@ void RepositorySession::resetBisect(const BisectResetRequest& request) {
     submitAndRefresh(makeBisectResetOperation(request), [this](bool succeeded) {
         if (succeeded) {
             refreshBisectStatus();
+        }
+    });
+}
+
+// --- M5: LFS ---------------------------------------------------------------
+
+void RepositorySession::refreshLfs() {
+    const CancellationToken token = readCancel_.token();
+    setBusy(true);
+
+    readPool_.post([this, token] {
+        auto installation = detectLfs(*runner_, paths_, token);
+        if (!installation) {
+            if (installation.error().code != GitError::Code::Cancelled) {
+                GitError error = std::move(installation).error();
+                QMetaObject::invokeMethod(
+                    this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+            }
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+
+        const bool available = installation->available;
+        LfsInstallation installationValue = *installation;
+        QMetaObject::invokeMethod(
+            this,
+            [this, installationValue] { lfsInstallation_ = installationValue; },
+            Qt::QueuedConnection);
+
+        if (!available) {
+            QMetaObject::invokeMethod(
+                this, [this] { emit lfsUpdated(); setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+
+        auto patterns = lfsStore_->trackedPatterns(token);
+        if (patterns) {
+            lfsPatterns_.publish(std::make_shared<std::vector<std::string>>(std::move(*patterns)));
+        }
+        auto files = lfsStore_->listFiles(token);
+        if (files) {
+            lfsFiles_.publish(std::make_shared<std::vector<LfsFileInfo>>(std::move(*files)));
+        }
+        QMetaObject::invokeMethod(
+            this, [this] { emit lfsUpdated(); setBusy(false); }, Qt::QueuedConnection);
+    });
+}
+
+void RepositorySession::installLfs() {
+    submitAndRefresh(makeLfsInstallOperation(), [this](bool succeeded) {
+        if (succeeded) {
+            refreshLfs();
+        }
+    });
+}
+
+void RepositorySession::trackLfsPattern(const LfsTrackRequest& request) {
+    submitAndRefresh(makeLfsTrackOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshLfs();
+        }
+    });
+}
+
+void RepositorySession::untrackLfsPattern(const LfsUntrackRequest& request) {
+    submitAndRefresh(makeLfsUntrackOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshLfs();
+        }
+    });
+}
+
+void RepositorySession::pullLfs(const LfsTransferRequest& request) {
+    LfsTransferRequest wired = request;
+    wired.askpassDir = askpass::makeRequestDir();
+    if (!wired.askpassDir.empty()) {
+        askpass_->start(wired.askpassDir);
+    }
+    submitAndRefresh(makeLfsPullOperation(wired), [this](bool succeeded) {
+        askpass_->stop();
+        if (succeeded) {
+            refreshLfs();
+        }
+    });
+}
+
+void RepositorySession::fetchLfs(const LfsTransferRequest& request) {
+    LfsTransferRequest wired = request;
+    wired.askpassDir = askpass::makeRequestDir();
+    if (!wired.askpassDir.empty()) {
+        askpass_->start(wired.askpassDir);
+    }
+    submitAndRefresh(makeLfsFetchOperation(wired), [this](bool succeeded) {
+        askpass_->stop();
+        if (succeeded) {
+            refreshLfs();
+        }
+    });
+}
+
+void RepositorySession::pruneLfs(const LfsPruneRequest& request) {
+    submitAndRefresh(makeLfsPruneOperation(request), [this](bool succeeded) {
+        if (succeeded) {
+            refreshLfs();
         }
     });
 }

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -24,6 +24,7 @@
 #include "core/git/ops/ResetOps.h"
 #include "core/git/ops/StageOps.h"
 #include "core/git/ops/StashOps.h"
+#include "core/git/ops/SubmoduleOps.h"
 #include "core/git/ops/TagOps.h"
 #include "core/git/ops/UndoOps.h"
 #include "core/git/ops/WorktreeOps.h"
@@ -42,6 +43,7 @@ namespace gbm {
 using StashListPtr = std::shared_ptr<const std::vector<StashEntry>>;
 using WorktreeListPtr = std::shared_ptr<const std::vector<WorktreeInfo>>;
 using RemoteListPtr = std::shared_ptr<const std::vector<RemoteInfo>>;
+using SubmoduleListPtr = std::shared_ptr<const std::vector<SubmoduleInfo>>;
 
 /// One open repository, and the single place where core callbacks become Qt
 /// signals.
@@ -238,6 +240,18 @@ public:
     /// Reverses the most recent journal entry -- see UndoOps.h.
     void undoLastOperation();
 
+    // --- M5: submodules ------------------------------------------------------
+
+    SubmoduleListPtr submodules() const { return submodules_.current(); }
+
+    void refreshSubmodules();
+
+    void addSubmodule(const AddSubmoduleRequest& request);
+    void initSubmodules(const SubmodulePathsRequest& request);
+    void updateSubmodules(const UpdateSubmodulesRequest& request);
+    void syncSubmodules(const SubmodulePathsRequest& request);
+    void deinitSubmodules(const DeinitSubmodulesRequest& request);
+
 signals:
     /// A newer graph snapshot is available (possibly partial).
     void graphUpdated(bool complete);
@@ -265,6 +279,7 @@ signals:
     void stashesUpdated();
     void worktreesUpdated();
     void remotesUpdated();
+    void submodulesUpdated();
 
     /// A `git` subprocess spawned by one of the M3 remote/tag operations is
     /// blocked waiting for `prompt`. The view layer is expected to show it and
@@ -312,6 +327,7 @@ private:
     std::unique_ptr<BlameStore> blameStore_;
     std::unique_ptr<FileHistoryStore> fileHistoryStore_;
     std::unique_ptr<ReflogStore> reflogStore_;
+    std::unique_ptr<SubmoduleStore> submoduleStore_;
     AskpassWatcher* askpass_ = nullptr;
 
     SnapshotHolder<GraphSnapshot> graph_;
@@ -320,6 +336,7 @@ private:
     SnapshotHolder<std::vector<StashEntry>> stashes_;
     SnapshotHolder<std::vector<WorktreeInfo>> worktrees_;
     SnapshotHolder<std::vector<RemoteInfo>> remotes_;
+    SnapshotHolder<std::vector<SubmoduleInfo>> submodules_;
 
     /// Cancels the in-flight history walk when a new one starts.
     CancellationSource historyCancel_;

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -21,6 +21,7 @@
 #include "core/git/ops/ConflictOps.h"
 #include "core/git/ops/LfsOps.h"
 #include "core/git/ops/MergeOps.h"
+#include "core/git/ops/PatchOps.h"
 #include "core/git/ops/RebaseOps.h"
 #include "core/git/ops/RemoteOps.h"
 #include "core/git/ops/ResetOps.h"
@@ -286,6 +287,15 @@ public:
     void pullLfs(const LfsTransferRequest& request);
     void fetchLfs(const LfsTransferRequest& request);
     void pruneLfs(const LfsPruneRequest& request);
+
+    // --- M5: patch import/export --------------------------------------------
+
+    void exportPatches(const ExportPatchesRequest& request);
+    void applyPatchFiles(const ApplyPatchFilesRequest& request);
+    void importPatches(const ImportPatchesRequest& request);
+    void continueImport();
+    void skipImport();
+    void abortImport();
 
 signals:
     /// A newer graph snapshot is available (possibly partial).

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -19,6 +19,7 @@
 #include "core/git/ops/CherryPickOps.h"
 #include "core/git/ops/CommitOps.h"
 #include "core/git/ops/ConflictOps.h"
+#include "core/git/ops/LfsOps.h"
 #include "core/git/ops/MergeOps.h"
 #include "core/git/ops/RebaseOps.h"
 #include "core/git/ops/RemoteOps.h"
@@ -37,6 +38,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace gbm {
@@ -46,6 +48,8 @@ using WorktreeListPtr = std::shared_ptr<const std::vector<WorktreeInfo>>;
 using RemoteListPtr = std::shared_ptr<const std::vector<RemoteInfo>>;
 using SubmoduleListPtr = std::shared_ptr<const std::vector<SubmoduleInfo>>;
 using BisectStatusPtr = std::shared_ptr<const BisectStatus>;
+using LfsFileListPtr = std::shared_ptr<const std::vector<LfsFileInfo>>;
+using LfsPatternListPtr = std::shared_ptr<const std::vector<std::string>>;
 
 /// One open repository, and the single place where core callbacks become Qt
 /// signals.
@@ -265,6 +269,24 @@ public:
     void skipBisect(const BisectSkipRequest& request);
     void resetBisect(const BisectResetRequest& request);
 
+    // --- M5: LFS -----------------------------------------------------------
+
+    /// Whether `git-lfs` is on `PATH`, detected once per session on the first
+    /// `refreshLfs()` call. `std::nullopt` before that first refresh completes.
+    std::optional<LfsInstallation> lfsInstallation() const { return lfsInstallation_; }
+
+    LfsPatternListPtr lfsTrackedPatterns() const { return lfsPatterns_.current(); }
+    LfsFileListPtr lfsFiles() const { return lfsFiles_.current(); }
+
+    void refreshLfs();
+
+    void installLfs();
+    void trackLfsPattern(const LfsTrackRequest& request);
+    void untrackLfsPattern(const LfsUntrackRequest& request);
+    void pullLfs(const LfsTransferRequest& request);
+    void fetchLfs(const LfsTransferRequest& request);
+    void pruneLfs(const LfsPruneRequest& request);
+
 signals:
     /// A newer graph snapshot is available (possibly partial).
     void graphUpdated(bool complete);
@@ -294,6 +316,7 @@ signals:
     void remotesUpdated();
     void submodulesUpdated();
     void bisectStatusUpdated();
+    void lfsUpdated();
 
     /// A `git` subprocess spawned by one of the M3 remote/tag operations is
     /// blocked waiting for `prompt`. The view layer is expected to show it and
@@ -343,6 +366,7 @@ private:
     std::unique_ptr<ReflogStore> reflogStore_;
     std::unique_ptr<SubmoduleStore> submoduleStore_;
     std::unique_ptr<BisectStore> bisectStore_;
+    std::unique_ptr<LfsStore> lfsStore_;
     AskpassWatcher* askpass_ = nullptr;
 
     SnapshotHolder<GraphSnapshot> graph_;
@@ -353,6 +377,9 @@ private:
     SnapshotHolder<std::vector<RemoteInfo>> remotes_;
     SnapshotHolder<std::vector<SubmoduleInfo>> submodules_;
     SnapshotHolder<BisectStatus> bisectStatus_;
+    SnapshotHolder<std::vector<std::string>> lfsPatterns_;
+    SnapshotHolder<std::vector<LfsFileInfo>> lfsFiles_;
+    std::optional<LfsInstallation> lfsInstallation_;
 
     /// Cancels the in-flight history walk when a new one starts.
     CancellationSource historyCancel_;

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -277,6 +277,7 @@ public:
     std::optional<LfsInstallation> lfsInstallation() const { return lfsInstallation_; }
 
     LfsPatternListPtr lfsTrackedPatterns() const { return lfsPatterns_.current(); }
+
     LfsFileListPtr lfsFiles() const { return lfsFiles_.current(); }
 
     void refreshLfs();

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -14,6 +14,7 @@
 #include "core/git/ReflogStore.h"
 #include "core/git/RepoState.h"
 #include "core/git/WorkingCopyStatus.h"
+#include "core/git/ops/BisectOps.h"
 #include "core/git/ops/CheckoutOp.h"
 #include "core/git/ops/CherryPickOps.h"
 #include "core/git/ops/CommitOps.h"
@@ -44,6 +45,7 @@ using StashListPtr = std::shared_ptr<const std::vector<StashEntry>>;
 using WorktreeListPtr = std::shared_ptr<const std::vector<WorktreeInfo>>;
 using RemoteListPtr = std::shared_ptr<const std::vector<RemoteInfo>>;
 using SubmoduleListPtr = std::shared_ptr<const std::vector<SubmoduleInfo>>;
+using BisectStatusPtr = std::shared_ptr<const BisectStatus>;
 
 /// One open repository, and the single place where core callbacks become Qt
 /// signals.
@@ -252,6 +254,17 @@ public:
     void syncSubmodules(const SubmodulePathsRequest& request);
     void deinitSubmodules(const DeinitSubmodulesRequest& request);
 
+    // --- M5: bisect ------------------------------------------------------
+
+    BisectStatusPtr bisectStatus() const { return bisectStatus_.current(); }
+
+    void refreshBisectStatus();
+
+    void startBisect(const BisectStartRequest& request);
+    void markBisect(const BisectMarkRequest& request);
+    void skipBisect(const BisectSkipRequest& request);
+    void resetBisect(const BisectResetRequest& request);
+
 signals:
     /// A newer graph snapshot is available (possibly partial).
     void graphUpdated(bool complete);
@@ -280,6 +293,7 @@ signals:
     void worktreesUpdated();
     void remotesUpdated();
     void submodulesUpdated();
+    void bisectStatusUpdated();
 
     /// A `git` subprocess spawned by one of the M3 remote/tag operations is
     /// blocked waiting for `prompt`. The view layer is expected to show it and
@@ -328,6 +342,7 @@ private:
     std::unique_ptr<FileHistoryStore> fileHistoryStore_;
     std::unique_ptr<ReflogStore> reflogStore_;
     std::unique_ptr<SubmoduleStore> submoduleStore_;
+    std::unique_ptr<BisectStore> bisectStore_;
     AskpassWatcher* askpass_ = nullptr;
 
     SnapshotHolder<GraphSnapshot> graph_;
@@ -337,6 +352,7 @@ private:
     SnapshotHolder<std::vector<WorktreeInfo>> worktrees_;
     SnapshotHolder<std::vector<RemoteInfo>> remotes_;
     SnapshotHolder<std::vector<SubmoduleInfo>> submodules_;
+    SnapshotHolder<BisectStatus> bisectStatus_;
 
     /// Cancels the in-flight history walk when a new one starts.
     CancellationSource historyCancel_;

--- a/src/app/bridge/ThemeManager.cpp
+++ b/src/app/bridge/ThemeManager.cpp
@@ -1,0 +1,123 @@
+#include "app/bridge/ThemeManager.h"
+
+#include <QApplication>
+#include <QSettings>
+#include <QStyle>
+#include <QStyleFactory>
+
+namespace gbm {
+
+namespace {
+
+constexpr auto kSettingsKey = "appearance/theme";
+
+/// Remembered so `Light`/`Dark` can be re-applied (e.g. after a QSettings
+/// change elsewhere) without needing to rebuild the style name from scratch,
+/// and so `System` has something concrete to restore.
+QString defaultStyleName() {
+    static const QString name = QApplication::style() != nullptr
+                                    ? QApplication::style()->objectName()
+                                    : QString();
+    return name;
+}
+
+}  // namespace
+
+Theme ThemeManager::loadSetting() {
+    QSettings settings;
+    const int stored = settings.value(QLatin1String(kSettingsKey), 0).toInt();
+    switch (stored) {
+        case 1:
+            return Theme::Light;
+        case 2:
+            return Theme::Dark;
+        default:
+            return Theme::System;
+    }
+}
+
+void ThemeManager::saveSetting(Theme theme) {
+    QSettings settings;
+    settings.setValue(QLatin1String(kSettingsKey),
+                      theme == Theme::Light ? 1 : theme == Theme::Dark ? 2 : 0);
+}
+
+QPalette ThemeManager::lightPalette() {
+    QPalette palette;
+    palette.setColor(QPalette::Window, QColor(240, 240, 240));
+    palette.setColor(QPalette::WindowText, Qt::black);
+    palette.setColor(QPalette::Base, Qt::white);
+    palette.setColor(QPalette::AlternateBase, QColor(233, 233, 233));
+    palette.setColor(QPalette::ToolTipBase, Qt::white);
+    palette.setColor(QPalette::ToolTipText, Qt::black);
+    palette.setColor(QPalette::Text, Qt::black);
+    palette.setColor(QPalette::Button, QColor(240, 240, 240));
+    palette.setColor(QPalette::ButtonText, Qt::black);
+    palette.setColor(QPalette::BrightText, Qt::red);
+    palette.setColor(QPalette::Link, QColor(0, 102, 204));
+    palette.setColor(QPalette::Highlight, QColor(76, 163, 224));
+    palette.setColor(QPalette::HighlightedText, Qt::white);
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(150, 150, 150));
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(150, 150, 150));
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(150, 150, 150));
+    return palette;
+}
+
+QPalette ThemeManager::darkPalette() {
+    // The long-published "Fusion dark palette" recipe (Qt's own examples and
+    // documentation use these exact values), because it is a known-legible
+    // starting point rather than a guess at contrast ratios.
+    QPalette palette;
+    palette.setColor(QPalette::Window, QColor(53, 53, 53));
+    palette.setColor(QPalette::WindowText, Qt::white);
+    palette.setColor(QPalette::Base, QColor(35, 35, 35));
+    palette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+    palette.setColor(QPalette::ToolTipBase, Qt::white);
+    palette.setColor(QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::Text, Qt::white);
+    palette.setColor(QPalette::Button, QColor(53, 53, 53));
+    palette.setColor(QPalette::ButtonText, Qt::white);
+    palette.setColor(QPalette::BrightText, Qt::red);
+    palette.setColor(QPalette::Link, QColor(42, 130, 218));
+    palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+    palette.setColor(QPalette::HighlightedText, Qt::black);
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+    return palette;
+}
+
+void ThemeManager::apply(Theme theme) {
+    defaultStyleName();  // captured on first call, before anything below changes it.
+
+    switch (theme) {
+        case Theme::System:
+            if (QStyle* style = QStyleFactory::create(defaultStyleName()); style != nullptr) {
+                QApplication::setStyle(style);
+            }
+            QApplication::setPalette(QApplication::style()->standardPalette());
+            break;
+        case Theme::Light:
+            QApplication::setStyle(QStyleFactory::create(QStringLiteral("Fusion")));
+            QApplication::setPalette(lightPalette());
+            break;
+        case Theme::Dark:
+            QApplication::setStyle(QStyleFactory::create(QStringLiteral("Fusion")));
+            QApplication::setPalette(darkPalette());
+            break;
+    }
+}
+
+QString ThemeManager::label(Theme theme) {
+    switch (theme) {
+        case Theme::System:
+            return QStringLiteral("System");
+        case Theme::Light:
+            return QStringLiteral("Light");
+        case Theme::Dark:
+            return QStringLiteral("Dark");
+    }
+    return QStringLiteral("System");
+}
+
+}  // namespace gbm

--- a/src/app/bridge/ThemeManager.cpp
+++ b/src/app/bridge/ThemeManager.cpp
@@ -15,9 +15,8 @@ constexpr auto kSettingsKey = "appearance/theme";
 /// change elsewhere) without needing to rebuild the style name from scratch,
 /// and so `System` has something concrete to restore.
 QString defaultStyleName() {
-    static const QString name = QApplication::style() != nullptr
-                                    ? QApplication::style()->objectName()
-                                    : QString();
+    static const QString name =
+        QApplication::style() != nullptr ? QApplication::style()->objectName() : QString();
     return name;
 }
 
@@ -39,7 +38,9 @@ Theme ThemeManager::loadSetting() {
 void ThemeManager::saveSetting(Theme theme) {
     QSettings settings;
     settings.setValue(QLatin1String(kSettingsKey),
-                      theme == Theme::Light ? 1 : theme == Theme::Dark ? 2 : 0);
+                      theme == Theme::Light  ? 1
+                      : theme == Theme::Dark ? 2
+                                             : 0);
 }
 
 QPalette ThemeManager::lightPalette() {

--- a/src/app/bridge/ThemeManager.h
+++ b/src/app/bridge/ThemeManager.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QPalette>
+#include <QString>
+
+namespace gbm {
+
+enum class Theme { System, Light, Dark };
+
+/// Applies and persists the app's colour theme.
+///
+/// Qt's own system-colour-scheme detection (`QStyleHints::colorScheme`) needs
+/// Qt 6.5; this app's floor is 6.4, so `System` is implemented as "leave the
+/// platform's own palette and style alone" rather than actively detecting
+/// dark mode -- on most desktops the platform theme plugin already does the
+/// right thing for the default palette, and this never fights it. `Light` and
+/// `Dark` switch to the Fusion style with an explicit palette, because native
+/// styles are free to ignore large parts of a custom QPalette.
+class ThemeManager {
+public:
+    /// Reads the persisted choice (QSettings, defaults to System).
+    static Theme loadSetting();
+
+    static void saveSetting(Theme theme);
+
+    /// Applies `theme` to the running QApplication. Safe to call before or
+    /// after any windows exist; existing widgets re-polish immediately.
+    static void apply(Theme theme);
+
+    static QString label(Theme theme);
+
+private:
+    static QPalette lightPalette();
+    static QPalette darkPalette();
+};
+
+}  // namespace gbm

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,5 +1,6 @@
 #include "gbm/Version.h"
 
+#include "app/bridge/ThemeManager.h"
 #include "app/views/MainWindow.h"
 #include "core/base/Logging.h"
 #include "core/base/ThreadCheck.h"
@@ -30,6 +31,10 @@ int main(int argc, char** argv) {
     QApplication::setApplicationName(QStringLiteral("git-branch-manager"));
     QApplication::setOrganizationName(QStringLiteral("git-branch-manager"));
     QApplication::setApplicationVersion(QStringLiteral(GBM_VERSION_STRING));
+
+    // Before the window is built, so the very first paint already reflects
+    // the saved choice instead of flashing the default theme first.
+    gbm::ThemeManager::apply(gbm::ThemeManager::loadSetting());
 
     gbm::Log::instance().setLevel(gbm::LogLevel::Info);
 

--- a/src/app/views/CredentialDialog.cpp
+++ b/src/app/views/CredentialDialog.cpp
@@ -20,6 +20,7 @@ CredentialDialog::CredentialDialog(const QString& prompt, QWidget* parent) : QDi
         prompt.contains(QStringLiteral("assphrase"), Qt::CaseInsensitive)) {
         edit_->setEchoMode(QLineEdit::Password);
     }
+    edit_->setAccessibleName(prompt);
     layout->addWidget(edit_);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);

--- a/src/app/views/DiffView.cpp
+++ b/src/app/views/DiffView.cpp
@@ -35,6 +35,7 @@ DiffView::DiffView(QWidget* parent) : QPlainTextEdit(parent) {
     setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
     setPlaceholderText(QStringLiteral("Select a commit to see its changes"));
+    setAccessibleName(QStringLiteral("Diff"));
     // Bounded undo/redo history is pointless in a read-only view and only costs
     // memory on large diffs.
     setUndoRedoEnabled(false);

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -418,9 +418,8 @@ void MainWindow::buildMenus() {
     lfsMenu->addAction(QStringLiteral("Manage LFS…"), this, &MainWindow::onManageLfs);
 
     auto* patchMenu = menuBar()->addMenu(QStringLiteral("&Patch"));
-    patchMenu->addAction(QStringLiteral("Export selected commits as patches…"),
-                         this,
-                         &MainWindow::onExportPatches);
+    patchMenu->addAction(
+        QStringLiteral("Export selected commits as patches…"), this, &MainWindow::onExportPatches);
     patchMenu->addSeparator();
     patchMenu->addAction(QStringLiteral("Apply patch file…"), this, &MainWindow::onApplyPatchFile);
     patchMenu->addAction(
@@ -2563,7 +2562,7 @@ void MainWindow::onManageSubmodules() {
     auto* deinitButton = new QPushButton(QStringLiteral("Deinit…"), &dialog);
     auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
     for (QPushButton* button :
-        {addButton, initButton, updateButton, syncButton, deinitButton, closeButton}) {
+         {addButton, initButton, updateButton, syncButton, deinitButton, closeButton}) {
         button->setAccessibleDescription(QStringLiteral("Submodule action"));
     }
     buttonRow->addWidget(addButton);
@@ -2577,19 +2576,22 @@ void MainWindow::onManageSubmodules() {
 
     connect(addButton, &QPushButton::clicked, &dialog, [this, &dialog] {
         bool ok = false;
-        const QString url = QInputDialog::getText(
-            &dialog, QStringLiteral("Add submodule"), QStringLiteral("URL:"),
-            QLineEdit::Normal, QString(), &ok);
+        const QString url = QInputDialog::getText(&dialog,
+                                                  QStringLiteral("Add submodule"),
+                                                  QStringLiteral("URL:"),
+                                                  QLineEdit::Normal,
+                                                  QString(),
+                                                  &ok);
         if (!ok || url.isEmpty()) {
             return;
         }
-        const QString path = QInputDialog::getText(
-            &dialog,
-            QStringLiteral("Add submodule"),
-            QStringLiteral("Path (leave blank to derive from the URL):"),
-            QLineEdit::Normal,
-            QString(),
-            &ok);
+        const QString path =
+            QInputDialog::getText(&dialog,
+                                  QStringLiteral("Add submodule"),
+                                  QStringLiteral("Path (leave blank to derive from the URL):"),
+                                  QLineEdit::Normal,
+                                  QString(),
+                                  &ok);
         if (!ok) {
             return;
         }
@@ -2639,9 +2641,9 @@ void MainWindow::onManageSubmodules() {
             QMessageBox::warning(&dialog,
                                  QStringLiteral("Deinitialize submodule?"),
                                  QStringLiteral("This removes the checked-out files for \"%1\" "
-                                               "(any local changes inside it are discarded). "
-                                               "\"%1\" stays listed in .gitmodules and can be "
-                                               "initialised again later.")
+                                                "(any local changes inside it are discarded). "
+                                                "\"%1\" stays listed in .gitmodules and can be "
+                                                "initialised again later.")
                                      .arg(QString::fromStdString(info->path)),
                                  QMessageBox::Yes | QMessageBox::Cancel,
                                  QMessageBox::Cancel);
@@ -2740,8 +2742,7 @@ void MainWindow::onBisect() {
             summary += QStringLiteral("\nGood: %1 commit(s) marked").arg(status->goodOids.size());
         }
         if (!status->skippedOids.empty()) {
-            summary +=
-                QStringLiteral("\nSkipped: %1 commit(s)").arg(status->skippedOids.size());
+            summary += QStringLiteral("\nSkipped: %1 commit(s)").arg(status->skippedOids.size());
         }
         currentLabel->setText(summary);
         logText->setPlainText(QString::fromStdString(status->logText));
@@ -2794,7 +2795,8 @@ void MainWindow::onManageLfs() {
     statusLabel->setWordWrap(true);
     layout->addWidget(statusLabel);
 
-    auto* installButton = new QPushButton(QStringLiteral("Set up LFS for this repository"), &dialog);
+    auto* installButton =
+        new QPushButton(QStringLiteral("Set up LFS for this repository"), &dialog);
     layout->addWidget(installButton);
 
     auto* patternsGroup = new QWidget(&dialog);
@@ -2837,8 +2839,15 @@ void MainWindow::onManageLfs() {
     layout->addLayout(transferRow);
     connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
 
-    auto reload = [this, statusLabel, installButton, patternsGroup, filesTable, pullButton,
-                   fetchButton, pruneButton, patternsList] {
+    auto reload = [this,
+                   statusLabel,
+                   installButton,
+                   patternsGroup,
+                   filesTable,
+                   pullButton,
+                   fetchButton,
+                   pruneButton,
+                   patternsList] {
         auto installation = session_->lfsInstallation();
         const bool available = installation && installation->available;
         installButton->setVisible(available);
@@ -2855,7 +2864,7 @@ void MainWindow::onManageLfs() {
         if (!available) {
             statusLabel->setText(
                 QStringLiteral("Git LFS is not installed. Install the git-lfs extension to "
-                              "track large files in this repository."));
+                               "track large files in this repository."));
             return;
         }
         statusLabel->setText(
@@ -2874,14 +2883,15 @@ void MainWindow::onManageLfs() {
             filesTable->setRowCount(static_cast<int>(files->size()));
             for (int row = 0; row < static_cast<int>(files->size()); ++row) {
                 const LfsFileInfo& info = (*files)[static_cast<std::size_t>(row)];
-                filesTable->setItem(row, 0, new QTableWidgetItem(QString::fromStdString(info.path)));
+                filesTable->setItem(
+                    row, 0, new QTableWidgetItem(QString::fromStdString(info.path)));
                 filesTable->setItem(
                     row, 1, new QTableWidgetItem(QString::fromStdString(info.oid).left(10)));
-                filesTable->setItem(row,
-                                    2,
-                                    new QTableWidgetItem(info.downloadedLocally
-                                                             ? QStringLiteral("yes")
-                                                             : QStringLiteral("no")));
+                filesTable->setItem(
+                    row,
+                    2,
+                    new QTableWidgetItem(info.downloadedLocally ? QStringLiteral("yes")
+                                                                : QStringLiteral("no")));
             }
         }
     };
@@ -2960,8 +2970,8 @@ void MainWindow::onExportPatches() {
         commits.push_back(commitModel_->oidAt(row));
     }
 
-    const QString dir = QFileDialog::getExistingDirectory(
-        this, QStringLiteral("Choose a folder for the patches"));
+    const QString dir =
+        QFileDialog::getExistingDirectory(this, QStringLiteral("Choose a folder for the patches"));
     if (dir.isEmpty()) {
         return;
     }
@@ -2976,11 +2986,11 @@ void MainWindow::onApplyPatchFile() {
     if (!session_) {
         return;
     }
-    const QStringList files = QFileDialog::getOpenFileNames(
-        this,
-        QStringLiteral("Apply patch"),
-        QString(),
-        QStringLiteral("Patches (*.patch *.diff);;All files (*)"));
+    const QStringList files =
+        QFileDialog::getOpenFileNames(this,
+                                      QStringLiteral("Apply patch"),
+                                      QString(),
+                                      QStringLiteral("Patches (*.patch *.diff);;All files (*)"));
     if (files.isEmpty()) {
         return;
     }
@@ -3035,9 +3045,10 @@ void MainWindow::onImportPatches() {
 
         QMessageBox box(this);
         box.setIcon(QMessageBox::Warning);
-        box.setText(QStringLiteral("A patch did not apply cleanly. Resolve the conflict in the "
-                                   "working copy (stage the result), then Continue -- or Skip "
-                                   "this patch, or Abort the import."));
+        box.setText(
+            QStringLiteral("A patch did not apply cleanly. Resolve the conflict in the "
+                           "working copy (stage the result), then Continue -- or Skip "
+                           "this patch, or Abort the import."));
         if (outcome.error) {
             box.setDetailedText(QString::fromStdString(outcome.error->detail));
         }

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -120,10 +120,12 @@ void MainWindow::buildUi() {
     repoSearch_ = new QLineEdit(browserPage);
     repoSearch_->setPlaceholderText(QStringLiteral("Filter repositories by name or path…"));
     repoSearch_->setClearButtonEnabled(true);
+    repoSearch_->setAccessibleName(QStringLiteral("Filter repositories"));
     connect(repoSearch_, &QLineEdit::textChanged, this, &MainWindow::onRepoSearchChanged);
 
     repoModel_ = new RepoListModel(this);
     repoView_ = new QTableView(browserPage);
+    repoView_->setAccessibleName(QStringLiteral("Repositories"));
     repoView_->setModel(repoModel_);
     repoView_->setSelectionBehavior(QAbstractItemView::SelectRows);
     repoView_->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -165,6 +167,7 @@ void MainWindow::buildUi() {
     bannerLabel_ = new QLabel(bannerRow);
     bannerLabel_->setVisible(false);
     bannerLabel_->setWordWrap(true);
+    bannerLabel_->setAccessibleName(QStringLiteral("Repository state banner"));
     // Unmissable by design: a repository stuck mid-rebase must never look normal.
     bannerLabel_->setStyleSheet(QStringLiteral("QLabel { color: white; }"));
     bannerLayout->addWidget(bannerLabel_, 1);
@@ -193,6 +196,7 @@ void MainWindow::buildUi() {
 
     refModel_ = new RefTreeModel(this);
     refView_ = new QTreeView(outerSplitter);
+    refView_->setAccessibleName(QStringLiteral("Branches and tags"));
     refView_->setModel(refModel_);
     refView_->setHeaderHidden(true);
     refView_->setUniformRowHeights(true);
@@ -208,6 +212,7 @@ void MainWindow::buildUi() {
 
     commitModel_ = new CommitListModel(this);
     commitView_ = new QTableView(rightSplitter);
+    commitView_->setAccessibleName(QStringLiteral("Commit history"));
     commitView_->setModel(commitModel_);
     commitView_->setSelectionBehavior(QAbstractItemView::SelectRows);
     commitView_->verticalHeader()->setVisible(false);
@@ -238,6 +243,7 @@ void MainWindow::buildUi() {
 
     auto* detailSplitter = new QSplitter(Qt::Horizontal, rightSplitter);
     fileView_ = new QTableView(detailSplitter);
+    fileView_->setAccessibleName(QStringLiteral("Changed files"));
     fileView_->setSelectionBehavior(QAbstractItemView::SelectRows);
     fileView_->verticalHeader()->setVisible(false);
     fileView_->setShowGrid(false);
@@ -282,10 +288,12 @@ void MainWindow::buildUi() {
 
     // --- status bar ----------------------------------------------------------
     statusLabel_ = new QLabel(QStringLiteral("Ready"), this);
+    statusLabel_->setAccessibleName(QStringLiteral("Status"));
     busyBar_ = new QProgressBar(this);
     busyBar_->setRange(0, 0);  // Indeterminate.
     busyBar_->setMaximumWidth(120);
     busyBar_->setVisible(false);
+    busyBar_->setAccessibleName(QStringLiteral("Busy"));
     statusBar()->addWidget(statusLabel_, 1);
     statusBar()->addPermanentWidget(busyBar_);
     statusBar()->addPermanentWidget(new QLabel(

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -381,6 +381,10 @@ void MainWindow::buildMenus() {
     worktreeMenu->addAction(
         QStringLiteral("Manage worktrees…"), this, &MainWindow::onManageWorktrees);
 
+    auto* submoduleMenu = menuBar()->addMenu(QStringLiteral("Sub&module"));
+    submoduleMenu->addAction(
+        QStringLiteral("Manage submodules…"), this, &MainWindow::onManageSubmodules);
+
     auto* toolBar = addToolBar(QStringLiteral("Main"));
     toolBar->setMovable(false);
     toolBar->addAction(refreshAction);
@@ -2440,6 +2444,179 @@ void MainWindow::onFileContextMenuRequested(const QPoint& pos) {
                     });
         session_->requestLineHistory(stdPath, startLine, endLine, revision);
     }
+}
+
+// --- M5: submodules ----------------------------------------------------------
+
+void MainWindow::onManageSubmodules() {
+    if (!session_) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Manage submodules"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    auto* table = new QTableWidget(&dialog);
+    table->setColumnCount(4);
+    table->setHorizontalHeaderLabels({QStringLiteral("Path"),
+                                      QStringLiteral("URL"),
+                                      QStringLiteral("Commit"),
+                                      QStringLiteral("Status")});
+    table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setSelectionMode(QAbstractItemView::SingleSelection);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->verticalHeader()->setVisible(false);
+    table->setAccessibleName(QStringLiteral("Submodule list"));
+    layout->addWidget(table, 1);
+
+    auto stateLabel = [](SubmoduleInfo::State state) {
+        switch (state) {
+            case SubmoduleInfo::State::NotInitialized:
+                return QStringLiteral("not initialized");
+            case SubmoduleInfo::State::Modified:
+                return QStringLiteral("modified");
+            case SubmoduleInfo::State::Conflicted:
+                return QStringLiteral("conflicted");
+            case SubmoduleInfo::State::UpToDate:
+                return QStringLiteral("up to date");
+        }
+        return QStringLiteral("up to date");
+    };
+
+    auto reload = [this, table, stateLabel] {
+        auto submodules = session_->submodules();
+        table->setRowCount(0);
+        if (!submodules) {
+            return;
+        }
+        table->setRowCount(static_cast<int>(submodules->size()));
+        for (int row = 0; row < static_cast<int>(submodules->size()); ++row) {
+            const SubmoduleInfo& info = (*submodules)[static_cast<std::size_t>(row)];
+            table->setItem(row, 0, new QTableWidgetItem(QString::fromStdString(info.path)));
+            table->setItem(row, 1, new QTableWidgetItem(QString::fromStdString(info.url)));
+            table->setItem(
+                row, 2, new QTableWidgetItem(QString::fromStdString(info.headOid).left(10)));
+            table->setItem(row, 3, new QTableWidgetItem(stateLabel(info.state)));
+        }
+    };
+    connect(session_.get(), &RepositorySession::submodulesUpdated, &dialog, reload);
+    session_->refreshSubmodules();
+    reload();
+
+    auto selectedInfo = [this, table]() -> std::optional<SubmoduleInfo> {
+        const int row = table->currentRow();
+        auto submodules = session_->submodules();
+        if (row < 0 || !submodules || row >= static_cast<int>(submodules->size())) {
+            return std::nullopt;
+        }
+        return (*submodules)[static_cast<std::size_t>(row)];
+    };
+
+    auto* buttonRow = new QHBoxLayout();
+    auto* addButton = new QPushButton(QStringLiteral("Add…"), &dialog);
+    auto* initButton = new QPushButton(QStringLiteral("Init"), &dialog);
+    auto* updateButton = new QPushButton(QStringLiteral("Update"), &dialog);
+    auto* syncButton = new QPushButton(QStringLiteral("Sync"), &dialog);
+    auto* deinitButton = new QPushButton(QStringLiteral("Deinit…"), &dialog);
+    auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+    for (QPushButton* button :
+        {addButton, initButton, updateButton, syncButton, deinitButton, closeButton}) {
+        button->setAccessibleDescription(QStringLiteral("Submodule action"));
+    }
+    buttonRow->addWidget(addButton);
+    buttonRow->addWidget(initButton);
+    buttonRow->addWidget(updateButton);
+    buttonRow->addWidget(syncButton);
+    buttonRow->addWidget(deinitButton);
+    buttonRow->addStretch(1);
+    buttonRow->addWidget(closeButton);
+    layout->addLayout(buttonRow);
+
+    connect(addButton, &QPushButton::clicked, &dialog, [this, &dialog] {
+        bool ok = false;
+        const QString url = QInputDialog::getText(
+            &dialog, QStringLiteral("Add submodule"), QStringLiteral("URL:"),
+            QLineEdit::Normal, QString(), &ok);
+        if (!ok || url.isEmpty()) {
+            return;
+        }
+        const QString path = QInputDialog::getText(
+            &dialog,
+            QStringLiteral("Add submodule"),
+            QStringLiteral("Path (leave blank to derive from the URL):"),
+            QLineEdit::Normal,
+            QString(),
+            &ok);
+        if (!ok) {
+            return;
+        }
+        AddSubmoduleRequest request;
+        request.url = url.toStdString();
+        request.path = path.toStdString();
+        runWithFeedback([this, request] { session_->addSubmodule(request); });
+    });
+
+    connect(initButton, &QPushButton::clicked, &dialog, [this, selectedInfo] {
+        auto info = selectedInfo();
+        if (!info) {
+            return;
+        }
+        SubmodulePathsRequest request;
+        request.paths = {info->path};
+        runWithFeedback([this, request] { session_->initSubmodules(request); });
+    });
+
+    connect(updateButton, &QPushButton::clicked, &dialog, [this, selectedInfo] {
+        auto info = selectedInfo();
+        if (!info) {
+            return;
+        }
+        UpdateSubmodulesRequest request;
+        request.paths = {info->path};
+        request.init = true;
+        runWithFeedback([this, request] { session_->updateSubmodules(request); });
+    });
+
+    connect(syncButton, &QPushButton::clicked, &dialog, [this, selectedInfo] {
+        auto info = selectedInfo();
+        if (!info) {
+            return;
+        }
+        SubmodulePathsRequest request;
+        request.paths = {info->path};
+        runWithFeedback([this, request] { session_->syncSubmodules(request); });
+    });
+
+    connect(deinitButton, &QPushButton::clicked, &dialog, [this, selectedInfo, &dialog] {
+        auto info = selectedInfo();
+        if (!info) {
+            return;
+        }
+        const auto confirmed =
+            QMessageBox::warning(&dialog,
+                                 QStringLiteral("Deinitialize submodule?"),
+                                 QStringLiteral("This removes the checked-out files for \"%1\" "
+                                               "(any local changes inside it are discarded). "
+                                               "\"%1\" stays listed in .gitmodules and can be "
+                                               "initialised again later.")
+                                     .arg(QString::fromStdString(info->path)),
+                                 QMessageBox::Yes | QMessageBox::Cancel,
+                                 QMessageBox::Cancel);
+        if (confirmed != QMessageBox::Yes) {
+            return;
+        }
+        DeinitSubmodulesRequest request;
+        request.paths = {info->path};
+        request.force = true;
+        runWithFeedback([this, request] { session_->deinitSubmodules(request); });
+    });
+
+    connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+
+    dialog.resize(720, 360);
+    dialog.exec();
 }
 
 }  // namespace gbm

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -1,10 +1,12 @@
 #include "app/views/MainWindow.h"
 
+#include "app/bridge/ThemeManager.h"
 #include "app/views/CredentialDialog.h"
 #include "core/git/ops/CheckoutOp.h"
 
 #include <QAbstractButton>
 #include <QAction>
+#include <QActionGroup>
 #include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
@@ -317,6 +319,21 @@ void MainWindow::buildMenus() {
     connect(logAction, &QAction::toggled, this, [this](bool visible) {
         logView_->setVisible(visible);
     });
+    viewMenu->addSeparator();
+    auto* themeMenu = viewMenu->addMenu(QStringLiteral("Theme"));
+    auto* themeGroup = new QActionGroup(this);
+    themeGroup->setExclusive(true);
+    const Theme currentTheme = ThemeManager::loadSetting();
+    for (Theme theme : {Theme::System, Theme::Light, Theme::Dark}) {
+        QAction* action = themeMenu->addAction(ThemeManager::label(theme));
+        action->setCheckable(true);
+        action->setChecked(theme == currentTheme);
+        themeGroup->addAction(action);
+        connect(action, &QAction::triggered, this, [theme] {
+            ThemeManager::apply(theme);
+            ThemeManager::saveSetting(theme);
+        });
+    }
 
     auto* branchMenu = menuBar()->addMenu(QStringLiteral("&Branch"));
     auto* checkoutAction = branchMenu->addAction(

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -388,6 +388,9 @@ void MainWindow::buildMenus() {
     auto* bisectMenu = menuBar()->addMenu(QStringLiteral("&Bisect"));
     bisectMenu->addAction(QStringLiteral("Bisect…"), this, &MainWindow::onBisect);
 
+    auto* lfsMenu = menuBar()->addMenu(QStringLiteral("&LFS"));
+    lfsMenu->addAction(QStringLiteral("Manage LFS…"), this, &MainWindow::onManageLfs);
+
     auto* toolBar = addToolBar(QStringLiteral("Main"));
     toolBar->setMovable(false);
     toolBar->addAction(refreshAction);
@@ -2738,6 +2741,160 @@ void MainWindow::onBisect() {
     });
 
     dialog.resize(560, 420);
+    dialog.exec();
+}
+
+// --- M5: LFS ---------------------------------------------------------------
+
+void MainWindow::onManageLfs() {
+    if (!session_) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Manage LFS"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    auto* statusLabel = new QLabel(&dialog);
+    statusLabel->setWordWrap(true);
+    layout->addWidget(statusLabel);
+
+    auto* installButton = new QPushButton(QStringLiteral("Set up LFS for this repository"), &dialog);
+    layout->addWidget(installButton);
+
+    auto* patternsGroup = new QWidget(&dialog);
+    auto* patternsLayout = new QVBoxLayout(patternsGroup);
+    patternsLayout->setContentsMargins(0, 0, 0, 0);
+    patternsLayout->addWidget(new QLabel(QStringLiteral("Tracked patterns:"), patternsGroup));
+    auto* patternsList = new QListWidget(patternsGroup);
+    patternsList->setAccessibleName(QStringLiteral("LFS tracked patterns"));
+    patternsList->setMaximumHeight(100);
+    patternsLayout->addWidget(patternsList);
+    auto* patternButtons = new QHBoxLayout();
+    auto* addPatternButton = new QPushButton(QStringLiteral("Track pattern…"), patternsGroup);
+    auto* removePatternButton = new QPushButton(QStringLiteral("Untrack"), patternsGroup);
+    patternButtons->addWidget(addPatternButton);
+    patternButtons->addWidget(removePatternButton);
+    patternButtons->addStretch(1);
+    patternsLayout->addLayout(patternButtons);
+    layout->addWidget(patternsGroup);
+
+    auto* filesTable = new QTableWidget(&dialog);
+    filesTable->setColumnCount(3);
+    filesTable->setHorizontalHeaderLabels(
+        {QStringLiteral("Path"), QStringLiteral("Object"), QStringLiteral("Local")});
+    filesTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    filesTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    filesTable->verticalHeader()->setVisible(false);
+    filesTable->setAccessibleName(QStringLiteral("LFS files"));
+    layout->addWidget(filesTable, 1);
+
+    auto* transferRow = new QHBoxLayout();
+    auto* pullButton = new QPushButton(QStringLiteral("Pull"), &dialog);
+    auto* fetchButton = new QPushButton(QStringLiteral("Fetch"), &dialog);
+    auto* pruneButton = new QPushButton(QStringLiteral("Prune"), &dialog);
+    auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+    transferRow->addWidget(pullButton);
+    transferRow->addWidget(fetchButton);
+    transferRow->addWidget(pruneButton);
+    transferRow->addStretch(1);
+    transferRow->addWidget(closeButton);
+    layout->addLayout(transferRow);
+    connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+
+    auto reload = [this, statusLabel, installButton, patternsGroup, filesTable, pullButton,
+                   fetchButton, pruneButton, patternsList] {
+        auto installation = session_->lfsInstallation();
+        const bool available = installation && installation->available;
+        installButton->setVisible(available);
+        patternsGroup->setVisible(available);
+        filesTable->setVisible(available);
+        pullButton->setEnabled(available);
+        fetchButton->setEnabled(available);
+        pruneButton->setEnabled(available);
+
+        if (!installation) {
+            statusLabel->setText(QStringLiteral("Checking for Git LFS…"));
+            return;
+        }
+        if (!available) {
+            statusLabel->setText(
+                QStringLiteral("Git LFS is not installed. Install the git-lfs extension to "
+                              "track large files in this repository."));
+            return;
+        }
+        statusLabel->setText(
+            QStringLiteral("Git LFS is available (%1).")
+                .arg(QString::fromStdString(installation->version).split(QChar(' ')).value(0)));
+
+        patternsList->clear();
+        if (auto patterns = session_->lfsTrackedPatterns()) {
+            for (const std::string& pattern : *patterns) {
+                patternsList->addItem(QString::fromStdString(pattern));
+            }
+        }
+
+        filesTable->setRowCount(0);
+        if (auto files = session_->lfsFiles()) {
+            filesTable->setRowCount(static_cast<int>(files->size()));
+            for (int row = 0; row < static_cast<int>(files->size()); ++row) {
+                const LfsFileInfo& info = (*files)[static_cast<std::size_t>(row)];
+                filesTable->setItem(row, 0, new QTableWidgetItem(QString::fromStdString(info.path)));
+                filesTable->setItem(
+                    row, 1, new QTableWidgetItem(QString::fromStdString(info.oid).left(10)));
+                filesTable->setItem(row,
+                                    2,
+                                    new QTableWidgetItem(info.downloadedLocally
+                                                             ? QStringLiteral("yes")
+                                                             : QStringLiteral("no")));
+            }
+        }
+    };
+    connect(session_.get(), &RepositorySession::lfsUpdated, &dialog, reload);
+    session_->refreshLfs();
+    reload();
+
+    connect(installButton, &QPushButton::clicked, &dialog, [this] {
+        runWithFeedback([this] { session_->installLfs(); });
+    });
+
+    connect(addPatternButton, &QPushButton::clicked, &dialog, [this, &dialog] {
+        bool ok = false;
+        const QString pattern = QInputDialog::getText(&dialog,
+                                                      QStringLiteral("Track pattern"),
+                                                      QStringLiteral("Pattern (e.g. *.psd):"),
+                                                      QLineEdit::Normal,
+                                                      QString(),
+                                                      &ok);
+        if (!ok || pattern.isEmpty()) {
+            return;
+        }
+        LfsTrackRequest request;
+        request.pattern = pattern.toStdString();
+        runWithFeedback([this, request] { session_->trackLfsPattern(request); });
+    });
+
+    connect(removePatternButton, &QPushButton::clicked, &dialog, [this, patternsList] {
+        const auto items = patternsList->selectedItems();
+        if (items.isEmpty()) {
+            return;
+        }
+        LfsUntrackRequest request;
+        request.pattern = items.first()->text().toStdString();
+        runWithFeedback([this, request] { session_->untrackLfsPattern(request); });
+    });
+
+    connect(pullButton, &QPushButton::clicked, &dialog, [this] {
+        runWithFeedback([this] { session_->pullLfs(LfsTransferRequest{}); });
+    });
+    connect(fetchButton, &QPushButton::clicked, &dialog, [this] {
+        runWithFeedback([this] { session_->fetchLfs(LfsTransferRequest{}); });
+    });
+    connect(pruneButton, &QPushButton::clicked, &dialog, [this] {
+        runWithFeedback([this] { session_->pruneLfs(LfsPruneRequest{}); });
+    });
+
+    dialog.resize(640, 480);
     dialog.exec();
 }
 

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -3,6 +3,7 @@
 #include "app/views/CredentialDialog.h"
 #include "core/git/ops/CheckoutOp.h"
 
+#include <QAbstractButton>
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
@@ -390,6 +391,15 @@ void MainWindow::buildMenus() {
 
     auto* lfsMenu = menuBar()->addMenu(QStringLiteral("&LFS"));
     lfsMenu->addAction(QStringLiteral("Manage LFS…"), this, &MainWindow::onManageLfs);
+
+    auto* patchMenu = menuBar()->addMenu(QStringLiteral("&Patch"));
+    patchMenu->addAction(QStringLiteral("Export selected commits as patches…"),
+                         this,
+                         &MainWindow::onExportPatches);
+    patchMenu->addSeparator();
+    patchMenu->addAction(QStringLiteral("Apply patch file…"), this, &MainWindow::onApplyPatchFile);
+    patchMenu->addAction(
+        QStringLiteral("Import patches (git am)…"), this, &MainWindow::onImportPatches);
 
     auto* toolBar = addToolBar(QStringLiteral("Main"));
     toolBar->setMovable(false);
@@ -2896,6 +2906,154 @@ void MainWindow::onManageLfs() {
 
     dialog.resize(640, 480);
     dialog.exec();
+}
+
+// --- M5: patch import/export -------------------------------------------------
+
+void MainWindow::onExportPatches() {
+    if (!session_) {
+        return;
+    }
+    const QModelIndexList selected = commitView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        return;
+    }
+
+    // Newest-first selection, oldest-first output -- same convention as
+    // onCherryPickRequested, and the same reason: `format-patch --start-number`
+    // must see the commits in the order they were made.
+    std::vector<int> rows;
+    rows.reserve(static_cast<std::size_t>(selected.size()));
+    for (const QModelIndex& index : selected) {
+        rows.push_back(index.row());
+    }
+    std::sort(rows.begin(), rows.end(), std::greater<>());
+
+    std::vector<ObjectId> commits;
+    commits.reserve(rows.size());
+    for (int row : rows) {
+        commits.push_back(commitModel_->oidAt(row));
+    }
+
+    const QString dir = QFileDialog::getExistingDirectory(
+        this, QStringLiteral("Choose a folder for the patches"));
+    if (dir.isEmpty()) {
+        return;
+    }
+
+    ExportPatchesRequest request;
+    request.commits = commits;
+    request.outputDir = std::filesystem::path(dir.toStdString());
+    runWithFeedback([this, request] { session_->exportPatches(request); });
+}
+
+void MainWindow::onApplyPatchFile() {
+    if (!session_) {
+        return;
+    }
+    const QStringList files = QFileDialog::getOpenFileNames(
+        this,
+        QStringLiteral("Apply patch"),
+        QString(),
+        QStringLiteral("Patches (*.patch *.diff);;All files (*)"));
+    if (files.isEmpty()) {
+        return;
+    }
+
+    ApplyPatchFilesRequest request;
+    for (const QString& file : files) {
+        request.patchFiles.push_back(std::filesystem::path(file.toStdString()));
+    }
+    // Staged, not just written to the work tree: applying a patch from the
+    // menu is a deliberate "bring this change in" action, so it is left ready
+    // to review and commit rather than as an extra unstaged-diff step.
+    request.updateIndex = true;
+    runWithFeedback([this, request] { session_->applyPatchFiles(request); });
+}
+
+void MainWindow::onImportPatches() {
+    if (!session_) {
+        return;
+    }
+    const QStringList files = QFileDialog::getOpenFileNames(
+        this,
+        QStringLiteral("Import patches (git am)"),
+        QString(),
+        QStringLiteral("Patches (*.patch *.eml *.mbox);;All files (*)"));
+    if (files.isEmpty()) {
+        return;
+    }
+
+    ImportPatchesRequest request;
+    for (const QString& file : files) {
+        request.patchFiles.push_back(std::filesystem::path(file.toStdString()));
+    }
+    request.threeWay = true;
+
+    // A conflicted patch leaves `git am` mid-sequence (see PatchOps.h on why
+    // this needs its own Continue/Skip/Abort rather than the shared banner,
+    // which would call `git rebase --continue` and be refused outright). This
+    // recurses on itself via a shared_ptr so each subsequent patch in the
+    // series -- which can conflict again -- gets the same recovery prompt.
+    auto handleOutcome = std::make_shared<std::function<void(const OperationOutcome&)>>();
+    *handleOutcome = [this, handleOutcome](const OperationOutcome& outcome) {
+        if (outcome.succeeded) {
+            statusLabel_->setText(QString::fromStdString(outcome.summary));
+            return;
+        }
+        if (!session_ || !RepoState::read(session_->paths()).isSequencerOperation()) {
+            if (outcome.error) {
+                showError(QString::fromStdString(outcome.summary), *outcome.error);
+            }
+            return;
+        }
+
+        QMessageBox box(this);
+        box.setIcon(QMessageBox::Warning);
+        box.setText(QStringLiteral("A patch did not apply cleanly. Resolve the conflict in the "
+                                   "working copy (stage the result), then Continue -- or Skip "
+                                   "this patch, or Abort the import."));
+        if (outcome.error) {
+            box.setDetailedText(QString::fromStdString(outcome.error->detail));
+        }
+        QPushButton* continueButton =
+            box.addButton(QStringLiteral("Continue"), QMessageBox::AcceptRole);
+        QPushButton* skipButton = box.addButton(QStringLiteral("Skip"), QMessageBox::ActionRole);
+        QPushButton* abortButton = box.addButton(QStringLiteral("Abort"), QMessageBox::RejectRole);
+        box.addButton(QStringLiteral("Later"), QMessageBox::DestructiveRole);
+        box.exec();
+
+        QAbstractButton* clicked = box.clickedButton();
+        if (clicked != continueButton && clicked != skipButton && clicked != abortButton) {
+            return;
+        }
+
+        auto connection = std::make_shared<QMetaObject::Connection>();
+        *connection = connect(session_.get(),
+                              &RepositorySession::workingCopyOperationFinished,
+                              this,
+                              [connection, handleOutcome](const OperationOutcome& next) {
+                                  QObject::disconnect(*connection);
+                                  (*handleOutcome)(next);
+                              });
+        if (clicked == continueButton) {
+            session_->continueImport();
+        } else if (clicked == skipButton) {
+            session_->skipImport();
+        } else {
+            session_->abortImport();
+        }
+    };
+
+    auto connection = std::make_shared<QMetaObject::Connection>();
+    *connection = connect(session_.get(),
+                          &RepositorySession::workingCopyOperationFinished,
+                          this,
+                          [connection, handleOutcome](const OperationOutcome& outcome) {
+                              QObject::disconnect(*connection);
+                              (*handleOutcome)(outcome);
+                          });
+    session_->importPatches(request);
 }
 
 }  // namespace gbm

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -385,6 +385,9 @@ void MainWindow::buildMenus() {
     submoduleMenu->addAction(
         QStringLiteral("Manage submodules…"), this, &MainWindow::onManageSubmodules);
 
+    auto* bisectMenu = menuBar()->addMenu(QStringLiteral("&Bisect"));
+    bisectMenu->addAction(QStringLiteral("Bisect…"), this, &MainWindow::onBisect);
+
     auto* toolBar = addToolBar(QStringLiteral("Main"));
     toolBar->setMovable(false);
     toolBar->addAction(refreshAction);
@@ -2616,6 +2619,125 @@ void MainWindow::onManageSubmodules() {
     connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
 
     dialog.resize(720, 360);
+    dialog.exec();
+}
+
+// --- M5: bisect ----------------------------------------------------------
+
+void MainWindow::onBisect() {
+    if (!session_) {
+        return;
+    }
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(QStringLiteral("Bisect"));
+    auto* layout = new QVBoxLayout(&dialog);
+
+    // --- "not bisecting yet" form ---
+    auto* startForm = new QWidget(&dialog);
+    auto* startLayout = new QVBoxLayout(startForm);
+    startLayout->setContentsMargins(0, 0, 0, 0);
+    auto* badRow = new QHBoxLayout();
+    auto* badLabel = new QLabel(QStringLiteral("Bad commit:"), startForm);
+    auto* badEdit = new QLineEdit(QStringLiteral("HEAD"), startForm);
+    badEdit->setAccessibleName(QStringLiteral("Bad commit"));
+    badRow->addWidget(badLabel);
+    badRow->addWidget(badEdit, 1);
+    startLayout->addLayout(badRow);
+    auto* goodRow = new QHBoxLayout();
+    auto* goodLabel = new QLabel(QStringLiteral("Good commit:"), startForm);
+    auto* goodEdit = new QLineEdit(startForm);
+    goodEdit->setPlaceholderText(QStringLiteral("e.g. a tag, branch or commit known to work"));
+    goodEdit->setAccessibleName(QStringLiteral("Good commit"));
+    goodRow->addWidget(goodLabel);
+    goodRow->addWidget(goodEdit, 1);
+    startLayout->addLayout(goodRow);
+    auto* startButton = new QPushButton(QStringLiteral("Start bisect"), startForm);
+    startLayout->addWidget(startButton, 0, Qt::AlignRight);
+    layout->addWidget(startForm);
+
+    // --- "bisecting" status view ---
+    auto* statusWidget = new QWidget(&dialog);
+    auto* statusLayout = new QVBoxLayout(statusWidget);
+    statusLayout->setContentsMargins(0, 0, 0, 0);
+    auto* currentLabel = new QLabel(statusWidget);
+    currentLabel->setWordWrap(true);
+    statusLayout->addWidget(currentLabel);
+    auto* logText = new QPlainTextEdit(statusWidget);
+    logText->setReadOnly(true);
+    logText->setAccessibleName(QStringLiteral("Bisect log"));
+    statusLayout->addWidget(logText, 1);
+    auto* actionRow = new QHBoxLayout();
+    auto* goodButton = new QPushButton(QStringLiteral("Mark Good"), statusWidget);
+    auto* badButton = new QPushButton(QStringLiteral("Mark Bad"), statusWidget);
+    auto* skipButton = new QPushButton(QStringLiteral("Skip"), statusWidget);
+    auto* resetButton = new QPushButton(QStringLiteral("Reset (end bisect)"), statusWidget);
+    actionRow->addWidget(goodButton);
+    actionRow->addWidget(badButton);
+    actionRow->addWidget(skipButton);
+    actionRow->addStretch(1);
+    actionRow->addWidget(resetButton);
+    statusLayout->addLayout(actionRow);
+    layout->addWidget(statusWidget);
+
+    auto* closeButton = new QPushButton(QStringLiteral("Close"), &dialog);
+    layout->addWidget(closeButton, 0, Qt::AlignRight);
+    connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+
+    auto reload = [this, startForm, statusWidget, currentLabel, logText] {
+        auto status = session_->bisectStatus();
+        const bool active = status && status->active;
+        startForm->setVisible(!active);
+        statusWidget->setVisible(active);
+        if (!active) {
+            return;
+        }
+        QString summary = QStringLiteral("Currently testing: %1")
+                              .arg(QString::fromStdString(status->currentOid).left(12));
+        if (!status->badOid.empty()) {
+            summary +=
+                QStringLiteral("\nBad: %1").arg(QString::fromStdString(status->badOid).left(12));
+        }
+        if (!status->goodOids.empty()) {
+            summary += QStringLiteral("\nGood: %1 commit(s) marked").arg(status->goodOids.size());
+        }
+        if (!status->skippedOids.empty()) {
+            summary +=
+                QStringLiteral("\nSkipped: %1 commit(s)").arg(status->skippedOids.size());
+        }
+        currentLabel->setText(summary);
+        logText->setPlainText(QString::fromStdString(status->logText));
+    };
+    connect(session_.get(), &RepositorySession::bisectStatusUpdated, &dialog, reload);
+    session_->refreshBisectStatus();
+    reload();
+
+    connect(startButton, &QPushButton::clicked, &dialog, [this, badEdit, goodEdit] {
+        BisectStartRequest request;
+        request.badRef = badEdit->text().toStdString();
+        if (!goodEdit->text().isEmpty()) {
+            request.goodRefs = {goodEdit->text().toStdString()};
+        }
+        runWithFeedback([this, request] { session_->startBisect(request); });
+    });
+    connect(goodButton, &QPushButton::clicked, &dialog, [this] {
+        BisectMarkRequest request;
+        request.good = true;
+        runWithFeedback([this, request] { session_->markBisect(request); });
+    });
+    connect(badButton, &QPushButton::clicked, &dialog, [this] {
+        BisectMarkRequest request;
+        request.good = false;
+        runWithFeedback([this, request] { session_->markBisect(request); });
+    });
+    connect(skipButton, &QPushButton::clicked, &dialog, [this] {
+        runWithFeedback([this] { session_->skipBisect(BisectSkipRequest{}); });
+    });
+    connect(resetButton, &QPushButton::clicked, &dialog, [this] {
+        runWithFeedback([this] { session_->resetBisect(BisectResetRequest{}); });
+    });
+
+    dialog.resize(560, 420);
     dialog.exec();
 }
 

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -94,6 +94,7 @@ private slots:
     // --- M5 -----------------------------------------------------------------
     void onManageSubmodules();
     void onBisect();
+    void onManageLfs();
 
 private:
     void buildUi();

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -93,6 +93,7 @@ private slots:
 
     // --- M5 -----------------------------------------------------------------
     void onManageSubmodules();
+    void onBisect();
 
 private:
     void buildUi();

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -95,6 +95,9 @@ private slots:
     void onManageSubmodules();
     void onBisect();
     void onManageLfs();
+    void onExportPatches();
+    void onApplyPatchFile();
+    void onImportPatches();
 
 private:
     void buildUi();

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -91,6 +91,9 @@ private slots:
     void onUndoLastOperation();
     void onFileContextMenuRequested(const QPoint& pos);
 
+    // --- M5 -----------------------------------------------------------------
+    void onManageSubmodules();
+
 private:
     void buildUi();
     void buildMenus();

--- a/src/app/views/OperationLogView.cpp
+++ b/src/app/views/OperationLogView.cpp
@@ -21,10 +21,13 @@ OperationLogView::OperationLogView(QWidget* parent) : QWidget(parent) {
     text_->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     text_->setLineWrapMode(QPlainTextEdit::NoWrap);
     text_->setPlaceholderText(QStringLiteral("Git commands run by this session appear here"));
+    text_->setAccessibleName(QStringLiteral("Operation log"));
 
     auto* buttons = new QHBoxLayout;
     auto* copyButton = new QPushButton(QStringLiteral("Copy all"), this);
     auto* clearButton = new QPushButton(QStringLiteral("Clear"), this);
+    copyButton->setAccessibleName(QStringLiteral("Copy operation log"));
+    clearButton->setAccessibleName(QStringLiteral("Clear operation log"));
     buttons->addWidget(copyButton);
     buttons->addWidget(clearButton);
     buttons->addStretch(1);

--- a/src/app/views/SideBySideDiffView.cpp
+++ b/src/app/views/SideBySideDiffView.cpp
@@ -52,6 +52,8 @@ SideBySideDiffView::SideBySideDiffView(QWidget* parent) : QWidget(parent) {
     left_ = makePane(this);
     right_ = makePane(this);
     left_->setPlaceholderText(QStringLiteral("Select a commit to see its changes"));
+    left_->setAccessibleName(QStringLiteral("Diff, before"));
+    right_->setAccessibleName(QStringLiteral("Diff, after"));
     layout->addWidget(left_);
     layout->addWidget(right_);
 

--- a/src/app/views/WorkingCopyView.cpp
+++ b/src/app/views/WorkingCopyView.cpp
@@ -74,6 +74,7 @@ void WorkingCopyView::buildUi() {
         new QLabel(tr("Conflicts — resolve before committing"), conflictedGroup_));
     conflictedList_ = new QListWidget(conflictedGroup_);
     conflictedList_->setMaximumHeight(120);
+    conflictedList_->setAccessibleName(tr("Conflicted files"));
     conflictedLayout->addWidget(conflictedList_);
     conflictedGroup_->setVisible(false);
     leftLayout->addWidget(conflictedGroup_);
@@ -81,6 +82,7 @@ void WorkingCopyView::buildUi() {
     leftLayout->addWidget(new QLabel(tr("Staged Changes"), leftWidget));
     stagedList_ = new QListWidget(leftWidget);
     stagedList_->setSelectionMode(QAbstractItemView::SingleSelection);
+    stagedList_->setAccessibleName(tr("Staged changes"));
     leftLayout->addWidget(stagedList_, 1);
     unstageAllButton_ = new QPushButton(tr("Unstage All"), leftWidget);
     leftLayout->addWidget(unstageAllButton_);
@@ -89,6 +91,7 @@ void WorkingCopyView::buildUi() {
     unstagedList_ = new QListWidget(leftWidget);
     unstagedList_->setSelectionMode(QAbstractItemView::SingleSelection);
     unstagedList_->setContextMenuPolicy(Qt::CustomContextMenu);
+    unstagedList_->setAccessibleName(tr("Unstaged changes"));
     leftLayout->addWidget(unstagedList_, 1);
     stageAllButton_ = new QPushButton(tr("Stage All"), leftWidget);
     leftLayout->addWidget(stageAllButton_);
@@ -96,6 +99,7 @@ void WorkingCopyView::buildUi() {
     messageEdit_ = new QPlainTextEdit(leftWidget);
     messageEdit_->setPlaceholderText(tr("Commit message"));
     messageEdit_->setMaximumHeight(100);
+    messageEdit_->setAccessibleName(tr("Commit message"));
     leftLayout->addWidget(messageEdit_);
 
     auto* commitRow = new QHBoxLayout();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(gbm_core STATIC
     git/ops/ResetOps.cpp
     git/ops/StageOps.cpp
     git/ops/StashOps.cpp
+    git/ops/SubmoduleOps.cpp
     git/ops/TagOps.cpp
     git/ops/UndoOps.cpp
     git/ops/WorktreeOps.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(gbm_core STATIC
     git/ops/CherryPickOps.cpp
     git/ops/CommitOps.cpp
     git/ops/ConflictOps.cpp
+    git/ops/LfsOps.cpp
     git/ops/MergeOps.cpp
     git/ops/RebaseOps.cpp
     git/ops/RemoteOps.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(gbm_core STATIC
     git/SideBySideDiff.cpp
     git/UnifiedDiffParser.cpp
     git/WorkingCopyStatus.cpp
+    git/ops/BisectOps.cpp
     git/ops/BranchOps.cpp
     git/ops/CheckoutOp.cpp
     git/ops/CherryPickOps.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(gbm_core STATIC
     git/ops/ConflictOps.cpp
     git/ops/LfsOps.cpp
     git/ops/MergeOps.cpp
+    git/ops/PatchOps.cpp
     git/ops/RebaseOps.cpp
     git/ops/RemoteOps.cpp
     git/ops/ResetOps.cpp

--- a/src/core/git/RepoState.cpp
+++ b/src/core/git/RepoState.cpp
@@ -138,6 +138,7 @@ std::vector<std::filesystem::path> RepoState::watchTargets(const RepoPaths& path
         paths.mergeHeadFile(),
         paths.cherryPickHeadFile(),
         paths.revertHeadFile(),
+        paths.bisectLogFile(),
         paths.rebaseMergeDir(),
         paths.rebaseApplyDir(),
         paths.sequencerDir(),

--- a/src/core/git/ops/BisectOps.cpp
+++ b/src/core/git/ops/BisectOps.cpp
@@ -1,0 +1,270 @@
+#include "core/git/ops/BisectOps.h"
+
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+std::string trimTrailingWhitespace(std::string text) {
+    while (!text.empty() && (text.back() == '\n' || text.back() == '\r' || text.back() == ' ')) {
+        text.pop_back();
+    }
+    return text;
+}
+
+/// `git bisect`'s subcommands are chatty on stdout (the next candidate, or the
+/// concluding "is the first bad commit" message), and that text is the whole
+/// point of the operation from the user's point of view, so it becomes the
+/// summary whenever there is any -- unlike most other ops, where `describe()`
+/// alone is enough.
+std::string summaryOrDescribe(const std::string& stdOut, const std::string& fallback) {
+    const std::string trimmed = trimTrailingWhitespace(stdOut);
+    return trimmed.empty() ? fallback : trimmed;
+}
+
+class BisectStartOperation final : public Operation {
+public:
+    explicit BisectStartOperation(BisectStartRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Start bisect"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"bisect", "start"};
+        if (request_.noCheckout) {
+            args.emplace_back("--no-checkout");
+        }
+        if (!request_.badRef.empty()) {
+            args.push_back(request_.badRef);
+        }
+        for (const auto& good : request_.goodRefs) {
+            args.push_back(good);
+        }
+        if (!request_.paths.empty()) {
+            args.emplace_back("--");
+            for (const auto& path : request_.paths) {
+                args.push_back(path);
+            }
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        // May check out the first candidate immediately when bad/good are
+        // both given up front, exactly like an ordinary checkout.
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = summaryOrDescribe(result->out, describe());
+        return outcome;
+    }
+
+private:
+    BisectStartRequest request_;
+};
+
+class BisectMarkOperation final : public Operation {
+public:
+    explicit BisectMarkOperation(BisectMarkRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        std::string label = request_.good ? "Mark good" : "Mark bad";
+        if (!request_.ref.empty()) {
+            label += " " + request_.ref;
+        }
+        return label;
+    }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"bisect", request_.good ? "good" : "bad"};
+        if (!request_.ref.empty()) {
+            args.push_back(request_.ref);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        // Checks out the next candidate (or concludes and checks out the
+        // result), so this is exactly as unbounded as an ordinary checkout.
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = summaryOrDescribe(result->out, describe());
+        return outcome;
+    }
+
+private:
+    BisectMarkRequest request_;
+};
+
+class BisectSkipOperation final : public Operation {
+public:
+    explicit BisectSkipOperation(BisectSkipRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Skip commit"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"bisect", "skip"};
+        for (const auto& ref : request_.refs) {
+            args.push_back(ref);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = summaryOrDescribe(result->out, describe());
+        return outcome;
+    }
+
+private:
+    BisectSkipRequest request_;
+};
+
+class BisectResetOperation final : public Operation {
+public:
+    explicit BisectResetOperation(BisectResetRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "End bisect"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"bisect", "reset"};
+        if (!request_.target.empty()) {
+            args.push_back(request_.target);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);  // restores the work tree.
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    BisectResetRequest request_;
+};
+
+}  // namespace
+
+BisectStore::BisectStore(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<BisectStatus> BisectStore::status(CancellationToken token) {
+    BisectStatus result;
+
+    std::error_code ec;
+    result.active = std::filesystem::exists(paths_.bisectLogFile(), ec);
+    if (!result.active) {
+        return result;
+    }
+
+    GitCommand logCmd(paths_.commandDir(), {"bisect", "log"});
+    logCmd.timeout = std::chrono::seconds(30);
+    auto logResult = runner_.run(logCmd, token);
+    if (!logResult) {
+        return fail(std::move(logResult).error());
+    }
+    result.logText = logResult->out;
+
+    // Every mark -- whether given directly to `bisect start <bad> <good>` or
+    // made afterward with a separate `bisect good`/`bad`/`skip` -- gets a
+    // "# bad: [oid] subject" / "# good: [...]" / "# skip: [...]" comment line
+    // in the log, unlike the "git bisect good <oid>" action line, which only
+    // appears for marks made after start. The comment form is therefore the
+    // one reliable source for both cases. `good` and `skip` accumulate one
+    // entry per commit ever marked that way; `bad` is overwritten by each new
+    // line, which is exactly the narrowest bad boundary known so far.
+    auto extractBracketedOid = [](std::string_view line,
+                                  std::string_view prefix) -> std::optional<std::string> {
+        if (!line.starts_with(prefix)) {
+            return std::nullopt;
+        }
+        const std::string_view rest = line.substr(prefix.size());
+        const std::size_t close = rest.find(']');
+        if (close == std::string_view::npos) {
+            return std::nullopt;
+        }
+        return std::string(rest.substr(0, close));
+    };
+
+    std::size_t start = 0;
+    while (start <= result.logText.size()) {
+        const std::size_t at = result.logText.find('\n', start);
+        const std::string_view line(result.logText.data() + start,
+                                    (at == std::string::npos ? result.logText.size() : at) - start);
+        if (auto badOid = extractBracketedOid(line, "# bad: [")) {
+            result.badOid = *badOid;
+        } else if (auto goodOid = extractBracketedOid(line, "# good: [")) {
+            result.goodOids.push_back(*goodOid);
+        } else if (auto skippedOid = extractBracketedOid(line, "# skip: [")) {
+            result.skippedOids.push_back(*skippedOid);
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+
+    GitCommand headCmd(paths_.commandDir(), {"rev-parse", "HEAD"});
+    headCmd.timeout = std::chrono::seconds(10);
+    if (auto headResult = runner_.run(headCmd, token)) {
+        result.currentOid = headResult->out;
+    }
+
+    return result;
+}
+
+std::unique_ptr<Operation> makeBisectStartOperation(BisectStartRequest request) {
+    return std::make_unique<BisectStartOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeBisectMarkOperation(BisectMarkRequest request) {
+    return std::make_unique<BisectMarkOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeBisectSkipOperation(BisectSkipRequest request) {
+    return std::make_unique<BisectSkipOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeBisectResetOperation(BisectResetRequest request) {
+    return std::make_unique<BisectResetOperation>(std::move(request));
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/BisectOps.h
+++ b/src/core/git/ops/BisectOps.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/git/IProcessRunner.h"
+#include "core/git/OperationRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+/// Current state of a `git bisect` session, read from `BISECT_LOG` rather than
+/// tracked in memory -- same reasoning as RepoState: a bisect survives closing
+/// the app, and a terminal may have advanced it in the meantime.
+struct BisectStatus {
+    bool active = false;
+    std::string currentOid;         ///< HEAD; the commit currently being tested.
+    std::string badOid;             ///< Empty until a bad commit has been marked.
+    std::vector<std::string> goodOids;
+    std::vector<std::string> skippedOids;
+    /// The raw `git bisect log` output, for a "show the log" view; also the
+    /// input `git bisect replay` would need, which this app does not expose.
+    std::string logText;
+};
+
+/// Reads `BISECT_LOG`, read-only like RefStore.
+class BisectStore {
+public:
+    BisectStore(IProcessRunner& runner, RepoPaths paths);
+
+    GitResult<BisectStatus> status(CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+struct BisectStartRequest {
+    /// Both may be empty: `git bisect start` with no revisions is valid and
+    /// simply waits for `good`/`bad` to be given afterward.
+    std::string badRef;
+    std::vector<std::string> goodRefs;
+    /// Limits the bisect to commits touching these paths.
+    std::vector<std::string> paths;
+    /// `--no-checkout`: leaves the work tree alone and only moves `BISECT_HEAD`,
+    /// for repositories too large to check out every candidate.
+    bool noCheckout = false;
+};
+
+struct BisectMarkRequest {
+    bool good = false;  ///< true marks `good`, false marks `bad`.
+    std::string ref;    ///< Empty means the current `HEAD`.
+};
+
+struct BisectSkipRequest {
+    /// Empty skips the current commit (`HEAD`); otherwise these specific revs.
+    std::vector<std::string> refs;
+};
+
+struct BisectResetRequest {
+    /// Empty returns to the branch/commit `git bisect start` was run from.
+    std::string target;
+};
+
+/// `git bisect start [<bad> [<good>...]] [--] [<paths>...]`.
+std::unique_ptr<Operation> makeBisectStartOperation(BisectStartRequest request);
+
+/// `git bisect good|bad [<ref>]`. May conclude the bisect (git prints
+/// "is the first bad commit"), in which case OperationOutcome::summary carries
+/// that message verbatim -- there is no separate "done" signal to poll for.
+std::unique_ptr<Operation> makeBisectMarkOperation(BisectMarkRequest request);
+
+/// `git bisect skip [<refs...>]`, for a commit that cannot be tested.
+std::unique_ptr<Operation> makeBisectSkipOperation(BisectSkipRequest request);
+
+/// `git bisect reset [<target>]`: ends the session and restores the work tree.
+std::unique_ptr<Operation> makeBisectResetOperation(BisectResetRequest request);
+
+}  // namespace gbm

--- a/src/core/git/ops/BisectOps.h
+++ b/src/core/git/ops/BisectOps.h
@@ -17,8 +17,8 @@ namespace gbm {
 /// the app, and a terminal may have advanced it in the meantime.
 struct BisectStatus {
     bool active = false;
-    std::string currentOid;         ///< HEAD; the commit currently being tested.
-    std::string badOid;             ///< Empty until a bad commit has been marked.
+    std::string currentOid;  ///< HEAD; the commit currently being tested.
+    std::string badOid;      ///< Empty until a bad commit has been marked.
     std::vector<std::string> goodOids;
     std::vector<std::string> skippedOids;
     /// The raw `git bisect log` output, for a "show the log" view; also the

--- a/src/core/git/ops/LfsOps.cpp
+++ b/src/core/git/ops/LfsOps.cpp
@@ -1,0 +1,313 @@
+#include "core/git/ops/LfsOps.h"
+
+#include "core/git/AskpassHelper.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+class LfsInstallOperation final : public Operation {
+public:
+    std::string describe() const override { return "Set up Git LFS for this repository"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        GitCommand command(paths.commandDir(), {"lfs", "install", "--local"});
+        command.timeout = std::chrono::seconds(30);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+};
+
+class LfsTrackOperation final : public Operation {
+public:
+    explicit LfsTrackOperation(LfsTrackRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Track " + request_.pattern + " with LFS"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.pattern.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "A pattern is required");
+            return outcome;
+        }
+        GitCommand command(paths.commandDir(), {"lfs", "track", request_.pattern});
+        command.timeout = std::chrono::seconds(30);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    LfsTrackRequest request_;
+};
+
+class LfsUntrackOperation final : public Operation {
+public:
+    explicit LfsUntrackOperation(LfsUntrackRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Untrack " + request_.pattern + " from LFS"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.pattern.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "A pattern is required");
+            return outcome;
+        }
+        GitCommand command(paths.commandDir(), {"lfs", "untrack", request_.pattern});
+        command.timeout = std::chrono::seconds(30);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    LfsUntrackRequest request_;
+};
+
+class LfsPullOperation final : public Operation {
+public:
+    explicit LfsPullOperation(LfsTransferRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Pull LFS objects"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"lfs", "pull"};
+        if (!request_.remoteName.empty()) {
+            args.push_back(request_.remoteName);
+        }
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);  // downloads objects; can be slow.
+        askpass::wire(command, request_.askpassDir);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    LfsTransferRequest request_;
+};
+
+class LfsFetchOperation final : public Operation {
+public:
+    explicit LfsFetchOperation(LfsTransferRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Fetch LFS objects"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"lfs", "fetch"};
+        if (!request_.remoteName.empty()) {
+            args.push_back(request_.remoteName);
+        }
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);
+        askpass::wire(command, request_.askpassDir);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    LfsTransferRequest request_;
+};
+
+class LfsPruneOperation final : public Operation {
+public:
+    explicit LfsPruneOperation(LfsPruneRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Prune old LFS objects"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"lfs", "prune"};
+        if (request_.dryRun) {
+            args.emplace_back("--dry-run");
+        }
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = result->out.empty() ? describe() : result->out;
+        return outcome;
+    }
+
+private:
+    LfsPruneRequest request_;
+};
+
+}  // namespace
+
+GitResult<LfsInstallation> detectLfs(IProcessRunner& runner,
+                                     const RepoPaths& paths,
+                                     CancellationToken token) {
+    GitCommand command(paths.commandDir(), {"lfs", "version"});
+    command.timeout = std::chrono::seconds(10);
+
+    auto result = runner.run(command, token);
+    LfsInstallation installation;
+    if (result) {
+        installation.available = true;
+        installation.version = result->out;
+    }
+    return installation;
+}
+
+LfsStore::LfsStore(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<std::vector<std::string>> LfsStore::trackedPatterns(CancellationToken token) {
+    GitCommand command(paths_.commandDir(), {"lfs", "track"});
+    command.timeout = std::chrono::seconds(30);
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    // "Listing tracked patterns\n    *.psd (.gitattributes)\n    ...\nListing
+    // excluded patterns\n...": each tracked line is indented, and the pattern
+    // is everything before the trailing " (<source file>)".
+    std::vector<std::string> patterns;
+    bool inTrackedSection = false;
+    std::size_t start = 0;
+    while (start <= result->out.size()) {
+        const std::size_t at = result->out.find('\n', start);
+        const std::string_view line(result->out.data() + start,
+                                    (at == std::string::npos ? result->out.size() : at) - start);
+        if (line == "Listing tracked patterns") {
+            inTrackedSection = true;
+        } else if (line == "Listing excluded patterns") {
+            inTrackedSection = false;
+        } else if (inTrackedSection) {
+            std::string_view trimmed = line;
+            while (!trimmed.empty() && trimmed.front() == ' ') {
+                trimmed.remove_prefix(1);
+            }
+            const std::size_t paren = trimmed.rfind(" (");
+            if (!trimmed.empty() && paren != std::string_view::npos) {
+                patterns.emplace_back(trimmed.substr(0, paren));
+            }
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return patterns;
+}
+
+GitResult<std::vector<LfsFileInfo>> LfsStore::listFiles(CancellationToken token) {
+    GitCommand command(paths_.commandDir(), {"lfs", "ls-files", "--long"});
+    command.timeout = std::chrono::seconds(60);
+    auto result = runner_.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    // Each line: "<sha256> <* or -> <path>". The marker is `*` when the real
+    // content is present in local LFS storage, `-` when only the pointer is.
+    std::vector<LfsFileInfo> files;
+    std::size_t start = 0;
+    while (start <= result->out.size()) {
+        const std::size_t at = result->out.find('\n', start);
+        const std::string_view line(result->out.data() + start,
+                                    (at == std::string::npos ? result->out.size() : at) - start);
+        const std::size_t firstSpace = line.find(' ');
+        if (firstSpace != std::string_view::npos && firstSpace + 2 < line.size() &&
+            line[firstSpace + 2] == ' ') {
+            LfsFileInfo info;
+            info.oid = std::string(line.substr(0, firstSpace));
+            info.downloadedLocally = line[firstSpace + 1] == '*';
+            info.path = std::string(line.substr(firstSpace + 3));
+            files.push_back(std::move(info));
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return files;
+}
+
+std::unique_ptr<Operation> makeLfsInstallOperation() {
+    return std::make_unique<LfsInstallOperation>();
+}
+
+std::unique_ptr<Operation> makeLfsTrackOperation(LfsTrackRequest request) {
+    return std::make_unique<LfsTrackOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeLfsUntrackOperation(LfsUntrackRequest request) {
+    return std::make_unique<LfsUntrackOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeLfsPullOperation(LfsTransferRequest request) {
+    return std::make_unique<LfsPullOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeLfsFetchOperation(LfsTransferRequest request) {
+    return std::make_unique<LfsFetchOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeLfsPruneOperation(LfsPruneRequest request) {
+    return std::make_unique<LfsPruneOperation>(std::move(request));
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/LfsOps.h
+++ b/src/core/git/ops/LfsOps.h
@@ -32,7 +32,7 @@ GitResult<LfsInstallation> detectLfs(IProcessRunner& runner,
 
 struct LfsFileInfo {
     std::string path;
-    std::string oid;         ///< Full sha256 pointer oid.
+    std::string oid;                 ///< Full sha256 pointer oid.
     bool downloadedLocally = false;  ///< `*` vs `-` in `git lfs ls-files`.
 };
 

--- a/src/core/git/ops/LfsOps.h
+++ b/src/core/git/ops/LfsOps.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/git/IProcessRunner.h"
+#include "core/git/OperationRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+/// Whether the `git-lfs` extension is on `PATH` at all. Most repositories do
+/// not use LFS, so this is not itself an error condition -- callers branch on
+/// `available` rather than treating a missing extension as a failure, the
+/// same way GitExecutable::isUsable() is checked rather than assumed.
+struct LfsInstallation {
+    bool available = false;
+    std::string version;  ///< Raw `git lfs version` output, e.g. "git-lfs/3.4.1 ...".
+};
+
+/// Runs `git lfs version`. A nonzero exit (git-lfs not installed, or `git`
+/// itself not recognising `lfs` as a subcommand) is reported as
+/// `available = false` rather than a GitResult failure -- this is a capability
+/// probe, not an operation that can meaningfully fail.
+GitResult<LfsInstallation> detectLfs(IProcessRunner& runner,
+                                     const RepoPaths& paths,
+                                     CancellationToken token);
+
+struct LfsFileInfo {
+    std::string path;
+    std::string oid;         ///< Full sha256 pointer oid.
+    bool downloadedLocally = false;  ///< `*` vs `-` in `git lfs ls-files`.
+};
+
+/// Reads tracked patterns and file status; read-only, like RefStore.
+class LfsStore {
+public:
+    LfsStore(IProcessRunner& runner, RepoPaths paths);
+
+    /// `git lfs track` with no arguments: the patterns currently recorded in
+    /// `.gitattributes` (and any nested one), one per `filter=lfs` entry.
+    GitResult<std::vector<std::string>> trackedPatterns(CancellationToken token);
+
+    /// `git lfs ls-files --long`: every path LFS is tracking in the current
+    /// checkout, with its pointer oid and whether the real content has been
+    /// downloaded into local LFS storage.
+    GitResult<std::vector<LfsFileInfo>> listFiles(CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+struct LfsTrackRequest {
+    std::string pattern;  ///< A gitattributes pattern, e.g. "*.psd".
+};
+
+struct LfsUntrackRequest {
+    std::string pattern;
+};
+
+struct LfsTransferRequest {
+    std::string remoteName;  ///< Empty uses the default remote.
+    std::filesystem::path askpassDir;
+};
+
+struct LfsPruneRequest {
+    bool dryRun = false;
+};
+
+/// `git lfs install --local`: wires the repository's smudge/clean filters and
+/// hooks. Scoped to this repository only -- never `--global` -- so it never
+/// touches a user's other repositories or machine-wide config.
+std::unique_ptr<Operation> makeLfsInstallOperation();
+
+/// `git lfs track "<pattern>"`. Editing `.gitattributes` is left to the
+/// caller (stage and commit it like any other working-copy change); this
+/// only records the pattern.
+std::unique_ptr<Operation> makeLfsTrackOperation(LfsTrackRequest request);
+
+/// `git lfs untrack "<pattern>"`.
+std::unique_ptr<Operation> makeLfsUntrackOperation(LfsUntrackRequest request);
+
+/// `git lfs pull [<remote>]`: fetches and checks out the LFS objects the
+/// current checkout's pointers reference.
+std::unique_ptr<Operation> makeLfsPullOperation(LfsTransferRequest request);
+
+/// `git lfs fetch [<remote>]`: downloads objects without touching the work tree.
+std::unique_ptr<Operation> makeLfsFetchOperation(LfsTransferRequest request);
+
+/// `git lfs prune [--dry-run]`: deletes old LFS objects from local storage
+/// that are no longer needed by any local ref.
+std::unique_ptr<Operation> makeLfsPruneOperation(LfsPruneRequest request);
+
+}  // namespace gbm

--- a/src/core/git/ops/PatchOps.cpp
+++ b/src/core/git/ops/PatchOps.cpp
@@ -157,6 +157,7 @@ public:
     std::string describe() const override { return "Continue applying patches"; }
 
     bool killableMidFlight() const override { return false; }
+
     bool allowedDuringSequencerOperation() const override { return true; }
 
     OperationOutcome run(IProcessRunner& runner,
@@ -183,6 +184,7 @@ public:
     std::string describe() const override { return "Skip patch"; }
 
     bool killableMidFlight() const override { return false; }
+
     bool allowedDuringSequencerOperation() const override { return true; }
 
     OperationOutcome run(IProcessRunner& runner,
@@ -209,6 +211,7 @@ public:
     std::string describe() const override { return "Abort patch import"; }
 
     bool killableMidFlight() const override { return false; }
+
     bool allowedDuringSequencerOperation() const override { return true; }
 
     OperationOutcome run(IProcessRunner& runner,

--- a/src/core/git/ops/PatchOps.cpp
+++ b/src/core/git/ops/PatchOps.cpp
@@ -1,0 +1,259 @@
+#include "core/git/ops/PatchOps.h"
+
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+class ExportPatchesOperation final : public Operation {
+public:
+    explicit ExportPatchesOperation(ExportPatchesRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        return "Export " + std::to_string(request_.commits.size()) + " patch(es)";
+    }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.commits.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "No commits selected");
+            return outcome;
+        }
+        if (request_.outputDir.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "No output folder chosen");
+            return outcome;
+        }
+
+        for (std::size_t i = 0; i < request_.commits.size(); ++i) {
+            if (token.isCancelled()) {
+                outcome.error = cancelled().error();
+                return outcome;
+            }
+            GitCommand command(paths.commandDir(),
+                               {"format-patch",
+                                "-1",
+                                request_.commits[i].hex(),
+                                "--start-number",
+                                std::to_string(i + 1),
+                                "-o",
+                                request_.outputDir.string()});
+            command.timeout = std::chrono::seconds(60);
+
+            auto result = runner.run(command, token);
+            if (!result) {
+                outcome.error = std::move(result).error();
+                outcome.summary = outcome.error->message;
+                return outcome;
+            }
+        }
+        outcome.succeeded = true;
+        outcome.summary = std::to_string(request_.commits.size()) + " patch(es) written to " +
+                          request_.outputDir.string();
+        return outcome;
+    }
+
+private:
+    ExportPatchesRequest request_;
+};
+
+class ApplyPatchFilesOperation final : public Operation {
+public:
+    explicit ApplyPatchFilesOperation(ApplyPatchFilesRequest request)
+        : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Apply patch"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.patchFiles.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "No patch file chosen");
+            return outcome;
+        }
+
+        std::vector<std::string> args{"apply"};
+        if (request_.threeWay) {
+            args.emplace_back("--3way");
+        }
+        if (request_.updateIndex) {
+            args.emplace_back("--index");
+        }
+        for (const auto& file : request_.patchFiles) {
+            args.push_back(file.string());
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::seconds(60);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    ApplyPatchFilesRequest request_;
+};
+
+class ImportPatchesOperation final : public Operation {
+public:
+    explicit ImportPatchesOperation(ImportPatchesRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override {
+        return "Import " + std::to_string(request_.patchFiles.size()) + " patch(es)";
+    }
+
+    /// A conflicted patch leaves `git am` mid-sequence, exactly like a
+    /// conflicted rebase or cherry-pick; killing the process would leave that
+    /// state half-written.
+    bool killableMidFlight() const override { return false; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.patchFiles.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "No patch file chosen");
+            return outcome;
+        }
+
+        std::vector<std::string> args{"am"};
+        if (request_.threeWay) {
+            args.emplace_back("--3way");
+        }
+        for (const auto& file : request_.patchFiles) {
+            args.push_back(file.string());
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    ImportPatchesRequest request_;
+};
+
+class AmContinueOperation final : public Operation {
+public:
+    std::string describe() const override { return "Continue applying patches"; }
+
+    bool killableMidFlight() const override { return false; }
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        GitCommand command(paths.commandDir(), {"am", "--continue"});
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+};
+
+class AmSkipOperation final : public Operation {
+public:
+    std::string describe() const override { return "Skip patch"; }
+
+    bool killableMidFlight() const override { return false; }
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        GitCommand command(paths.commandDir(), {"am", "--skip"});
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+};
+
+class AmAbortOperation final : public Operation {
+public:
+    std::string describe() const override { return "Abort patch import"; }
+
+    bool killableMidFlight() const override { return false; }
+    bool allowedDuringSequencerOperation() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        GitCommand command(paths.commandDir(), {"am", "--abort"});
+        command.timeout = std::chrono::seconds(120);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+};
+
+}  // namespace
+
+std::unique_ptr<Operation> makeExportPatchesOperation(ExportPatchesRequest request) {
+    return std::make_unique<ExportPatchesOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeApplyPatchFilesOperation(ApplyPatchFilesRequest request) {
+    return std::make_unique<ApplyPatchFilesOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeImportPatchesOperation(ImportPatchesRequest request) {
+    return std::make_unique<ImportPatchesOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeAmContinueOperation() {
+    return std::make_unique<AmContinueOperation>();
+}
+
+std::unique_ptr<Operation> makeAmSkipOperation() {
+    return std::make_unique<AmSkipOperation>();
+}
+
+std::unique_ptr<Operation> makeAmAbortOperation() {
+    return std::make_unique<AmAbortOperation>();
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/PatchOps.h
+++ b/src/core/git/ops/PatchOps.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "core/base/ObjectId.h"
+#include "core/git/OperationRunner.h"
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace gbm {
+
+struct ExportPatchesRequest {
+    /// Oldest first, same convention as CherryPickRequest::commits -- a single
+    /// commit is a one-element list, a range is this same list after the
+    /// caller has expanded it with RefStore::resolveRange.
+    std::vector<ObjectId> commits;
+    std::filesystem::path outputDir;
+};
+
+/// `git format-patch -1 <commit> --start-number <n> -o <dir>`, once per commit
+/// in order. One call per commit rather than a single range invocation, so an
+/// arbitrary (not necessarily contiguous) selection can be exported exactly
+/// like it can be cherry-picked; `--start-number` keeps the filenames in the
+/// caller's order instead of each call resetting to 0001 and overwriting the
+/// last one.
+std::unique_ptr<Operation> makeExportPatchesOperation(ExportPatchesRequest request);
+
+struct ApplyPatchFilesRequest {
+    std::vector<std::filesystem::path> patchFiles;
+    /// `--3way`: falls back to a merge (leaving conflict markers) instead of
+    /// refusing outright when the patch does not apply cleanly.
+    bool threeWay = false;
+    /// `--index`: also stages the result, not just the work tree.
+    bool updateIndex = false;
+};
+
+/// `git apply`: applies a plain diff without creating a commit. For a patch
+/// produced by `format-patch` and its commit metadata, see the `am` family
+/// below instead.
+std::unique_ptr<Operation> makeApplyPatchFilesOperation(ApplyPatchFilesRequest request);
+
+struct ImportPatchesRequest {
+    std::vector<std::filesystem::path> patchFiles;
+    /// `--3way`: same fallback as ApplyPatchFilesRequest::threeWay.
+    bool threeWay = false;
+};
+
+/// `git am`: applies one or more `format-patch`-style patches as commits,
+/// preserving author, date and message. Like `rebase`/`cherry-pick`, a patch
+/// that does not apply stops the sequence; see makeAmContinueOperation et al.
+/// `git am` shares its on-disk state directory with the old-style
+/// `rebase --apply` backend (RepoState::RebaseApply covers both), but the two
+/// are not interchangeable: continuing an `am` needs `git am --continue`, not
+/// `git rebase --continue`, so it gets its own continue/skip/abort here rather
+/// than reusing RebaseOps.
+std::unique_ptr<Operation> makeImportPatchesOperation(ImportPatchesRequest request);
+
+/// `git am --continue`, once the conflicted patch's resolution is staged.
+std::unique_ptr<Operation> makeAmContinueOperation();
+
+/// `git am --skip`: drops the current patch and moves on to the next queued.
+std::unique_ptr<Operation> makeAmSkipOperation();
+
+/// `git am --abort`: unwinds back to before the patch series started.
+std::unique_ptr<Operation> makeAmAbortOperation();
+
+}  // namespace gbm

--- a/src/core/git/ops/SubmoduleOps.cpp
+++ b/src/core/git/ops/SubmoduleOps.cpp
@@ -30,7 +30,8 @@ public:
                          CancellationToken token) override {
         OperationOutcome outcome;
         if (request_.url.empty()) {
-            outcome.error = GitError(GitError::Code::InvalidArgument, "A submodule URL is required");
+            outcome.error =
+                GitError(GitError::Code::InvalidArgument, "A submodule URL is required");
             return outcome;
         }
 
@@ -65,7 +66,8 @@ private:
 
 class InitSubmodulesOperation final : public Operation {
 public:
-    explicit InitSubmodulesOperation(SubmodulePathsRequest request) : request_(std::move(request)) {}
+    explicit InitSubmodulesOperation(SubmodulePathsRequest request)
+        : request_(std::move(request)) {}
 
     std::string describe() const override { return "Initialise submodules"; }
 
@@ -138,7 +140,8 @@ private:
 
 class SyncSubmodulesOperation final : public Operation {
 public:
-    explicit SyncSubmodulesOperation(SubmodulePathsRequest request) : request_(std::move(request)) {}
+    explicit SyncSubmodulesOperation(SubmodulePathsRequest request)
+        : request_(std::move(request)) {}
 
     std::string describe() const override { return "Sync submodule URLs"; }
 
@@ -224,6 +227,7 @@ GitResult<std::vector<SubmoduleInfo>> SubmoduleStore::list(CancellationToken tok
         std::string url;
         std::string branch;
     };
+
     // Keyed by path: `.gitmodules` sections are keyed by name, but that name is
     // usually (not always) equal to the path, so parsing keys off the `.path`
     // entry each section declares rather than assuming name == path.
@@ -231,11 +235,12 @@ GitResult<std::vector<SubmoduleInfo>> SubmoduleStore::list(CancellationToken tok
 
     {
         std::error_code ec;
-        const bool hasGitmodules =
-            !paths_.workDir().empty() && std::filesystem::exists(paths_.workDir() / ".gitmodules", ec);
+        const bool hasGitmodules = !paths_.workDir().empty() &&
+                                   std::filesystem::exists(paths_.workDir() / ".gitmodules", ec);
         if (hasGitmodules) {
-            GitCommand configCmd(paths_.commandDir(),
-                                 {"config", "--file", ".gitmodules", "--get-regexp", "^submodule\\."});
+            GitCommand configCmd(
+                paths_.commandDir(),
+                {"config", "--file", ".gitmodules", "--get-regexp", "^submodule\\."});
             configCmd.timeout = std::chrono::seconds(30);
             auto configResult = runner_.run(configCmd, token);
             if (configResult) {
@@ -317,9 +322,9 @@ GitResult<std::vector<SubmoduleInfo>> SubmoduleStore::list(CancellationToken tok
                 info.headOid = std::string(rest.substr(0, sp));
                 std::string_view pathAndDescribe = rest.substr(sp + 1);
                 const std::size_t paren = pathAndDescribe.rfind(" (");
-                info.path = std::string(paren == std::string_view::npos
-                                            ? pathAndDescribe
-                                            : pathAndDescribe.substr(0, paren));
+                info.path =
+                    std::string(paren == std::string_view::npos ? pathAndDescribe
+                                                                : pathAndDescribe.substr(0, paren));
                 switch (statusChar) {
                     case '-':
                         info.state = SubmoduleInfo::State::NotInitialized;

--- a/src/core/git/ops/SubmoduleOps.cpp
+++ b/src/core/git/ops/SubmoduleOps.cpp
@@ -1,0 +1,375 @@
+#include "core/git/ops/SubmoduleOps.h"
+
+#include "core/git/AskpassHelper.h"
+
+#include <unordered_map>
+#include <utility>
+
+namespace gbm {
+
+namespace {
+
+void appendPathsArgs(std::vector<std::string>& args, const std::vector<std::string>& paths) {
+    if (paths.empty()) {
+        return;
+    }
+    args.emplace_back("--");
+    for (const auto& path : paths) {
+        args.push_back(path);
+    }
+}
+
+class AddSubmoduleOperation final : public Operation {
+public:
+    explicit AddSubmoduleOperation(AddSubmoduleRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Add submodule " + request_.url; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.url.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "A submodule URL is required");
+            return outcome;
+        }
+
+        std::vector<std::string> args{"submodule", "add"};
+        if (!request_.branch.empty()) {
+            args.emplace_back("-b");
+            args.push_back(request_.branch);
+        }
+        args.push_back(request_.url);
+        if (!request_.path.empty()) {
+            args.push_back(request_.path);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);  // clones a remote; can be slow.
+        askpass::wire(command, request_.askpassDir);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    AddSubmoduleRequest request_;
+};
+
+class InitSubmodulesOperation final : public Operation {
+public:
+    explicit InitSubmodulesOperation(SubmodulePathsRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Initialise submodules"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"submodule", "init"};
+        appendPathsArgs(args, request_.paths);
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::seconds(60);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    SubmodulePathsRequest request_;
+};
+
+class UpdateSubmodulesOperation final : public Operation {
+public:
+    explicit UpdateSubmodulesOperation(UpdateSubmodulesRequest request)
+        : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Update submodules"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"submodule", "update"};
+        if (request_.init) {
+            args.emplace_back("--init");
+        }
+        if (request_.recursive) {
+            args.emplace_back("--recursive");
+        }
+        if (request_.remote) {
+            args.emplace_back("--remote");
+        }
+        appendPathsArgs(args, request_.paths);
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::milliseconds(0);  // clones/fetches; can be slow.
+        askpass::wire(command, request_.askpassDir);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    UpdateSubmodulesRequest request_;
+};
+
+class SyncSubmodulesOperation final : public Operation {
+public:
+    explicit SyncSubmodulesOperation(SubmodulePathsRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Sync submodule URLs"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"submodule", "sync"};
+        if (request_.recursive) {
+            args.emplace_back("--recursive");
+        }
+        appendPathsArgs(args, request_.paths);
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::seconds(60);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    SubmodulePathsRequest request_;
+};
+
+class DeinitSubmodulesOperation final : public Operation {
+public:
+    explicit DeinitSubmodulesOperation(DeinitSubmodulesRequest request)
+        : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Deinitialise submodules"; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        std::vector<std::string> args{"submodule", "deinit"};
+        if (request_.force) {
+            args.emplace_back("-f");
+        }
+        if (request_.paths.empty()) {
+            // `git submodule deinit` refuses a bare invocation with no pathspec
+            // and no `--all`, unlike init/update/sync, which default to every
+            // submodule -- so the "every submodule" case needs the flag spelled
+            // out explicitly here.
+            args.emplace_back("--all");
+        } else {
+            appendPathsArgs(args, request_.paths);
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        command.timeout = std::chrono::seconds(60);
+
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    DeinitSubmodulesRequest request_;
+};
+
+}  // namespace
+
+SubmoduleStore::SubmoduleStore(IProcessRunner& runner, RepoPaths paths)
+    : runner_(runner), paths_(std::move(paths)) {}
+
+GitResult<std::vector<SubmoduleInfo>> SubmoduleStore::list(CancellationToken token) {
+    struct Declared {
+        std::string name;
+        std::string url;
+        std::string branch;
+    };
+    // Keyed by path: `.gitmodules` sections are keyed by name, but that name is
+    // usually (not always) equal to the path, so parsing keys off the `.path`
+    // entry each section declares rather than assuming name == path.
+    std::unordered_map<std::string, Declared> byPath;
+
+    {
+        std::error_code ec;
+        const bool hasGitmodules =
+            !paths_.workDir().empty() && std::filesystem::exists(paths_.workDir() / ".gitmodules", ec);
+        if (hasGitmodules) {
+            GitCommand configCmd(paths_.commandDir(),
+                                 {"config", "--file", ".gitmodules", "--get-regexp", "^submodule\\."});
+            configCmd.timeout = std::chrono::seconds(30);
+            auto configResult = runner_.run(configCmd, token);
+            if (configResult) {
+                // Each line is "submodule.<name>.<key> <value>"; <name> may itself
+                // contain dots, so the key is split from the right, not the left.
+                static constexpr std::string_view kPrefix = "submodule.";
+                std::unordered_map<std::string, Declared> byName;
+                std::size_t start = 0;
+                while (start <= configResult->out.size()) {
+                    const std::size_t at = configResult->out.find('\n', start);
+                    const std::string_view line(
+                        configResult->out.data() + start,
+                        (at == std::string::npos ? configResult->out.size() : at) - start);
+                    const std::size_t sp = line.find(' ');
+                    if (sp != std::string_view::npos && line.starts_with(kPrefix)) {
+                        const std::string_view key = line.substr(0, sp);
+                        const std::string_view value = line.substr(sp + 1);
+                        const std::string_view withoutPrefix = key.substr(kPrefix.size());
+                        const std::size_t lastDot = withoutPrefix.rfind('.');
+                        if (lastDot != std::string_view::npos) {
+                            const std::string name(withoutPrefix.substr(0, lastDot));
+                            const std::string_view attr = withoutPrefix.substr(lastDot + 1);
+                            Declared& entry = byName[name];
+                            entry.name = name;
+                            if (attr == "url") {
+                                entry.url = std::string(value);
+                            } else if (attr == "branch") {
+                                entry.branch = std::string(value);
+                            } else if (attr == "path") {
+                                byPath[std::string(value)] = entry;
+                            }
+                        }
+                    }
+                    if (at == std::string::npos) {
+                        break;
+                    }
+                    start = at + 1;
+                }
+                // A second pass so url/branch entries seen after path are not
+                // dropped, since the map above snapshots `entry` at path-time.
+                for (auto& [path, declared] : byPath) {
+                    auto found = byName.find(declared.name);
+                    if (found != byName.end()) {
+                        declared.url = found->second.url;
+                        declared.branch = found->second.branch;
+                    }
+                }
+            }
+            // A malformed .gitmodules is not fatal to listing status below; the
+            // submodule simply shows up with no url/branch metadata attached.
+        }
+    }
+
+    GitCommand statusCmd(paths_.commandDir(), {"submodule", "status"});
+    statusCmd.timeout = std::chrono::seconds(120);
+    auto statusResult = runner_.run(statusCmd, token);
+    if (!statusResult) {
+        return fail(std::move(statusResult).error());
+    }
+
+    // Each line: a one-character status prefix, a 40-(or more, for sha256)
+    // character oid, a space, the path, and an optional " (<describe>)" suffix
+    // that is dropped here -- this is the same "Would remove " prefix-matching
+    // leniency CleanPreviewer uses, since `git submodule status` has no
+    // `--porcelain` form to parse instead.
+    std::vector<SubmoduleInfo> infos;
+    std::size_t start = 0;
+    while (start <= statusResult->out.size()) {
+        const std::size_t at = statusResult->out.find('\n', start);
+        const std::string_view line(
+            statusResult->out.data() + start,
+            (at == std::string::npos ? statusResult->out.size() : at) - start);
+        if (line.size() > 1) {
+            const char statusChar = line.front();
+            std::string_view rest = line.substr(1);
+            const std::size_t sp = rest.find(' ');
+            if (sp != std::string_view::npos) {
+                SubmoduleInfo info;
+                info.headOid = std::string(rest.substr(0, sp));
+                std::string_view pathAndDescribe = rest.substr(sp + 1);
+                const std::size_t paren = pathAndDescribe.rfind(" (");
+                info.path = std::string(paren == std::string_view::npos
+                                            ? pathAndDescribe
+                                            : pathAndDescribe.substr(0, paren));
+                switch (statusChar) {
+                    case '-':
+                        info.state = SubmoduleInfo::State::NotInitialized;
+                        break;
+                    case '+':
+                        info.state = SubmoduleInfo::State::Modified;
+                        break;
+                    case 'U':
+                        info.state = SubmoduleInfo::State::Conflicted;
+                        break;
+                    default:
+                        info.state = SubmoduleInfo::State::UpToDate;
+                        break;
+                }
+                if (auto found = byPath.find(info.path); found != byPath.end()) {
+                    info.name = found->second.name;
+                    info.url = found->second.url;
+                    info.branch = found->second.branch;
+                } else {
+                    info.name = info.path;
+                }
+                infos.push_back(std::move(info));
+            }
+        }
+        if (at == std::string::npos) {
+            break;
+        }
+        start = at + 1;
+    }
+    return infos;
+}
+
+std::unique_ptr<Operation> makeAddSubmoduleOperation(AddSubmoduleRequest request) {
+    return std::make_unique<AddSubmoduleOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeInitSubmodulesOperation(SubmodulePathsRequest request) {
+    return std::make_unique<InitSubmodulesOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeUpdateSubmodulesOperation(UpdateSubmodulesRequest request) {
+    return std::make_unique<UpdateSubmodulesOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeSyncSubmodulesOperation(SubmodulePathsRequest request) {
+    return std::make_unique<SyncSubmodulesOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeDeinitSubmodulesOperation(DeinitSubmodulesRequest request) {
+    return std::make_unique<DeinitSubmodulesOperation>(std::move(request));
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/SubmoduleOps.h
+++ b/src/core/git/ops/SubmoduleOps.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/git/IProcessRunner.h"
+#include "core/git/OperationRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace gbm {
+
+struct SubmoduleInfo {
+    std::string name;  ///< The `.gitmodules` section name; usually equal to `path`.
+    std::string path;
+    std::string url;
+    std::string branch;  ///< `submodule.<name>.branch`, if configured; empty otherwise.
+    std::string headOid;  ///< The commit currently recorded, from `git submodule status`.
+
+    enum class State {
+        /// Listed in `.gitmodules` but never `git submodule init`-ed / cloned.
+        NotInitialized,
+        /// Checked-out commit matches what the superproject's index records.
+        UpToDate,
+        /// Checked-out commit differs from the index (`+` in `git submodule status`).
+        Modified,
+        /// Merge conflict in the submodule's recorded commit (`U`).
+        Conflicted,
+    };
+    State state = State::UpToDate;
+};
+
+/// Reads `.gitmodules` plus `git submodule status`, read-only like RefStore.
+class SubmoduleStore {
+public:
+    SubmoduleStore(IProcessRunner& runner, RepoPaths paths);
+
+    GitResult<std::vector<SubmoduleInfo>> list(CancellationToken token);
+
+private:
+    IProcessRunner& runner_;
+    RepoPaths paths_;
+};
+
+struct AddSubmoduleRequest {
+    std::string url;
+    std::string path;  ///< Empty lets git derive it from the URL, same as the CLI.
+    std::string branch;
+    std::filesystem::path askpassDir;
+};
+
+/// One or more submodule paths; empty means "every submodule", matching the
+/// bare `git submodule <verb>` with no pathspec.
+struct SubmodulePathsRequest {
+    std::vector<std::string> paths;
+    bool recursive = false;
+};
+
+struct UpdateSubmodulesRequest {
+    std::vector<std::string> paths;
+    bool recursive = false;
+    bool init = false;  ///< `--init`: also initialise submodules never checked out.
+    /// `--remote`: update to the remote-tracking branch tip instead of the
+    /// commit recorded in the superproject's index.
+    bool remote = false;
+    std::filesystem::path askpassDir;
+};
+
+struct DeinitSubmodulesRequest {
+    std::vector<std::string> paths;
+    /// `--force`: discards local modifications inside the submodule's work tree.
+    /// Only ever set after the user has already been told what that means,
+    /// same contract as every other `force` in this codebase.
+    bool force = false;
+};
+
+/// `git submodule add [-b <branch>] <url> [<path>]`.
+std::unique_ptr<Operation> makeAddSubmoduleOperation(AddSubmoduleRequest request);
+
+/// `git submodule init [--] <paths...>`. Copies the recorded URL into local
+/// config; does not clone anything by itself.
+std::unique_ptr<Operation> makeInitSubmodulesOperation(SubmodulePathsRequest request);
+
+/// `git submodule update [--init] [--recursive] [--remote] [--] <paths...>`.
+std::unique_ptr<Operation> makeUpdateSubmodulesOperation(UpdateSubmodulesRequest request);
+
+/// `git submodule sync [--recursive] [--] <paths...>`: re-copies the URL from
+/// `.gitmodules` into local config, for when it changed upstream.
+std::unique_ptr<Operation> makeSyncSubmodulesOperation(SubmodulePathsRequest request);
+
+/// `git submodule deinit [-f] [--] <paths...>`: empties the submodule's work
+/// tree and removes its local config, leaving `.gitmodules` untouched.
+std::unique_ptr<Operation> makeDeinitSubmodulesOperation(DeinitSubmodulesRequest request);
+
+}  // namespace gbm

--- a/src/core/git/ops/SubmoduleOps.h
+++ b/src/core/git/ops/SubmoduleOps.h
@@ -17,7 +17,7 @@ struct SubmoduleInfo {
     std::string name;  ///< The `.gitmodules` section name; usually equal to `path`.
     std::string path;
     std::string url;
-    std::string branch;  ///< `submodule.<name>.branch`, if configured; empty otherwise.
+    std::string branch;   ///< `submodule.<name>.branch`, if configured; empty otherwise.
     std::string headOid;  ///< The commit currently recorded, from `git submodule status`.
 
     enum class State {

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -2442,6 +2442,13 @@ TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
     }
 
     bool concluded = false;
+    // Diagnostic trail for the assertion below: this test has failed on the
+    // Windows and macOS CI runners (both on git 2.55.x) in a way that has not
+    // reproduced locally (git 2.43.0) across 30 repeated runs, so if it fails
+    // again the exact per-step data is what is needed to root-cause it rather
+    // than guess again -- what commit was actually tested, what `git bisect`
+    // actually printed, and the full log, at every step.
+    std::string trail;
     for (int i = 0; i < 10 && !concluded; ++i) {
         auto current = store.status(CancellationToken{});
         ASSERT_TRUE(current) << current.error().message;
@@ -2455,6 +2462,15 @@ TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
         auto markOutcome = submitAndWait(operations, makeBisectMarkOperation(mark));
         ASSERT_TRUE(markOutcome.succeeded) << (markOutcome.error ? markOutcome.error->detail : "");
 
+        auto afterMark = store.status(CancellationToken{});
+        ASSERT_TRUE(afterMark) << afterMark.error().message;
+        trail += "step " + std::to_string(i) + ": tested c" + std::to_string(commitNumber) + " (" +
+                 current->currentOid.substr(0, 10) + "), marked " + (mark.good ? "good" : "bad") +
+                 "; markOutcome.summary=[" + markOutcome.summary +
+                 "]; afterMark.active=" + (afterMark->active ? "true" : "false") +
+                 "; afterMark.currentOid=" + afterMark->currentOid.substr(0, 10) +
+                 "; afterMark.badOid=" + afterMark->badOid.substr(0, 10) + "\n";
+
         // Not `markOutcome.summary.find("is the first bad commit")`: that is
         // `git bisect`'s human-readable stdout message, and it turned out not
         // to be a stable string to match on across git versions/locales --
@@ -2462,11 +2478,11 @@ TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
         // runners while passing on Linux. `# first bad commit: [` is the
         // machine-readable marker `git bisect log`/`replay` themselves rely
         // on, so it is the actual stable contract to depend on here.
-        auto afterMark = store.status(CancellationToken{});
-        ASSERT_TRUE(afterMark) << afterMark.error().message;
         concluded = afterMark->logText.find("# first bad commit: [") != std::string::npos;
     }
-    ASSERT_TRUE(concluded) << "bisect did not conclude within 10 steps";
+    ASSERT_TRUE(concluded) << "bisect did not conclude within 10 steps\n"
+                           << trail << "\nfull log:\n"
+                           << store.status(CancellationToken{})->logText;
 
     auto finalStatus = store.status(CancellationToken{});
     ASSERT_TRUE(finalStatus) << finalStatus.error().message;

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -29,6 +29,7 @@
 #include "core/git/ops/ResetOps.h"
 #include "core/git/ops/StageOps.h"
 #include "core/git/ops/StashOps.h"
+#include "core/git/ops/SubmoduleOps.h"
 #include "core/git/ops/TagOps.h"
 #include "core/git/ops/UndoOps.h"
 #include "core/git/ops/WorktreeOps.h"
@@ -72,11 +73,27 @@ protected:
         ASSERT_TRUE(run({"config", "user.email", "test@example.invalid"}));
         ASSERT_TRUE(run({"config", "user.name", "Test"}));
         ASSERT_TRUE(run({"config", "commit.gpgsign", "false"}));
+        // Git refuses a submodule's recursive clone over the plain `file`
+        // transport by default since CVE-2022-39253, and deliberately will not
+        // honour a repo-local config override for it -- otherwise a malicious
+        // repository could just grant itself the permission. The M5 submodule
+        // tests below use a sibling directory as the submodule URL, so this is
+        // relaxed process-wide for the test binary, the same way git's own test
+        // suite does it (GIT_ALLOW_PROTOCOL) rather than by touching global git
+        // config. The app itself never sets this.
+#ifdef _WIN32
+        _putenv_s("GIT_ALLOW_PROTOCOL", "file:git:http:https:ssh");
+#else
+        setenv("GIT_ALLOW_PROTOCOL", "file:git:http:https:ssh", 1);
+#endif
     }
 
     void TearDown() override {
         std::error_code ec;
         std::filesystem::remove_all(repo_, ec);
+        for (const auto& extra : extraDirs_) {
+            std::filesystem::remove_all(extra, ec);
+        }
     }
 
     GitResult<ProcessResult> run(std::vector<std::string> args) {
@@ -137,10 +154,38 @@ protected:
         return oids;
     }
 
+    /// A second, independent repository with one commit, for tests that add it
+    /// as a submodule of `repo_`. A plain filesystem path is a valid submodule
+    /// URL, so no server or `file://` scheme is needed.
+    std::filesystem::path makeSourceRepo(const std::string& suffix) {
+        const std::filesystem::path source = repo_.string() + suffix;
+        std::filesystem::remove_all(source);
+        std::filesystem::create_directories(source);
+
+        GitCommand init(source, {"init", "--quiet", "--initial-branch=main"});
+        init.timeout = std::chrono::seconds(30);
+        EXPECT_TRUE(runner_->run(init, CancellationToken{}));
+        GitCommand email(source, {"config", "user.email", "test@example.invalid"});
+        EXPECT_TRUE(runner_->run(email, CancellationToken{}));
+        GitCommand name(source, {"config", "user.name", "Test"});
+        EXPECT_TRUE(runner_->run(name, CancellationToken{}));
+
+        std::ofstream out(source / "readme.txt");
+        out << "source\n";
+        out.close();
+        GitCommand add(source, {"add", "readme.txt"});
+        EXPECT_TRUE(runner_->run(add, CancellationToken{}));
+        GitCommand commit(source, {"commit", "--quiet", "-m", "initial"});
+        EXPECT_TRUE(runner_->run(commit, CancellationToken{}));
+        extraDirs_.push_back(source);
+        return source;
+    }
+
     static GitInstallation installation_;
     std::filesystem::path repo_;
     std::unique_ptr<IProcessRunner> runner_;
     RepoPaths paths_;
+    std::vector<std::filesystem::path> extraDirs_;
 };
 
 GitInstallation RealRepoTest::installation_;
@@ -2252,6 +2297,114 @@ TEST_F(RealRepoTest, UndoRefusesAfterSwitchingToADifferentBranch) {
     EXPECT_FALSE(outcome.succeeded);
     ASSERT_TRUE(outcome.error.has_value());
     EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
+}
+
+// --- M5: submodules ------------------------------------------------------
+
+TEST_F(RealRepoTest, AddingASubmoduleClonesItAndListsItUpToDate) {
+    commitFile("a.txt", "1\n", "c1");
+    const std::filesystem::path source = makeSourceRepo("-sub-add");
+
+    OperationRunner operations(*runner_, paths_);
+    AddSubmoduleRequest request;
+    request.url = source.string();
+    request.path = "vendor/sub";
+    auto outcome = submitAndWait(operations, makeAddSubmoduleOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "vendor" / "sub" / "readme.txt"));
+    EXPECT_TRUE(std::filesystem::exists(repo_ / ".gitmodules"));
+
+    SubmoduleStore store(*runner_, paths_);
+    auto list = store.list(CancellationToken{});
+    ASSERT_TRUE(list) << list.error().message;
+    ASSERT_EQ(list->size(), 1u);
+    EXPECT_EQ((*list)[0].path, "vendor/sub");
+    EXPECT_EQ((*list)[0].url, source.string());
+    EXPECT_EQ((*list)[0].state, SubmoduleInfo::State::UpToDate);
+    EXPECT_FALSE((*list)[0].headOid.empty());
+}
+
+TEST_F(RealRepoTest, DeinitLeavesTheSubmoduleNotInitialized) {
+    commitFile("a.txt", "1\n", "c1");
+    const std::filesystem::path source = makeSourceRepo("-sub-deinit");
+
+    OperationRunner operations(*runner_, paths_);
+    AddSubmoduleRequest add;
+    add.url = source.string();
+    add.path = "sub";
+    ASSERT_TRUE(submitAndWait(operations, makeAddSubmoduleOperation(add)).succeeded);
+
+    DeinitSubmodulesRequest deinit;
+    deinit.paths = {"sub"};
+    deinit.force = true;
+    auto outcome = submitAndWait(operations, makeDeinitSubmodulesOperation(deinit));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    EXPECT_FALSE(std::filesystem::exists(repo_ / "sub" / "readme.txt"))
+        << "deinit must empty the submodule's work tree";
+
+    SubmoduleStore store(*runner_, paths_);
+    auto list = store.list(CancellationToken{});
+    ASSERT_TRUE(list) << list.error().message;
+    ASSERT_EQ(list->size(), 1u);
+    EXPECT_EQ((*list)[0].state, SubmoduleInfo::State::NotInitialized);
+}
+
+TEST_F(RealRepoTest, InitAndUpdateBringABackADeinitializedSubmodule) {
+    commitFile("a.txt", "1\n", "c1");
+    const std::filesystem::path source = makeSourceRepo("-sub-reinit");
+
+    OperationRunner operations(*runner_, paths_);
+    AddSubmoduleRequest add;
+    add.url = source.string();
+    add.path = "sub";
+    ASSERT_TRUE(submitAndWait(operations, makeAddSubmoduleOperation(add)).succeeded);
+
+    DeinitSubmodulesRequest deinit;
+    deinit.paths = {"sub"};
+    deinit.force = true;
+    ASSERT_TRUE(submitAndWait(operations, makeDeinitSubmodulesOperation(deinit)).succeeded);
+
+    SubmodulePathsRequest init;
+    init.paths = {"sub"};
+    ASSERT_TRUE(submitAndWait(operations, makeInitSubmodulesOperation(init)).succeeded);
+
+    UpdateSubmodulesRequest update;
+    update.paths = {"sub"};
+    auto outcome = submitAndWait(operations, makeUpdateSubmodulesOperation(update));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "sub" / "readme.txt"));
+
+    SubmoduleStore store(*runner_, paths_);
+    auto list = store.list(CancellationToken{});
+    ASSERT_TRUE(list) << list.error().message;
+    ASSERT_EQ(list->size(), 1u);
+    EXPECT_EQ((*list)[0].state, SubmoduleInfo::State::UpToDate);
+}
+
+TEST_F(RealRepoTest, SyncSubmodulesRewritesTheLocalUrlFromGitmodules) {
+    commitFile("a.txt", "1\n", "c1");
+    const std::filesystem::path source = makeSourceRepo("-sub-sync");
+
+    OperationRunner operations(*runner_, paths_);
+    AddSubmoduleRequest add;
+    add.url = source.string();
+    add.path = "sub";
+    ASSERT_TRUE(submitAndWait(operations, makeAddSubmoduleOperation(add)).succeeded);
+
+    const std::string newUrl = source.string() + "-renamed";
+    ASSERT_TRUE(run({"config", "--file", ".gitmodules", "submodule.sub.url", newUrl}));
+
+    SubmodulePathsRequest sync;
+    sync.paths = {"sub"};
+    auto outcome = submitAndWait(operations, makeSyncSubmodulesOperation(sync));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    auto configured = run({"config", "submodule.sub.url"});
+    ASSERT_TRUE(configured);
+    EXPECT_EQ(configured->out, newUrl);
 }
 
 }  // namespace

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -24,6 +24,7 @@
 #include "core/git/ops/CherryPickOps.h"
 #include "core/git/ops/CommitOps.h"
 #include "core/git/ops/ConflictOps.h"
+#include "core/git/ops/LfsOps.h"
 #include "core/git/ops/MergeOps.h"
 #include "core/git/ops/RebaseOps.h"
 #include "core/git/ops/RemoteOps.h"
@@ -2512,6 +2513,88 @@ TEST_F(RealRepoTest, BisectSkipMovesPastAnUntestableCommit) {
 
     BisectResetRequest reset;
     ASSERT_TRUE(submitAndWait(operations, makeBisectResetOperation(reset)).succeeded);
+}
+
+// --- M5: LFS -----------------------------------------------------------------
+
+TEST_F(RealRepoTest, DetectsWhetherGitLfsIsInstalled) {
+    auto detected = detectLfs(*runner_, paths_, CancellationToken{});
+    ASSERT_TRUE(detected) << detected.error().message;
+    // Whichever way it goes, detection itself must not fail -- see LfsOps.h.
+    SUCCEED();
+}
+
+TEST_F(RealRepoTest, TrackingAPatternRecordsItInGitattributesAndIsListed) {
+    auto detected = detectLfs(*runner_, paths_, CancellationToken{});
+    ASSERT_TRUE(detected) << detected.error().message;
+    if (!detected->available) {
+        GTEST_SKIP() << "git-lfs is not installed";
+    }
+    commitFile("a.txt", "1\n", "c1");
+
+    OperationRunner operations(*runner_, paths_);
+    ASSERT_TRUE(submitAndWait(operations, makeLfsInstallOperation()).succeeded);
+
+    LfsTrackRequest track;
+    track.pattern = "*.bin";
+    ASSERT_TRUE(submitAndWait(operations, makeLfsTrackOperation(track)).succeeded);
+
+    std::ifstream attrs(repo_ / ".gitattributes");
+    std::string content((std::istreambuf_iterator<char>(attrs)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("*.bin"), std::string::npos);
+    EXPECT_NE(content.find("filter=lfs"), std::string::npos);
+
+    LfsStore store(*runner_, paths_);
+    auto patterns = store.trackedPatterns(CancellationToken{});
+    ASSERT_TRUE(patterns) << patterns.error().message;
+    EXPECT_NE(std::find(patterns->begin(), patterns->end(), "*.bin"), patterns->end());
+
+    LfsUntrackRequest untrack;
+    untrack.pattern = "*.bin";
+    ASSERT_TRUE(submitAndWait(operations, makeLfsUntrackOperation(untrack)).succeeded);
+
+    auto afterUntrack = store.trackedPatterns(CancellationToken{});
+    ASSERT_TRUE(afterUntrack) << afterUntrack.error().message;
+    EXPECT_EQ(std::find(afterUntrack->begin(), afterUntrack->end(), "*.bin"), afterUntrack->end());
+}
+
+TEST_F(RealRepoTest, AddingATrackedFileStoresAPointerAndListsItDownloaded) {
+    auto detected = detectLfs(*runner_, paths_, CancellationToken{});
+    ASSERT_TRUE(detected) << detected.error().message;
+    if (!detected->available) {
+        GTEST_SKIP() << "git-lfs is not installed";
+    }
+    commitFile("a.txt", "1\n", "c1");
+
+    OperationRunner operations(*runner_, paths_);
+    ASSERT_TRUE(submitAndWait(operations, makeLfsInstallOperation()).succeeded);
+    LfsTrackRequest track;
+    track.pattern = "*.bin";
+    ASSERT_TRUE(submitAndWait(operations, makeLfsTrackOperation(track)).succeeded);
+    ASSERT_TRUE(run({"add", ".gitattributes"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "track *.bin"}));
+
+    {
+        std::ofstream out(repo_ / "asset.bin", std::ios::binary | std::ios::trunc);
+        out << "not really binary, just needs to go through the clean filter";
+    }
+    ASSERT_TRUE(run({"add", "asset.bin"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "add asset.bin"}));
+
+    // The clean filter must have replaced the working-tree content with an LFS
+    // pointer in the object git actually stored, proving LFS -- not a plain
+    // blob -- captured the file.
+    auto stored = run({"show", "HEAD:asset.bin"});
+    ASSERT_TRUE(stored);
+    EXPECT_NE(stored->out.find("https://git-lfs.github.com/spec/v1"), std::string::npos);
+
+    LfsStore store(*runner_, paths_);
+    auto files = store.listFiles(CancellationToken{});
+    ASSERT_TRUE(files) << files.error().message;
+    ASSERT_EQ(files->size(), 1u);
+    EXPECT_EQ((*files)[0].path, "asset.bin");
+    EXPECT_TRUE((*files)[0].downloadedLocally);
+    EXPECT_FALSE((*files)[0].oid.empty());
 }
 
 }  // namespace

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -2441,14 +2441,32 @@ TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
         EXPECT_EQ(initial->goodOids[0], goodBase->out);
     }
 
+    // Neither the stdout message nor the log marker for "found it" turned out
+    // to be a fixed string: older git prints "is the first bad commit" and
+    // logs "# first bad commit: [", but git 2.55 quotes the (customizable)
+    // term -- "is the first 'bad' commit" / "# first 'bad' commit: [" --
+    // confirmed by capturing the raw log from a CI failure on git 2.55, which
+    // otherwise looked like it never converged. `# first ` followed somewhere
+    // on the same line by ` commit: [` holds across both.
+    auto bisectConcluded = [](std::string_view log) {
+        std::size_t lineStart = 0;
+        while (lineStart <= log.size()) {
+            const std::size_t at = log.find('\n', lineStart);
+            const std::string_view line(
+                log.data() + lineStart,
+                (at == std::string_view::npos ? log.size() : at) - lineStart);
+            if (line.starts_with("# first ") && line.find(" commit: [") != std::string_view::npos) {
+                return true;
+            }
+            if (at == std::string_view::npos) {
+                break;
+            }
+            lineStart = at + 1;
+        }
+        return false;
+    };
+
     bool concluded = false;
-    // Diagnostic trail for the assertion below: this test has failed on the
-    // Windows and macOS CI runners (both on git 2.55.x) in a way that has not
-    // reproduced locally (git 2.43.0) across 30 repeated runs, so if it fails
-    // again the exact per-step data is what is needed to root-cause it rather
-    // than guess again -- what commit was actually tested, what `git bisect`
-    // actually printed, and the full log, at every step.
-    std::string trail;
     for (int i = 0; i < 10 && !concluded; ++i) {
         auto current = store.status(CancellationToken{});
         ASSERT_TRUE(current) << current.error().message;
@@ -2464,25 +2482,9 @@ TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
 
         auto afterMark = store.status(CancellationToken{});
         ASSERT_TRUE(afterMark) << afterMark.error().message;
-        trail += "step " + std::to_string(i) + ": tested c" + std::to_string(commitNumber) + " (" +
-                 current->currentOid.substr(0, 10) + "), marked " + (mark.good ? "good" : "bad") +
-                 "; markOutcome.summary=[" + markOutcome.summary +
-                 "]; afterMark.active=" + (afterMark->active ? "true" : "false") +
-                 "; afterMark.currentOid=" + afterMark->currentOid.substr(0, 10) +
-                 "; afterMark.badOid=" + afterMark->badOid.substr(0, 10) + "\n";
-
-        // Not `markOutcome.summary.find("is the first bad commit")`: that is
-        // `git bisect`'s human-readable stdout message, and it turned out not
-        // to be a stable string to match on across git versions/locales --
-        // this failed the exact same way on both the Windows and macOS CI
-        // runners while passing on Linux. `# first bad commit: [` is the
-        // machine-readable marker `git bisect log`/`replay` themselves rely
-        // on, so it is the actual stable contract to depend on here.
-        concluded = afterMark->logText.find("# first bad commit: [") != std::string::npos;
+        concluded = bisectConcluded(afterMark->logText);
     }
-    ASSERT_TRUE(concluded) << "bisect did not conclude within 10 steps\n"
-                           << trail << "\nfull log:\n"
-                           << store.status(CancellationToken{})->logText;
+    ASSERT_TRUE(concluded) << "bisect did not conclude within 10 steps";
 
     auto finalStatus = store.status(CancellationToken{});
     ASSERT_TRUE(finalStatus) << finalStatus.error().message;

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -2454,7 +2454,17 @@ TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
         mark.good = commitNumber < 3;
         auto markOutcome = submitAndWait(operations, makeBisectMarkOperation(mark));
         ASSERT_TRUE(markOutcome.succeeded) << (markOutcome.error ? markOutcome.error->detail : "");
-        concluded = markOutcome.summary.find("is the first bad commit") != std::string::npos;
+
+        // Not `markOutcome.summary.find("is the first bad commit")`: that is
+        // `git bisect`'s human-readable stdout message, and it turned out not
+        // to be a stable string to match on across git versions/locales --
+        // this failed the exact same way on both the Windows and macOS CI
+        // runners while passing on Linux. `# first bad commit: [` is the
+        // machine-readable marker `git bisect log`/`replay` themselves rely
+        // on, so it is the actual stable contract to depend on here.
+        auto afterMark = store.status(CancellationToken{});
+        ASSERT_TRUE(afterMark) << afterMark.error().message;
+        concluded = afterMark->logText.find("# first bad commit: [") != std::string::npos;
     }
     ASSERT_TRUE(concluded) << "bisect did not conclude within 10 steps";
 

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -26,6 +26,7 @@
 #include "core/git/ops/ConflictOps.h"
 #include "core/git/ops/LfsOps.h"
 #include "core/git/ops/MergeOps.h"
+#include "core/git/ops/PatchOps.h"
 #include "core/git/ops/RebaseOps.h"
 #include "core/git/ops/RemoteOps.h"
 #include "core/git/ops/ResetOps.h"
@@ -2595,6 +2596,170 @@ TEST_F(RealRepoTest, AddingATrackedFileStoresAPointerAndListsItDownloaded) {
     EXPECT_EQ((*files)[0].path, "asset.bin");
     EXPECT_TRUE((*files)[0].downloadedLocally);
     EXPECT_FALSE((*files)[0].oid.empty());
+}
+
+// --- M5: patch import/export -------------------------------------------------
+
+TEST_F(RealRepoTest, ExportsPatchesForSelectedCommitsInOrder) {
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+    commitFile("a.txt", "3\n", "c3");
+    auto c2 = run({"rev-parse", "HEAD~1"});
+    ASSERT_TRUE(c2);
+    auto c3 = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(c3);
+
+    const std::filesystem::path outputDir = repo_ / "patches";
+    OperationRunner operations(*runner_, paths_);
+    ExportPatchesRequest request;
+    request.commits = {ObjectId::fromHex(c2->out), ObjectId::fromHex(c3->out)};
+    request.outputDir = outputDir;
+    auto outcome = submitAndWait(operations, makeExportPatchesOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    std::vector<std::string> names;
+    for (const auto& entry : std::filesystem::directory_iterator(outputDir)) {
+        names.push_back(entry.path().filename().string());
+    }
+    std::sort(names.begin(), names.end());
+    ASSERT_EQ(names.size(), 2u);
+    EXPECT_TRUE(names[0].starts_with("0001-"));
+    EXPECT_NE(names[0].find("c2"), std::string::npos);
+    EXPECT_TRUE(names[1].starts_with("0002-"));
+    EXPECT_NE(names[1].find("c3"), std::string::npos);
+}
+
+TEST_F(RealRepoTest, AppliesAPlainDiffWithoutCommittingOrStaging) {
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+    auto diff = run({"diff", "HEAD~1", "HEAD"});
+    ASSERT_TRUE(diff);
+    const std::filesystem::path patchFile = repo_.string() + "-plain.patch";
+    {
+        std::ofstream out(patchFile, std::ios::binary | std::ios::trunc);
+        out << diff->out << "\n";
+    }
+    ASSERT_TRUE(run({"reset", "--quiet", "--hard", "HEAD~1"}));
+
+    OperationRunner operations(*runner_, paths_);
+    ApplyPatchFilesRequest request;
+    request.patchFiles = {patchFile};
+    auto outcome = submitAndWait(operations, makeApplyPatchFilesOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    std::ifstream in(repo_ / "a.txt");
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "2\n");
+    auto staged = run({"diff", "--cached", "--name-only"});
+    ASSERT_TRUE(staged);
+    EXPECT_TRUE(staged->out.empty()) << "a plain apply must not touch the index";
+
+    std::filesystem::remove(patchFile);
+}
+
+TEST_F(RealRepoTest, ImportsAPatchAsACommitPreservingItsMessage) {
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("b.txt", "x\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    const std::filesystem::path patchDir = repo_ / "am-patches";
+    ASSERT_TRUE(run({"format-patch", "-1", "feature", "-o", patchDir.string()}));
+    std::filesystem::path patchFile;
+    for (const auto& entry : std::filesystem::directory_iterator(patchDir)) {
+        patchFile = entry.path();
+    }
+    ASSERT_FALSE(patchFile.empty());
+
+    OperationRunner operations(*runner_, paths_);
+    ImportPatchesRequest request;
+    request.patchFiles = {patchFile};
+    auto outcome = submitAndWait(operations, makeImportPatchesOperation(request));
+    ASSERT_TRUE(outcome.succeeded) << (outcome.error ? outcome.error->detail : "");
+
+    EXPECT_TRUE(std::filesystem::exists(repo_ / "b.txt"));
+    auto subject = run({"log", "-1", "--format=%s"});
+    ASSERT_TRUE(subject);
+    EXPECT_EQ(subject->out, "feature commit");
+    auto count = run({"rev-list", "--count", "HEAD"});
+    ASSERT_TRUE(count);
+    EXPECT_EQ(count->out, "2");
+}
+
+TEST_F(RealRepoTest, ImportConflictContinuesAfterResolution) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+
+    const std::filesystem::path patchDir = repo_ / "am-conflict-patches";
+    ASSERT_TRUE(run({"format-patch", "-1", "feature", "-o", patchDir.string()}));
+    std::filesystem::path patchFile;
+    for (const auto& entry : std::filesystem::directory_iterator(patchDir)) {
+        patchFile = entry.path();
+    }
+    ASSERT_FALSE(patchFile.empty());
+
+    OperationRunner operations(*runner_, paths_);
+    ImportPatchesRequest request;
+    request.patchFiles = {patchFile};
+    request.threeWay = true;
+    auto outcome = submitAndWait(operations, makeImportPatchesOperation(request));
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::Conflict);
+    EXPECT_TRUE(RepoState::read(paths_).inProgress());
+
+    // Resolve by taking the incoming (feature) side, matching how the working
+    // copy's conflict resolution already handles "theirs".
+    ASSERT_TRUE(run({"checkout", "--theirs", "shared.txt"}));
+    ASSERT_TRUE(run({"add", "shared.txt"}));
+
+    auto continued = submitAndWait(operations, makeAmContinueOperation());
+    ASSERT_TRUE(continued.succeeded) << (continued.error ? continued.error->detail : "");
+    EXPECT_FALSE(RepoState::read(paths_).inProgress());
+
+    auto subject = run({"log", "-1", "--format=%s"});
+    ASSERT_TRUE(subject);
+    EXPECT_EQ(subject->out, "feature commit");
+    std::ifstream in(repo_ / "shared.txt");
+    std::string fileContent((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(fileContent, "feature change\n");
+}
+
+TEST_F(RealRepoTest, ImportAbortUnwindsCleanly) {
+    commitFile("shared.txt", "base\n", "base");
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("shared.txt", "feature change\n", "feature commit");
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+    commitFile("shared.txt", "main change\n", "main commit");
+    auto beforeImport = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(beforeImport);
+
+    const std::filesystem::path patchDir = repo_ / "am-abort-patches";
+    ASSERT_TRUE(run({"format-patch", "-1", "feature", "-o", patchDir.string()}));
+    std::filesystem::path patchFile;
+    for (const auto& entry : std::filesystem::directory_iterator(patchDir)) {
+        patchFile = entry.path();
+    }
+    ASSERT_FALSE(patchFile.empty());
+
+    OperationRunner operations(*runner_, paths_);
+    ImportPatchesRequest request;
+    request.patchFiles = {patchFile};
+    request.threeWay = true;
+    auto outcome = submitAndWait(operations, makeImportPatchesOperation(request));
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(RepoState::read(paths_).inProgress());
+
+    auto aborted = submitAndWait(operations, makeAmAbortOperation());
+    ASSERT_TRUE(aborted.succeeded) << (aborted.error ? aborted.error->detail : "");
+    EXPECT_FALSE(RepoState::read(paths_).inProgress());
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->out, beforeImport->out);
 }
 
 }  // namespace

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -18,6 +18,7 @@
 #include "core/git/ReflogStore.h"
 #include "core/git/RepoState.h"
 #include "core/git/WorkingCopyStatus.h"
+#include "core/git/ops/BisectOps.h"
 #include "core/git/ops/BranchOps.h"
 #include "core/git/ops/CheckoutOp.h"
 #include "core/git/ops/CherryPickOps.h"
@@ -2405,6 +2406,112 @@ TEST_F(RealRepoTest, SyncSubmodulesRewritesTheLocalUrlFromGitmodules) {
     auto configured = run({"config", "submodule.sub.url"});
     ASSERT_TRUE(configured);
     EXPECT_EQ(configured->out, newUrl);
+}
+
+// --- M5: bisect ------------------------------------------------------------
+
+TEST_F(RealRepoTest, BisectFindsTheFirstBadCommitByGoodBadStepping) {
+    commitFile("a.txt", "1\n", "c1");  // good
+    commitFile("a.txt", "2\n", "c2");  // good
+    commitFile("a.txt", "3\n", "c3");  // first bad
+    commitFile("a.txt", "4\n", "c4");  // also bad
+    auto badHead = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(badHead);
+    auto goodBase = run({"rev-parse", "HEAD~3"});
+    ASSERT_TRUE(goodBase);
+    auto expectedFirstBad = run({"rev-parse", "HEAD~1"});
+    ASSERT_TRUE(expectedFirstBad);
+
+    OperationRunner operations(*runner_, paths_);
+    BisectStartRequest start;
+    start.badRef = badHead->out;
+    start.goodRefs = {goodBase->out};
+    auto startOutcome = submitAndWait(operations, makeBisectStartOperation(start));
+    ASSERT_TRUE(startOutcome.succeeded) << (startOutcome.error ? startOutcome.error->detail : "");
+
+    BisectStore store(*runner_, paths_);
+    {
+        auto initial = store.status(CancellationToken{});
+        ASSERT_TRUE(initial) << initial.error().message;
+        EXPECT_TRUE(initial->active);
+        EXPECT_EQ(initial->badOid, badHead->out);
+        ASSERT_EQ(initial->goodOids.size(), 1u);
+        EXPECT_EQ(initial->goodOids[0], goodBase->out);
+    }
+
+    bool concluded = false;
+    for (int i = 0; i < 10 && !concluded; ++i) {
+        auto current = store.status(CancellationToken{});
+        ASSERT_TRUE(current) << current.error().message;
+        ASSERT_TRUE(current->active);
+        auto subject = run({"log", "-1", "--format=%s", current->currentOid});
+        ASSERT_TRUE(subject);
+        const int commitNumber = std::stoi(subject->out.substr(1));
+
+        BisectMarkRequest mark;
+        mark.good = commitNumber < 3;
+        auto markOutcome = submitAndWait(operations, makeBisectMarkOperation(mark));
+        ASSERT_TRUE(markOutcome.succeeded) << (markOutcome.error ? markOutcome.error->detail : "");
+        concluded = markOutcome.summary.find("is the first bad commit") != std::string::npos;
+    }
+    ASSERT_TRUE(concluded) << "bisect did not conclude within 10 steps";
+
+    auto finalStatus = store.status(CancellationToken{});
+    ASSERT_TRUE(finalStatus) << finalStatus.error().message;
+    EXPECT_EQ(finalStatus->badOid, expectedFirstBad->out);
+
+    BisectResetRequest reset;
+    auto resetOutcome = submitAndWait(operations, makeBisectResetOperation(reset));
+    ASSERT_TRUE(resetOutcome.succeeded) << (resetOutcome.error ? resetOutcome.error->detail : "");
+
+    auto afterReset = store.status(CancellationToken{});
+    ASSERT_TRUE(afterReset) << afterReset.error().message;
+    EXPECT_FALSE(afterReset->active);
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->out, badHead->out) << "reset must return to the branch bisect started from";
+}
+
+TEST_F(RealRepoTest, BisectSkipMovesPastAnUntestableCommit) {
+    // Four commits leave two real candidates (c2, c3) between good and bad, so
+    // skipping the first still leaves a next one to test rather than
+    // exhausting the search outright (which exits non-zero -- a different,
+    // legitimate outcome covered by BisectFindsTheFirstBadCommitByGoodBadStepping's
+    // "only skip'ped commits left" case is deliberately not this test).
+    commitFile("a.txt", "1\n", "c1");
+    commitFile("a.txt", "2\n", "c2");
+    commitFile("a.txt", "3\n", "c3");
+    commitFile("a.txt", "4\n", "c4");
+    auto badHead = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(badHead);
+    auto goodBase = run({"rev-parse", "HEAD~3"});
+    ASSERT_TRUE(goodBase);
+    auto middle = run({"rev-parse", "HEAD~1"});
+    ASSERT_TRUE(middle);
+
+    OperationRunner operations(*runner_, paths_);
+    BisectStartRequest start;
+    start.badRef = badHead->out;
+    start.goodRefs = {goodBase->out};
+    ASSERT_TRUE(submitAndWait(operations, makeBisectStartOperation(start)).succeeded);
+
+    BisectStore store(*runner_, paths_);
+    auto beforeSkip = store.status(CancellationToken{});
+    ASSERT_TRUE(beforeSkip) << beforeSkip.error().message;
+    EXPECT_EQ(beforeSkip->currentOid, middle->out);
+
+    BisectSkipRequest skip;
+    auto skipOutcome = submitAndWait(operations, makeBisectSkipOperation(skip));
+    ASSERT_TRUE(skipOutcome.succeeded) << (skipOutcome.error ? skipOutcome.error->detail : "");
+
+    auto afterSkip = store.status(CancellationToken{});
+    ASSERT_TRUE(afterSkip) << afterSkip.error().message;
+    ASSERT_EQ(afterSkip->skippedOids.size(), 1u);
+    EXPECT_EQ(afterSkip->skippedOids[0], middle->out);
+
+    BisectResetRequest reset;
+    ASSERT_TRUE(submitAndWait(operations, makeBisectResetOperation(reset)).succeeded);
 }
 
 }  // namespace


### PR DESCRIPTION
SubmoduleStore reads .gitmodules alongside `git submodule status` to report
each submodule's path, URL, branch, checked-out commit and state
(not-initialized / up-to-date / modified / conflicted). The five mutating
operations wrap `git submodule add/init/update/sync/deinit` following the
existing Operation pattern, wired through RepositorySession into a new
"Manage submodules" dialog under a Submodule menu.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019APn67VHf8TQxPaBLaNiac