### PR TITLE
feat, fix, refactor, test: 修正 git graph 分支過濾、自動刷新與大型倉庫穩定性問題

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,5 +1,14 @@
 # Performance
 
+## Scope of the table below
+
+The numbers in this section come from `gbm_graph_check`, which links only
+`gbm_core` -- no Qt, no `RepositorySession`, no `CommitListModel`, no
+`cat-file` metadata fetching, no `for-each-ref`-driven UI refresh cycle. They
+measure `git rev-list` streaming plus `GraphBuilder`'s lane algorithm in
+isolation, and are not evidence about what the running app feels like end to
+end. See "UI refresh path" below for the numbers that are.
+
 ## Measured behaviour
 
 On a generated 200,000-commit repository (40 branches, 8% merge rate, commit-graph
@@ -38,6 +47,100 @@ render cap and pushes about 12% of edges into the overflow gutter. For compariso
 `git log --graph` needs *more* columns than we use on the same input (51 vs 31 on a
 4-branch variant), so the width is a property of the topology rather than of the
 lane allocator.
+
+## UI refresh path
+
+Unlike the section above, this measures what a refresh actually costs once
+Qt, refs and commit metadata are in the loop -- the thing users reporting "it
+takes a while to sync" are describing.
+
+`gbm_graph_check` was extended to time `RefStore::load()` (`for-each-ref`)
+itself, run twice in a row to mirror what `RepositorySession` used to do
+before this fix (see below). On a generated repository with 50,000 commits
+and **3,798 refs** (many stale branches, closer to a repository that has been
+alive for years than the 40-branch fixture above), with a commit-graph
+written:
+
+| Stage | Measured |
+|---|---|
+| `for-each-ref` (one call) | **~0.8-2.2 s**, machine-load dependent |
+| `for-each-ref` (two calls, back to back) | roughly double the one-call cost |
+| Full `rev-list` walk, 50,000 commits | **~440-580 ms** |
+
+The `for-each-ref` range is wide because, unlike the isolated `gbm_core` numbers
+above, this ran on a machine doing other work across different sessions (770-850
+ms on a quiet run, up to ~2.2 s once). The number that matters is not any single
+digit in that range but the comparison: on both quiet and loaded runs, one
+`for-each-ref` call cost as much as or more than the entire commit-graph-accelerated
+`rev-list` walk of 50k commits. That comparison is what motivates the fix below,
+not the absolute milliseconds.
+
+Reproduce (the "refs:" line prints both timings):
+
+```bash
+R=/tmp/gbm-perf-fixture
+git init --quiet --bare $R/.git && git -C $R config core.bare false
+./build/dev/tests/gen_history --commits 50000 --branches 3000 --merge-rate 0.05 \
+    --octopus 2 --tags 800 --seed 7 | git -C $R fast-import --quiet
+git -C $R commit-graph write --reachable --changed-paths
+
+./build/dev/tests/gbm_graph_check $R
+```
+
+**Finding:** on a repository with thousands of refs, a single `for-each-ref`
+call costs *more* than the entire commit-graph-accelerated `rev-list` walk of
+50k commits, and `RepositorySession::refreshHistory()` used to run it a
+**second** time on top of whatever `refreshRefs()` had already just run
+(both are always called back to back -- every call site in the app does so),
+for no functional reason beyond a comment explaining the two ran as
+unordered, independently-scheduled pool tasks. Isolating the field list
+confirms roughly half of a single call's cost is `%(upstream:track)`
+specifically (minimal `%(refname)`-only format: ~440 ms; the app's full
+8-field format: ~770 ms on the same repository) -- but that field is now
+load-bearing for the stale-upstream validation fix (`RefStore::refExists`,
+`RefInfo::isGone`), so it isn't a safe thing to drop.
+
+**Fix applied:** `RepositorySession::refreshRefsAndHistory()` runs the load
+once, publishes it, and feeds the same `RefSnapshotPtr` into the history walk
+-- no synchronization primitive needed, because (verified by reading every
+call site) `refreshHistory()` is *never* called without an immediately
+preceding `refreshRefs()` except from `setHistoryFilter()`, which keeps
+calling the original `refreshHistory()` and still reloads on its own. Every
+other call site (checkout, merge, cherry-pick, fetch, pull, stash-branch,
+repo open, Refresh, window-reactivation resync, ...) now calls
+`refreshRefsAndHistory()` instead, cutting one `for-each-ref` call -- on the
+order of the "one call" row above, hundreds of milliseconds to low seconds
+depending on machine load -- out of every one of those refreshes. Also worth
+naming: this is a small behavior change on the error path. Before this fix, a
+failed ref load in `refreshRefs()` did not stop `refreshHistory()`'s
+independent load from possibly succeeding on its own; now a failed load in
+`refreshRefsAndHistory()` aborts both. No test in this codebase exercises
+`RepositorySession` directly (there is no harness for it), so this was not
+regression-tested; it is judged more correct -- a session should not present a
+graph built from before a ref load failure as current -- but it is a real,
+deliberate change in the 8 converted call sites' error behavior.
+
+**Deferred, not implemented in this pass** (the plan's own gate: measure
+before committing to more than the stage that dominates):
+
+- **Debouncing a burst of `refreshHistory()`/`refreshRefsAndHistory()` calls**
+  (`core/workers/Debouncer.h` exists, unused) so several operations firing in
+  quick succession collapse into one walk. Real, but secondary to the
+  duplicate-load fix above, and needs a `QTimer`-driven integration this pass
+  didn't have room for.
+- **Persisting commit metadata** (`CatFileBatch`/`cat-file` results) in
+  `RepoIndexDb` instead of the in-process ~20k-entry `QHash` that starts
+  empty every session. Explicitly the largest remaining piece, and the
+  riskiest -- a new schema, an eviction policy, and invalidation on top of
+  the discovery-only cache that exists today.
+- These numbers are from this machine (macOS), not the Windows machine where
+  the "always re-syncs, takes a while" report originated. Process-spawn cost
+  differs by platform (`CatFileBatch.h` already notes 20-40 ms per spawn on
+  Windows, worse under antivirus filter drivers), so the relative weight of
+  "for-each-ref cost" vs. "process-spawn count" vs. "cat-file batch cost" may
+  differ there. If it's still slow after this fix, re-run the reproduction
+  above on the repository in question to see which stage actually dominates
+  before reaching for either of the two deferred items.
 
 ## Repository performance settings
 

--- a/docs/design/qss-coverage.md
+++ b/docs/design/qss-coverage.md
@@ -1,0 +1,61 @@
+# QSS coverage audit
+
+Requested by item 3 ("make sure all styles are self-designed, not default"):
+an inventory of every Qt widget class the app instantiates, checked against
+`resources/qss/app.qss` coverage, so the app is not silently falling back to
+Fusion/platform defaults anywhere. Audit-and-report first, per the user's
+answer when this was scoped — fixed here only the visually obvious, low-risk
+gaps; the rest are listed below as decisions for the user.
+
+Fusion is forced app-wide (`ThemeManager::apply`,
+`QApplication::setStyle(QStyleFactory::create("Fusion"))`), so nothing here
+falls through to a *native* OS control by accident except where noted — the
+gap is un-tokenized Fusion defaults, not native chrome, unless called out.
+
+## Fixed in this pass
+
+| Gap | Where it showed | Fix |
+|---|---|---|
+| `QScrollArea` / its viewport | `DiffPage`, `CommitExpansionPanel` — both already set `NoFrame` in code, but the viewport still filled with `QPalette::Base`, a plain gray with no theme token, seaming against the panel surfaces around it | `QScrollArea { background: transparent; border: none; }` plus a structural `QScrollArea > QWidget` rule (the viewport has no stable object name) |
+| `QAbstractScrollArea::corner` | The square between two scrollbars once `gbmCommitView`/`gbmRefView`/`gbmRepoView` grow wide enough to scroll both ways | Styled to `@surface-panel-raised`, matching `QHeaderView::section` |
+| `QScrollBar::add-page`/`::sub-page` | The trough above/below the handle — only the groove and handle were styled, not the page regions specifically | Set to `transparent`, matching the groove |
+| `QToolBar::separator` | The divider between the refresh button and the theme swatches (`MainWindow.cpp` toolbar) | Styled to `@border-subtle`, 1px |
+
+All four verified via `ThemeTest::qssSubstitutionLeavesNoUnresolvedPlaceholder`
+(no new `@` placeholders leaked unresolved) and `gbm_model_tests`/
+`gbm_theme_tests` still green.
+
+## Investigated, not fixed — reasoned out
+
+| Gap | Why it's real | Why not fixed here |
+|---|---|---|
+| `QTreeView::branch` (expand/collapse arrows on `gbmRefView`) | Default Fusion branch indicators, not token-driven | QSS's `::branch` subcontrol needs an `image:`/`border-image:` the moment *any* rule targets it, or Qt's built-in arrow disappears entirely with nothing to replace it. A correct fix needs a real per-theme icon (via `IconLoader`, which already tints SVGs per token) wired through `QTreeView::indexWidget` or a custom style, not a QSS-only patch — attempting a shallow QSS rule risks *removing* the expand/collapse affordance rather than restyling it. Left as a real follow-up, not a QSS one-liner. |
+| `QHeaderView::up-arrow`/`::down-arrow` (sort indicators) | Un-styled, would show default arrows | **Dead gap in practice**: `grep -rn "setSortingEnabled" src/app` returns nothing — no view in the app enables column sorting, so these subcontrols never render today. Not worth styling until sorting is a feature. |
+
+## Deliberately left as a choice, not a fix
+
+| Gap | Why it's real | The tradeoff |
+|---|---|---|
+| `QFileDialog` (`MainWindow.cpp` folder/file pickers, `ManageWorktreesDialog`) | Fully native OS dialog — `DontUseNativeDialog` is set nowhere in the repo, so these bypass QSS and the theme entirely | Forcing `DontUseNativeDialog` makes them themed, but loses the OS's recent-places sidebar, native search, and platform-specific affordances (Quick Look on macOS, etc.) — a real regression for most users, not a strict improvement. Left as the user's call. |
+| `QInputDialog` (`MainWindow.cpp`, `SidebarPanel.cpp`, `ManageWorktreesDialog.cpp`) | Gets only the generic `QDialog`/`QLabel` rules already in `app.qss` (background + label color), no dedicated line-edit-in-a-prompt styling | Low-traffic surface (rename/create-with-a-name prompts); a bespoke QSS pass here is easy to add later if it turns out to matter, so it wasn't force-fit into this slice. |
+
+## Confirmed *not* gaps (checked, already covered)
+
+So these aren't mistakenly "fixed" again later: `QTableWidget` and
+`QListWidget` are matched by the `QTableView`/`QListView` type selectors in
+`app.qss` (Qt type selectors match subclasses); `QMessageBox` has its own
+rule; `QDialog`, `QComboBox` (including its popup `QAbstractItemView`),
+`QSpinBox`/`QDoubleSpinBox`, `QGroupBox`, `QRadioButton`, `QCheckBox`,
+`QToolTip`, `QProgressBar`, `QSplitter`, `QTabBar`, `QStatusBar`,
+`QDialogButtonBox`, `QScrollBar` (handle + groove), `QMenuBar`/`QMenu`
+(including separators) all have dedicated rules already.
+
+## Inline `setStyleSheet` call sites (bypass the token system on purpose or not)
+
+`DiffPage.cpp`, `WorkingCopyView.cpp` (x2), `CommitExpansionPanel.cpp` each
+call `setStyleSheet()` directly on a widget rather than going through
+`app.qss`. Each of these already has its own `refreshTheme()` re-applied on
+a theme switch (`DiffPage::refreshTheme`, `WorkingCopyView::refreshTheme`,
+etc.), so they are not stale — just outside this file's inventory. Not
+flagged as a gap; noted here so a future audit doesn't re-discover them as
+one.

--- a/docs/design/tokens-reference.md
+++ b/docs/design/tokens-reference.md
@@ -156,3 +156,28 @@ Kept here so implementation does not depend on re-fetching the design project.
 .gbm-diffline-ctx{color:var(--text-secondary)}
 .gbm-diffline-hunk{color:var(--text-tertiary);background:var(--surface-sunken)}
 ```
+
+## Departure from the source: `--ref-chip-fill` / `--ref-chip-text`
+
+The verbatim spec above (`.gbm-tag-branch`, line 119) has the non-current branch
+chip use `--accent-subtle` for both border and background. In implementation
+that token turned out to be **byte-identical to `--surface-selected`** in
+`dark-technical` (`#0d2a4d`) and `neutral-professional` (`#eaf1fe`), so the chip
+disappeared entirely on a selected commit row — a real readability bug, not an
+implementation slip; it traces back to this source file.
+
+`Token::RefChipFill` / `Token::RefChipText` (`src/app/theme/Tokens.h`,
+`ThemeTokens.cpp`) exist to fix that and are **not** part of the design
+project's token set — do not "correct" them back to `--accent-subtle` to match
+this doc. Values, chosen for ≥4.5:1 text contrast and visible separation from
+`--surface-selected`/`--accent-subtle` in every theme:
+
+| Theme | `--ref-chip-fill` | `--ref-chip-text` |
+|---|---|---|
+| dark-technical | `#1c3f66` | `#eaf1fe` |
+| light-ide | `#c7dbfa` | `#1857b8` |
+| neutral-professional | `#c7dbfa` | `#1857b8` |
+
+Consumed directly by `PillPainter::colorsForRef` (C++), not via an `app.qss`
+`@` placeholder, so there is no corresponding entry in `ThemeManager.cpp`'s
+placeholder table.

--- a/resources/qss/app.qss
+++ b/resources/qss/app.qss
@@ -128,6 +128,12 @@ QToolBar QToolButton:checked {
     color: @accent;
 }
 
+QToolBar::separator {
+    background: @border-subtle;
+    width: 1px;
+    margin: 6px 4px;
+}
+
 QLabel#gbmRepoNameLabel {
     font-size: 18px;
     font-weight: 600;
@@ -400,6 +406,24 @@ QLabel#gbmBadgeRemoved {
     color: @diff-del-text;
 }
 
+/* --- scroll areas -------------------------------------------------------- */
+
+/* DiffPage and CommitExpansionPanel both set QFrame::NoFrame in code, which
+ * only drops the border -- the Fusion style still fills QScrollArea and its
+ * internal viewport with QPalette::Base, a plain default gray with no
+ * theme token behind it, which read as a seam against the panel surfaces
+ * around it. The viewport has no stable object name to select directly, so
+ * this targets it structurally: the immediate-child QWidget QScrollArea
+ * creates to host setWidget()'s content. */
+QScrollArea {
+    background: transparent;
+    border: none;
+}
+
+QScrollArea > QWidget {
+    background: transparent;
+}
+
 /* --- tree / table views -----------------------------------------------------*/
 
 QTreeView,
@@ -471,6 +495,15 @@ QHeaderView::section {
     border-bottom: 1px solid @border-default;
     border-right: 1px solid @border-subtle;
     padding: 4px 8px;
+}
+
+/* The square left over where a vertical and horizontal scrollbar meet, e.g.
+ * gbmCommitView/gbmRefView/gbmRepoView once history or the ref tree grows
+ * wide enough to scroll sideways -- otherwise a default gray square sits
+ * between two themed scrollbars. */
+QAbstractScrollArea::corner {
+    background: @surface-panel-raised;
+    border: none;
 }
 
 /* --- tabs -------------------------------------------------------------------*/
@@ -546,6 +579,14 @@ QScrollBar::sub-line:vertical {
     height: 0;
 }
 
+/* The trough above/below the handle -- QScrollBar:vertical's own background
+ * above only covers the groove as a whole; without these two, the page
+ * regions specifically fell back to a default (non-transparent) fill. */
+QScrollBar::add-page:vertical,
+QScrollBar::sub-page:vertical {
+    background: transparent;
+}
+
 QScrollBar:horizontal {
     background: transparent;
     height: 12px;
@@ -565,6 +606,11 @@ QScrollBar::handle:horizontal:hover {
 QScrollBar::add-line:horizontal,
 QScrollBar::sub-line:horizontal {
     width: 0;
+}
+
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal {
+    background: transparent;
 }
 
 /* --- status bar ------------------------------------------------------------*/

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -81,11 +81,11 @@ std::uint64_t fingerprintRefs(const RefSnapshot& refs) {
 }
 
 bool historyQueryEquals(const HistoryQuery& a, const HistoryQuery& b) {
-    return a.includeRefs == b.includeRefs && a.excludeRefs == b.excludeRefs &&
-           a.pathFilter == b.pathFilter && a.grep == b.grep && a.author == b.author &&
-           a.since == b.since && a.until == b.until && a.firstParentOnly == b.firstParentOnly &&
-           a.includeReflog == b.includeReflog && a.dateOrder == b.dateOrder &&
-           a.maxCount == b.maxCount;
+    return a.seedRefs == b.seedRefs && a.includeRefs == b.includeRefs &&
+           a.excludeRefs == b.excludeRefs && a.pathFilter == b.pathFilter && a.grep == b.grep &&
+           a.author == b.author && a.since == b.since && a.until == b.until &&
+           a.firstParentOnly == b.firstParentOnly && a.includeReflog == b.includeReflog &&
+           a.dateOrder == b.dateOrder && a.maxCount == b.maxCount;
 }
 
 }  // namespace
@@ -154,11 +154,11 @@ void RepositorySession::setBusy(bool busy) {
 }
 
 void RepositorySession::refreshHistory(HistoryQuery query) {
-    // A bare refreshHistory() call is what every existing call site uses
-    // (the Refresh button, a checkout, a fetch completing, ...) and means
-    // "refresh with whatever's currently selected" -- if setHistoryFilter()
-    // has set a branch filter, substitute it here rather than letting an
-    // incidental refresh silently revert the graph to "show everything".
+    // A bare refreshHistory() call is what setHistoryFilter() and a few other
+    // ref-independent callers use, and means "refresh with whatever's
+    // currently selected" -- if setHistoryFilter() has set a branch filter,
+    // substitute it here rather than letting an incidental refresh silently
+    // revert the graph to "show everything".
     if (historyQueryEquals(query, HistoryQuery{}) &&
         !historyQueryEquals(activeHistoryQuery_, HistoryQuery{})) {
         query = activeHistoryQuery_;
@@ -181,75 +181,137 @@ void RepositorySession::refreshHistory(HistoryQuery query) {
     setBusy(true);
 
     readPool_.post([this, query = std::move(query), token]() mutable {
-        // Re-read refs here rather than trusting refs_.current(): callers
-        // routinely call refreshRefs() and refreshHistory() back-to-back
-        // after a mutating operation, and the two run as independent tasks
-        // on the pool with no ordering guarantee between them. Reading
-        // refs_.current() could observe the pre-operation snapshot and wrongly
-        // conclude nothing changed. `for-each-ref` is one cheap process, so
-        // paying for it again here to get a fingerprint we can trust is a
-        // good trade against skipping a multi-second `rev-list` walk.
+        // Re-read refs here rather than trusting refs_.current(): a caller
+        // that calls this alone (no adjacent refreshRefs()) has no other
+        // guarantee refs_ reflects anything that happened since the last
+        // refresh. Callers that DO have a fresh RefSnapshotPtr in hand
+        // already -- refreshRefs() immediately followed by refreshHistory(),
+        // which is every other call site -- should call
+        // refreshRefsAndHistory() instead, which shares one `for-each-ref`
+        // load between the two rather than paying for this one twice.
         auto freshRefs = refStore_->load(token);
         if (!freshRefs && freshRefs.error().code == GitError::Code::Cancelled) {
             QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
             return;
         }
         const RefSnapshotPtr refsForSeed = freshRefs ? *freshRefs : refs_.current();
+        walkHistoryWithRefs(std::move(query), refsForSeed, token);
+    });
+}
 
-        // If no explicit tips were given, seed from the refs so the trunk
-        // lands in lane 0.
-        if (query.includeRefs.empty() && refsForSeed) {
-            query.includeRefs = RefStore::historySeedRefs(*refsForSeed);
-        }
+void RepositorySession::refreshRefsAndHistory(HistoryQuery query) {
+    if (historyQueryEquals(query, HistoryQuery{}) &&
+        !historyQueryEquals(activeHistoryQuery_, HistoryQuery{})) {
+        query = activeHistoryQuery_;
+    }
+    if (query.maxCount == 0) {
+        query.maxCount = maxGraphRowsSetting(paths_);
+    }
 
-        const std::uint64_t fingerprint = refsForSeed ? fingerprintRefs(*refsForSeed) : 0;
-        if (hasLastWalk_ && fingerprint == lastWalkFingerprint_ &&
-            historyQueryEquals(query, lastWalkQuery_)) {
-            if (const GraphSnapshotPtr current = graph_.current(); current && current->complete) {
-                // Nothing that could change the walk's result has happened
-                // since the last completed walk with this same query -- skip
-                // re-running `rev-list` and just republish what we have.
+    historyCancel_.cancel();
+    historyCancel_ = CancellationSource();
+    const CancellationToken token = historyCancel_.token();
+
+    setBusy(true);
+
+    readPool_.post([this, query = std::move(query), token]() mutable {
+        auto freshRefs = refStore_->load(token);
+        if (!freshRefs) {
+            if (freshRefs.error().code != GitError::Code::Cancelled) {
+                GitError error = std::move(freshRefs).error();
                 QMetaObject::invokeMethod(
-                    this,
-                    [this] {
-                        emit graphUpdated(true);
-                        setBusy(false);
-                    },
-                    Qt::QueuedConnection);
-                return;
+                    this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+            }
+            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+            return;
+        }
+        const RefSnapshotPtr refsForSeed = *freshRefs;
+        refs_.publish(refsForSeed);
+        QMetaObject::invokeMethod(this, [this] { emit refsUpdated(); }, Qt::QueuedConnection);
+        walkHistoryWithRefs(std::move(query), refsForSeed, token);
+    });
+}
+
+void RepositorySession::walkHistoryWithRefs(HistoryQuery query,
+                                            RefSnapshotPtr refsForSeed,
+                                            CancellationToken token) {
+    // Always seed from the refs so the trunk lands in lane 0 -- this is
+    // ordering only (HistoryQuery::toRevListArgs), never narrowing: it is
+    // followed by --all whenever includeRefs (the branch filter) is
+    // empty, and ignored outright when includeRefs is set.
+    if (refsForSeed) {
+        query.seedRefs = RefStore::historySeedRefs(*refsForSeed);
+    }
+
+    // The branch filter (query.includeRefs) is sticky -- see
+    // setHistoryFilter -- and can go stale between when it was chosen
+    // and when this refresh actually runs: a filtered-on branch or
+    // remote-tracking ref can be deleted or pruned in between. Drop
+    // anything no longer present in the fresh snapshot rather than
+    // handing rev-list a dead name, which would abort the entire walk.
+    // If everything gets dropped, toRevListArgs' includeRefs.empty()
+    // check falls back to "show everything", same as an unset filter.
+    if (!query.includeRefs.empty() && refsForSeed) {
+        std::vector<std::string> stillValid;
+        stillValid.reserve(query.includeRefs.size());
+        for (const std::string& ref : query.includeRefs) {
+            if (RefStore::refExists(*refsForSeed, ref)) {
+                stillValid.push_back(ref);
+            } else {
+                GBM_LOG_WARN("Branch filter: '" + ref +
+                             "' no longer exists, dropping it from the graph filter");
             }
         }
+        query.includeRefs = std::move(stillValid);
+    }
 
-        auto result = history_->walk(
-            query,
-            [this, token](GraphSnapshotPtr chunk) {
-                if (token.isCancelled()) {
-                    return;
-                }
-                const bool complete = chunk->complete;
-                graph_.publish(std::move(chunk));
-                // Queued, so the UI thread picks it up in its own event loop.
-                QMetaObject::invokeMethod(
-                    this, [this, complete] { emit graphUpdated(complete); }, Qt::QueuedConnection);
-            },
-            token);
-
-        if (result) {
+    const std::uint64_t fingerprint = refsForSeed ? fingerprintRefs(*refsForSeed) : 0;
+    if (hasLastWalk_ && fingerprint == lastWalkFingerprint_ &&
+        historyQueryEquals(query, lastWalkQuery_)) {
+        if (const GraphSnapshotPtr current = graph_.current(); current && current->complete) {
+            // Nothing that could change the walk's result has happened
+            // since the last completed walk with this same query -- skip
+            // re-running `rev-list` and just republish what we have.
             QMetaObject::invokeMethod(
                 this,
-                [this, fingerprint, query] {
-                    lastWalkFingerprint_ = fingerprint;
-                    lastWalkQuery_ = query;
-                    hasLastWalk_ = true;
+                [this] {
+                    emit graphUpdated(true);
+                    setBusy(false);
                 },
                 Qt::QueuedConnection);
-        } else if (result.error().code != GitError::Code::Cancelled) {
-            GitError error = std::move(result).error();
-            QMetaObject::invokeMethod(
-                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+            return;
         }
-        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
-    });
+    }
+
+    auto result = history_->walk(
+        query,
+        [this, token](GraphSnapshotPtr chunk) {
+            if (token.isCancelled()) {
+                return;
+            }
+            const bool complete = chunk->complete;
+            graph_.publish(std::move(chunk));
+            // Queued, so the UI thread picks it up in its own event loop.
+            QMetaObject::invokeMethod(
+                this, [this, complete] { emit graphUpdated(complete); }, Qt::QueuedConnection);
+        },
+        token);
+
+    if (result) {
+        QMetaObject::invokeMethod(
+            this,
+            [this, fingerprint, query] {
+                lastWalkFingerprint_ = fingerprint;
+                lastWalkQuery_ = query;
+                hasLastWalk_ = true;
+            },
+            Qt::QueuedConnection);
+    } else if (result.error().code != GitError::Code::Cancelled) {
+        GitError error = std::move(result).error();
+        QMetaObject::invokeMethod(
+            this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+    }
+    QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
 }
 
 void RepositorySession::setHistoryFilter(HistoryQuery query) {
@@ -293,7 +355,7 @@ void RepositorySession::requestCommitMetadata(std::vector<ObjectId> oids) {
                 this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
             return;
         }
-        std::vector<CommitMeta> metadata = catFile_->readCommits(oids);
+        std::vector<CommitMeta> metadata = catFile_->readCommits(oids, token);
         if (token.isCancelled() || metadata.empty()) {
             return;
         }
@@ -350,8 +412,7 @@ void RepositorySession::checkout(const CheckoutRequest& request) {
                 setBusy(false);
                 emit operationFinished(outcome);
                 if (outcome.succeeded) {
-                    refreshRefs();
-                    refreshHistory();
+                    refreshRefsAndHistory();
                 }
             },
             Qt::QueuedConnection);
@@ -393,6 +454,14 @@ void RepositorySession::deleteBranch(const DeleteBranchRequest& request) {
 void RepositorySession::cancelPendingReads() {
     readCancel_.cancel();
     readCancel_ = CancellationSource();
+    // historyCancel_ is otherwise only touched by refreshHistory() itself
+    // (superseding the previous walk on every new one) -- without cancelling
+    // it here too, a history walk in flight when the session is about to be
+    // destroyed would only be noticed inside ~RepositorySession(), by which
+    // point the caller (MainWindow::closeRepository) has no chance to wait
+    // for the worker to actually stop before the destructor runs.
+    historyCancel_.cancel();
+    historyCancel_ = CancellationSource();
 }
 
 void RepositorySession::refreshWorkingCopyStatus() {
@@ -489,8 +558,7 @@ void RepositorySession::submitWorkingCopyOperation(std::unique_ptr<Operation> op
                     if (alsoRefreshHistory) {
                         // A commit moved HEAD, so both the ref list and the
                         // graph need to reflect it.
-                        refreshRefs();
-                        refreshHistory();
+                        refreshRefsAndHistory();
                     }
                 }
             },
@@ -581,12 +649,14 @@ void RepositorySession::requestConflictSides(const std::string& path,
 
         // Best-effort: a stage that fails to read (or does not exist) shows as
         // empty rather than failing the whole request, so the two sides that
-        // did read are still shown.
-        auto readOrEmpty = [this](const std::string& blob) {
-            if (blob.empty()) {
+        // did read are still shown. Checked between the three reads (not just
+        // once above): a cancellation arriving while the first blob is being
+        // fetched should stop the remaining two from starting.
+        auto readOrEmpty = [this, token](const std::string& blob) {
+            if (blob.empty() || token.isCancelled()) {
                 return std::string();
             }
-            auto object = catFile_->read(blob);
+            auto object = catFile_->read(blob, token);
             return object ? object->content : std::string();
         };
         const std::string ancestor = readOrEmpty(ancestorBlob);
@@ -631,7 +701,7 @@ void RepositorySession::requestFileContent(const std::string& path, const std::s
         // `revision:path`, e.g. "HEAD:src/main.cpp" or ":src/main.cpp" for the
         // index -- the same syntax CatFileBatch::read documents accepting.
         const std::string object = revision + ":" + path;
-        auto result = catFile_->read(object);
+        auto result = catFile_->read(object, token);
         // Best-effort, like requestConflictSides: a missing object (untracked
         // file, or a path that did not exist at `revision`) is a normal
         // display state, not a failure worth surfacing as an error.
@@ -651,24 +721,30 @@ void RepositorySession::requestFileContent(const std::string& path, const std::s
 }
 
 void RepositorySession::submitAndRefresh(std::unique_ptr<Operation> operation,
-                                         std::function<void(bool)> afterFinished) {
-    setBusy(true);
-    operations_->submit(std::move(operation),
-                        [this, afterFinished = std::move(afterFinished)](OperationOutcome outcome) {
-                            // Runs on the operation runner's serial thread; hop to the UI
-                            // thread before touching anything Qt, same as
-                            // submitWorkingCopyOperation.
-                            QMetaObject::invokeMethod(
-                                this,
-                                [this, outcome = std::move(outcome), afterFinished] {
-                                    setBusy(false);
-                                    emit workingCopyOperationFinished(outcome);
-                                    if (afterFinished) {
-                                        afterFinished(outcome.succeeded);
-                                    }
-                                },
-                                Qt::QueuedConnection);
-                        });
+                                         std::function<void(bool)> afterFinished,
+                                         bool drivesBusy) {
+    if (drivesBusy) {
+        setBusy(true);
+    }
+    operations_->submit(
+        std::move(operation),
+        [this, afterFinished = std::move(afterFinished), drivesBusy](OperationOutcome outcome) {
+            // Runs on the operation runner's serial thread; hop to the UI
+            // thread before touching anything Qt, same as
+            // submitWorkingCopyOperation.
+            QMetaObject::invokeMethod(
+                this,
+                [this, outcome = std::move(outcome), afterFinished, drivesBusy] {
+                    if (drivesBusy) {
+                        setBusy(false);
+                    }
+                    emit workingCopyOperationFinished(outcome);
+                    if (afterFinished) {
+                        afterFinished(outcome.succeeded);
+                    }
+                },
+                Qt::QueuedConnection);
+        });
 }
 
 // --- M3: stashes -------------------------------------------------------
@@ -724,8 +800,7 @@ void RepositorySession::branchFromStash(const StashBranchRequest& request) {
         if (succeeded) {
             refreshWorkingCopyStatus();
             refreshStashes();
-            refreshRefs();
-            refreshHistory();
+            refreshRefsAndHistory();
         }
     });
 }
@@ -883,7 +958,10 @@ void RepositorySession::fetchRemote(FetchRequest request) {
     submitAndRefresh(makeFetchOperation(std::move(request)), [this](bool succeeded) {
         askpass_->stop();
         if (succeeded) {
-            refreshRefs();
+            // A fetch can bring in new commits on remote-tracking refs; without
+            // this the graph kept showing "not pulled yet" until the user
+            // pulled or merged, even though the commits were already fetched.
+            refreshRefsAndHistory();
         }
     });
 }
@@ -892,11 +970,22 @@ void RepositorySession::fetchRemoteSilently() {
     // No askpassDir wiring: an empty FetchRequest::askpassDir means "no
     // credential prompt is possible", so an auth failure fails fast instead
     // of starting the askpass watcher that would otherwise surface a dialog.
-    submitAndRefresh(makeFetchOperation(FetchRequest{}), [this](bool succeeded) {
-        if (succeeded) {
-            refreshRefs();
-        }
-    });
+    // prune = true so a deleted remote branch's remote-tracking ref actually
+    // goes away here, instead of lingering as a `[gone]` upstream that
+    // historySeedRefs has to keep filtering out on every refresh.
+    FetchRequest request;
+    request.prune = true;
+    // drivesBusy = false: this runs automatically (repo open, window
+    // re-activation), not from a user action, so the UI must not read as
+    // stalled for a network round trip nobody asked for.
+    submitAndRefresh(
+        makeFetchOperation(std::move(request)),
+        [this](bool succeeded) {
+            if (succeeded) {
+                refreshRefsAndHistory();
+            }
+        },
+        /*drivesBusy=*/false);
 }
 
 void RepositorySession::maybeAutoFetch() {
@@ -920,8 +1009,7 @@ void RepositorySession::pullChanges(PullRequest request) {
         askpass_->stop();
         refreshWorkingCopyStatus();
         if (succeeded) {
-            refreshRefs();
-            refreshHistory();
+            refreshRefsAndHistory();
         }
     });
 }

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -89,7 +89,11 @@ public:
 
     /// Starts (or restarts) the history walk. Any walk already running is
     /// cancelled rather than waited for, which is what makes changing a filter or
-    /// switching repositories feel immediate.
+    /// switching repositories feel immediate. Re-reads refs itself (see the
+    /// comment inside), so a caller that just changed something ref-related
+    /// and wants both refreshed should call refreshRefsAndHistory() instead
+    /// -- this alone is for the cases with no accompanying refreshRefs()
+    /// call, e.g. setHistoryFilter().
     void refreshHistory(HistoryQuery query = {});
 
     /// Sets the branch/ref filter the graph should show from now on (empty
@@ -105,6 +109,14 @@ public:
     const HistoryQuery& historyFilter() const { return activeHistoryQuery_; }
 
     void refreshRefs();
+
+    /// refreshRefs() + refreshHistory() sharing a single `for-each-ref` load
+    /// instead of each independently re-running it. Every current call site
+    /// that calls both back-to-back should call this instead: measured on a
+    /// synthetic repository with ~3.8k refs, the second for-each-ref alone
+    /// cost more than the entire rev-list walk that followed it (~750ms vs
+    /// ~450ms for 50k commits with a commit-graph) -- see docs/PERFORMANCE.md.
+    void refreshRefsAndHistory(HistoryQuery query = {});
 
     /// Queues metadata for rows the user can actually see. Called by the model on
     /// a cache miss; never blocks the caller.
@@ -128,6 +140,15 @@ public:
     /// through the same askpass dance as `deleteTag`'s `alsoRemote` path.
     void deleteBranch(const DeleteBranchRequest& request);
 
+    /// Cancels every in-flight read this session may have posted to the
+    /// shared read pool -- both readCancel_ (refs, metadata, diffs, working
+    /// copy status, ...) and historyCancel_ (the history walk, which
+    /// supersedes itself independently on every refreshHistory() call, so it
+    /// needs its own explicit cancel here too). Called before destroying this
+    /// session (MainWindow::closeRepository) so no queued or in-flight
+    /// worker task is still touching it -- see ThreadPool::cancelQueuedAndDrain,
+    /// which the caller uses right after this to actually wait for whatever
+    /// was already running to notice and stop.
     void cancelPendingReads();
 
     /// The most recent working-copy status. May be stale until the next
@@ -458,8 +479,25 @@ private:
     /// banner reacts uniformly regardless of which kind of operation this is),
     /// and hands the outcome to `afterFinished` for the caller to decide what
     /// to refresh.
+    ///
+    /// `drivesBusy`: false for background work the user didn't ask for and
+    /// shouldn't have to watch (currently just fetchRemoteSilently) -- the UI
+    /// should not read as stalled for a network operation nobody triggered.
+    /// Every user-initiated caller leaves this at the default.
     void submitAndRefresh(std::unique_ptr<Operation> operation,
-                          std::function<void(bool succeeded)> afterFinished);
+                          std::function<void(bool succeeded)> afterFinished,
+                          bool drivesBusy = true);
+
+    /// The seed/filter/fingerprint/walk portion shared by refreshHistory()'s
+    /// and refreshRefsAndHistory()'s posted tasks -- everything after "I now
+    /// have a RefSnapshotPtr". Runs on a worker thread. `refsForSeed` may be
+    /// null (refs unreadable, e.g. a repository with no commits yet); the
+    /// walk still runs with no seed, matching refreshHistory()'s prior
+    /// behaviour. Handles its own busy/error/graphUpdated signalling, so
+    /// callers only need to have called setBusy(true) beforehand.
+    void walkHistoryWithRefs(HistoryQuery query,
+                             RefSnapshotPtr refsForSeed,
+                             CancellationToken token);
 
     GitInstallation installation_;
     RepoPaths paths_;
@@ -516,7 +554,13 @@ private:
 
     /// Debounce state for maybeAutoFetch(); nullopt before the first call.
     std::optional<std::chrono::steady_clock::time_point> lastAutoFetchAt_;
-    static constexpr std::chrono::seconds kAutoFetchMinInterval{30};
+    /// 30s was tuned for "every History tab visit", which this no longer
+    /// runs on (see MainWindow::onShowHistory) -- the remaining triggers are
+    /// repo-open and window re-activation (MainWindow::onWindowActivated),
+    /// both far less frequent, so a silent `git fetch` no longer needs to be
+    /// this eager. Still short enough that opening the app after a while
+    /// away, or alt-tabbing back after a long break, picks up new commits.
+    static constexpr std::chrono::minutes kAutoFetchMinInterval{5};
 
     int busyCount_ = 0;
 };

--- a/src/app/dialogs/GraphBranchFilterDialog.h
+++ b/src/app/dialogs/GraphBranchFilterDialog.h
@@ -13,9 +13,10 @@ namespace gbm {
 
 /// Lets the user pick which branches the History graph should be built
 /// from. Backed by RepositorySession::setHistoryFilter / HistoryQuery::
-/// includeRefs -- both already fully wired to `git rev-list`, this dialog is
-/// just the missing UI for it. Nothing checked means "show everything",
-/// matching HistoryQuery::includeRefs's own "empty means --all" contract.
+/// includeRefs, which narrows the `git rev-list` walk to only what's
+/// reachable from the checked refs (no `--all`) -- this dialog is just the
+/// UI for it. Nothing checked means "show everything", matching
+/// HistoryQuery::includeRefs's own "empty means --all" contract.
 class GraphBranchFilterDialog : public QDialog {
     Q_OBJECT
 

--- a/src/app/models/PillPainter.cpp
+++ b/src/app/models/PillPainter.cpp
@@ -44,13 +44,20 @@ PillColors PillPainter::colorsForRef(RefKind kind, bool isHead) {
                         ThemeManager::color(Token::Accent),
                         ThemeManager::color(Token::Accent)};
             }
-            return {ThemeManager::color(Token::Accent),
-                    ThemeManager::color(Token::AccentSubtle),
-                    ThemeManager::color(Token::AccentSubtle)};
+            // RefChipFill/RefChipText, not Accent/AccentSubtle: AccentSubtle is
+            // byte-identical to SurfaceSelected in the dark and neutral themes,
+            // so a chip painted with it disappeared entirely on a selected row.
+            return {ThemeManager::color(Token::RefChipText),
+                    ThemeManager::color(Token::RefChipFill),
+                    ThemeManager::color(Token::RefChipFill)};
         case RefKind::Tag:
+            // SurfaceHover rather than no fill (QColor() = invalid, so
+            // fillPath was skipped entirely) -- without it the "pill" was
+            // just an outline with no fill, compositing straight onto
+            // whatever the view painted behind it.
             return {ThemeManager::color(Token::Warning),
                     ThemeManager::color(Token::BorderDefault),
-                    QColor()};
+                    ThemeManager::color(Token::SurfaceHover)};
         case RefKind::RemoteBranch:
         case RefKind::Note:
         case RefKind::Stash:
@@ -58,7 +65,7 @@ PillColors PillPainter::colorsForRef(RefKind kind, bool isHead) {
         default:
             return {ThemeManager::color(Token::TextTertiary),
                     ThemeManager::color(Token::BorderDefault),
-                    QColor()};
+                    ThemeManager::color(Token::SurfaceHover)};
     }
 }
 

--- a/src/app/theme/ThemeTokens.cpp
+++ b/src/app/theme/ThemeTokens.cpp
@@ -11,7 +11,7 @@ namespace {
 // parallel arrays (rather than, say, a QHash per theme) makes it obvious at a
 // glance that every theme defines every token, and a mismatched row count is a
 // compile-time array-size error rather than a silent runtime gap.
-constexpr int kTokenCount = 37;
+constexpr int kTokenCount = 39;
 
 using TokenTable = std::array<const char*, kTokenCount>;
 
@@ -39,6 +39,8 @@ constexpr TokenTable kDarkTechnical{{
     "#4c9bff",  // AccentHover
     "#1f6ce0",  // AccentActive
     "#0d2a4d",  // AccentSubtle
+    "#1c3f66",  // RefChipFill -- distinct from SurfaceSelected (#0d2a4d)
+    "#eaf1fe",  // RefChipText -- ~10:1 contrast against RefChipFill
     "#3fb950",  // Success
     "#f85149",  // Danger
     "#ff6a63",  // DangerHover
@@ -80,6 +82,8 @@ constexpr TokenTable kLightIde{{
     "#1f6ce0",  // AccentHover
     "#1857b8",  // AccentActive
     "#eaf1fe",  // AccentSubtle
+    "#c7dbfa",  // RefChipFill -- distinct from SurfaceSelected (#e4edfd) and AccentSubtle (#eaf1fe)
+    "#1857b8",  // RefChipText -- ~5.2:1 contrast against RefChipFill
     "#1a7f37",  // Success
     "#cf222e",  // Danger
     "#a40e26",  // DangerHover
@@ -124,6 +128,8 @@ constexpr TokenTable kNeutralProfessional{{
     "#1f6ce0",  // AccentHover       (accent-600)
     "#1857b8",  // AccentActive      (accent-700)
     "#eaf1fe",  // AccentSubtle      (accent-50)
+    "#c7dbfa",  // RefChipFill -- distinct from SurfaceSelected/AccentSubtle (both accent-50)
+    "#1857b8",  // RefChipText       (accent-700)
     "#1a8a4a",  // Success           (green-500)
     "#d33d3d",  // Danger            (red-500)
     "#b32c2c",  // DangerHover       (red-600)

--- a/src/app/theme/Tokens.h
+++ b/src/app/theme/Tokens.h
@@ -36,6 +36,14 @@ enum class Token {
     AccentHover,
     AccentActive,
     AccentSubtle,
+    /// Non-HEAD local-branch ref chip (PillPainter::colorsForRef). Deliberately
+    /// its own tokens rather than reusing Accent/AccentSubtle: AccentSubtle is
+    /// byte-identical to SurfaceSelected in the dark and neutral themes, so a
+    /// chip painted with it disappears entirely on a selected commit row.
+    /// RefChipFill doubles as the chip's border, matching how the HEAD chip
+    /// already uses one token (Accent) for both.
+    RefChipFill,
+    RefChipText,
     Success,
     Danger,
     DangerHover,

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -37,6 +37,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDialog>
+#include <QElapsedTimer>
 #include <QFileDialog>
 #include <QGuiApplication>
 #include <QHBoxLayout>
@@ -146,6 +147,19 @@ MainWindow::MainWindow(GitInstallation installation, QWidget* parent)
                 repoModel_->setProbe(repoId, probe);
             });
     connect(discovery_.get(), &DiscoveryController::errorOccurred, this, &MainWindow::onCoreError);
+
+    // App-level activation, not QEvent::WindowActivate: the latter fires on
+    // this window every time a child dialog (Branches…, a QMessageBox, …) is
+    // dismissed, since focus returns to MainWindow as a *window* activation
+    // even though the app itself never lost focus. That would resync on
+    // every dialog close, not just on alt-tab back into the app -- see
+    // onWindowActivated()'s doc comment.
+    connect(
+        qApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state) {
+            if (state == Qt::ApplicationActive) {
+                onWindowActivated();
+            }
+        });
 }
 
 MainWindow::~MainWindow() {
@@ -153,6 +167,13 @@ MainWindow::~MainWindow() {
     // teardown must not call into a destroyed widget.
     Log::instance().setOperationSink(nullptr);
     Log::instance().setMessageSink(nullptr);
+    // closeRepository() cancels, drains and destroys session_ (in that
+    // order -- see its own comments) before returning, so readPool_ is
+    // already idle and holds nothing capturing the now-destroyed session by
+    // the time shutdown() below joins its workers. Keep this ordering: a
+    // shutdown() before closeRepository() would join workers that are still
+    // draining, and ThreadPool::shutdown() *joins* whatever is still queued
+    // rather than discarding it.
     closeRepository();
     readPool_.shutdown();
 }
@@ -606,17 +627,20 @@ void MainWindow::buildMenus() {
     viewMenu->addSeparator();
     // Refresh/rescan/cancel-scan have no home in the design's 7-menu table --
     // View is the most sensible fit, so they stay here.
-    auto* refreshAction =
-        viewMenu->addAction(QStringLiteral("Refresh"), this, &MainWindow::onRefresh);
+    //
+    // This action only rescans the repository-browser list (see
+    // rescanRepositories()) -- an open session re-syncs itself automatically
+    // on window re-activation instead (resyncOpenSession(), wired from
+    // event()), so the button has nothing to do on the graph page and is
+    // hidden there by the stack_->currentChanged connection below.
+    auto* refreshAction = viewMenu->addAction(
+        QStringLiteral("Refresh Repository List"), this, &MainWindow::onRefresh);
     refreshAction->setShortcut(QKeySequence(Qt::Key_F5));
-    // Real Lucide SVGs (refresh-cw, download-cloud, arrow-down-to-line,
-    // arrow-up-from-line) are what the design names, but this sandbox has no
-    // network access to fetch them -- Qt's bundled standard icons stand in
-    // rather than shipping fabricated placeholder SVGs.
-    refreshAction->setIcon(style()->standardIcon(QStyle::SP_BrowserReload));
     refreshAction_ = refreshAction;
-    auto* forceAction = viewMenu->addAction(
-        QStringLiteral("Refresh (rescan everything)"), this, &MainWindow::onForceRefresh);
+    auto* forceAction =
+        viewMenu->addAction(QStringLiteral("Refresh Repository List (rescan everything)"),
+                            this,
+                            &MainWindow::onForceRefresh);
     forceAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+F5")));
     viewMenu->addAction(QStringLiteral("Cancel scan"), this, &MainWindow::onCancelScan);
     viewMenu->addAction(QStringLiteral("Preferences…"), this, &MainWindow::onShowPreferences);
@@ -823,6 +847,16 @@ void MainWindow::buildMenus() {
     refreshAction->setIcon(IconLoader::icon(QStringLiteral("refresh-cw"), Token::TextSecondary));
     toolBar->addAction(refreshAction);
 
+    // "Refresh Repository List" only does anything on the repository-browser
+    // page (stack_ index 0); an open session (index 1, which includes the
+    // graph) re-syncs itself on window re-activation instead, so the action
+    // -- toolbar button and View menu entry alike, since both are this same
+    // QAction -- has no reason to occupy space there.
+    connect(stack_, &QStackedWidget::currentChanged, this, [this](int index) {
+        refreshAction_->setVisible(index == 0);
+    });
+    refreshAction_->setVisible(stack_->currentIndex() == 0);
+
     toolBar->addSeparator();
 
     // Checkable and exclusive, unlike the plain QActions this replaces (which
@@ -968,28 +1002,28 @@ void MainWindow::onManageBaseFolders() {
 }
 
 void MainWindow::onRefresh() {
-    discovery_->startScan(ScanMode::Incremental);
-    // The discovery rescan above only refreshes the sidebar's repo list --
-    // it never touches the currently open session, so external changes (a
-    // `git stash` run in another terminal, for instance) were invisible
-    // until the user switched tabs. Refresh the open session's live state
-    // too.
-    if (session_) {
-        session_->refreshWorkingCopyStatus();
-        session_->refreshStashes();
-        session_->refreshRefs();
-        session_->refreshHistory();
-    }
+    rescanRepositories(ScanMode::Incremental);
 }
 
 void MainWindow::onForceRefresh() {
-    discovery_->startScan(ScanMode::Full);
-    if (session_) {
-        session_->refreshWorkingCopyStatus();
-        session_->refreshStashes();
-        session_->refreshRefs();
-        session_->refreshHistory();
+    rescanRepositories(ScanMode::Full);
+}
+
+void MainWindow::rescanRepositories(ScanMode mode) {
+    // Repository-browser list only -- an open session (the graph, working
+    // copy, stashes) re-syncs itself on window re-activation instead; see
+    // resyncOpenSession() and onWindowActivated(). Deliberately does not
+    // touch session_ here even when one is open.
+    discovery_->startScan(mode);
+}
+
+void MainWindow::resyncOpenSession() {
+    if (!session_) {
+        return;
     }
+    session_->refreshWorkingCopyStatus();
+    session_->refreshStashes();
+    session_->refreshRefsAndHistory();
 }
 
 void MainWindow::onCancelScan() {
@@ -997,13 +1031,34 @@ void MainWindow::onCancelScan() {
     statusLabel_->setText(QStringLiteral("Cancelling scan…"));
 }
 
+void MainWindow::onWindowActivated() {
+    // Called from qApp's applicationStateChanged reaching Qt::ApplicationActive
+    // -- i.e. the app regaining OS-level focus (alt-tab back in), not any
+    // window inside it becoming active. Throttled: alt-tabbing repeatedly must
+    // not queue a rev-list walk per activation. maybeAutoFetch() below is
+    // unaffected by this throttle -- it is network work and is gated by its
+    // own, much longer interval (RepositorySession::kAutoFetchMinInterval), so
+    // this only controls how often the (local, cheap) resync can run.
+    if (windowActivateThrottle_.isValid() &&
+        windowActivateThrottle_.elapsed() < kWindowActivateThrottleMs) {
+        return;
+    }
+    windowActivateThrottle_.restart();
+
+    resyncOpenSession();
+    if (session_) {
+        session_->maybeAutoFetch();
+    }
+}
+
 void MainWindow::onShowHistory() {
     if (session_) {
         stack_->setCurrentIndex(1);
         tabWidget_->setCurrentIndex(kHistoryTab);
-        // Sync branch status on every visit, not just on repo open -- see
-        // RepositorySession::maybeAutoFetch (debounced, silent on failure).
-        session_->maybeAutoFetch();
+        // No maybeAutoFetch() here anymore: repo-open plus window
+        // re-activation (onWindowActivated) already cover it, and firing a
+        // silent `git fetch` on every tab visit was needlessly eager -- see
+        // RepositorySession::kAutoFetchMinInterval's comment.
     }
 }
 
@@ -1162,9 +1217,10 @@ void MainWindow::openRepository(const RepoRecord& record) {
     updateStateBanner();
 
     // Refs first, so the history walk can be seeded with HEAD and the trunk; that
-    // seeding order is what puts the trunk in lane 0.
-    session_->refreshRefs();
-    session_->refreshHistory();
+    // seeding order is what puts the trunk in lane 0. refreshRefsAndHistory()
+    // shares a single for-each-ref load between the two rather than each
+    // independently re-running it -- see its doc comment.
+    session_->refreshRefsAndHistory();
     // So the remote picker in the Push/Push tag dialogs has something to show
     // the first time they are opened, without waiting on a Fetch.
     session_->refreshRemotes();
@@ -1219,6 +1275,22 @@ void MainWindow::closeRepository() {
         return;
     }
     session_->cancelPendingReads();
+    // Block until every read task this session posted to readPool_ has
+    // either been discarded (still queued) or actually noticed cancellation
+    // and returned (already running) -- without this, session_.reset() below
+    // could destroy the session while a worker thread was still inside it
+    // (RepositorySession, CatFileBatch, HistoryProvider, ...), which is
+    // exactly the "Unhandled exception in reads worker: no such process"
+    // reports on Windows traced back to. In the expected case this resolves
+    // quickly: every read this session posts is built on ProcessRunner (which
+    // now unregisters its cancel callback on every return path) or
+    // CatFileBatch (whose read()/readCommit()/readCommits() now all take a
+    // token, checked before each object starts). That is not a hard bound,
+    // though -- CatFileBatch's pipe read has no deadline, so a single request
+    // already in flight when cancellation fires still blocks until the child
+    // answers it. See ThreadPool::cancelQueuedAndDrain's doc for the same
+    // caveat spelled out in full.
+    readPool_.cancelQueuedAndDrain();
     // commitModel_->setSession(nullptr) resets the model, which fires
     // modelAboutToBeReset and collapses any inline expansion -- see the
     // connection in buildUi() -- but the closing-repository case is worth

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -17,6 +17,7 @@
 #include "core/git/GitExecutable.h"
 #include "core/workers/ThreadPool.h"
 
+#include <QElapsedTimer>
 #include <QLabel>
 #include <QList>
 #include <QMainWindow>
@@ -85,6 +86,7 @@ private slots:
     void onRefresh();
     void onForceRefresh();
     void onCancelScan();
+    void onWindowActivated();
     void onRepoActivated(const QModelIndex& index);
     void onRepoRowClicked(const QModelIndex& index);
     void openPendingRepo();
@@ -176,6 +178,19 @@ private:
     void buildMenus();
     void openRepository(const RepoRecord& record);
     void closeRepository();
+
+    /// Rescans the base folders for repositories (what the "Refresh
+    /// Repository List" action/F5 does). Only touches the repo-list page --
+    /// an already-open session is untouched, see resyncOpenSession().
+    void rescanRepositories(ScanMode mode);
+
+    /// Re-syncs the currently open session's working-copy status, stashes,
+    /// refs and history from disk -- everything an external `git` command run
+    /// in another terminal could have changed. Called on window re-activation
+    /// (throttled, see windowActivateThrottle_); no longer reachable from the
+    /// Refresh button, which is repo-list-only now (see rescanRepositories()).
+    /// A no-op if no session is open.
+    void resyncOpenSession();
     void probeVisibleRepos();
     void updateStateBanner();
     /// Restores `splitter`'s sizes from QSettings key `window/splitters/<key>`
@@ -370,6 +385,14 @@ private:
     /// tearing down -- a RepositorySession per row passed through.
     QTimer* repoOpenDebounce_ = nullptr;
     int pendingRepoOpenRow_ = -1;
+
+    /// Throttles resyncOpenSession() on repeated app-activation events (e.g.
+    /// alt-tab drumming) to roughly once per second. Local git reads only --
+    /// the auto-fetch triggered alongside it (RepositorySession::
+    /// maybeAutoFetch) is gated by its own, much longer interval, not this
+    /// one; see the call site in onWindowActivated().
+    QElapsedTimer windowActivateThrottle_;
+    static constexpr qint64 kWindowActivateThrottleMs = 1000;
 
     /// The target of the checkout currently in flight (a ref name or a raw
     /// commit hex), so onOperationFinished's dirty-work-tree retry re-issues

--- a/src/core/base/CancellationToken.h
+++ b/src/core/base/CancellationToken.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -14,8 +16,18 @@ namespace detail {
 struct CancellationState {
     std::atomic_bool cancelled{false};
     std::mutex mutex;
-    std::vector<std::function<void()>> callbacks;
+    std::vector<std::pair<std::uint64_t, std::function<void()>>> callbacks;
+    std::uint64_t nextCallbackId = 0;
 };
+
+inline void removeCallback(CancellationState& state, std::uint64_t id) {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    auto& callbacks = state.callbacks;
+    callbacks.erase(std::remove_if(callbacks.begin(),
+                                   callbacks.end(),
+                                   [id](const auto& entry) { return entry.first == id; }),
+                    callbacks.end());
+}
 
 }  // namespace detail
 
@@ -33,21 +45,79 @@ public:
         return state_ && state_->cancelled.load(std::memory_order_acquire);
     }
 
+    /// RAII handle for one onCancel() registration: unregisters the callback
+    /// on destruction (or an explicit reset()). Move-only, so exactly one
+    /// owner decides when the callback's captures stop being valid --
+    /// whoever calls onCancel() must keep the returned Registration alive
+    /// for at least as long as anything the callback closes over. This is
+    /// what ProcessRunner::execute() uses to stop a callback capturing a
+    /// stack local from outliving the stack frame that registered it: every
+    /// return path destroys the local Registration first.
+    ///
+    /// A callback that is mid-fire (CancellationSource::cancel() already
+    /// swapped it out of the callback list) and a concurrent reset() are
+    /// both safe -- they never touch the same list entry at once, since
+    /// cancel() removes every callback from the list before invoking any of
+    /// them.
+    class Registration {
+    public:
+        Registration() = default;
+        Registration(const Registration&) = delete;
+        Registration& operator=(const Registration&) = delete;
+
+        Registration(Registration&& other) noexcept { *this = std::move(other); }
+
+        Registration& operator=(Registration&& other) noexcept {
+            if (this != &other) {
+                reset();
+                state_ = std::move(other.state_);
+                id_ = other.id_;
+                other.state_.reset();
+            }
+            return *this;
+        }
+
+        ~Registration() { reset(); }
+
+        /// Unregisters early, if still registered. Idempotent.
+        void reset() {
+            if (state_) {
+                detail::removeCallback(*state_, id_);
+                state_.reset();
+            }
+        }
+
+    private:
+        friend class CancellationToken;
+
+        Registration(std::shared_ptr<detail::CancellationState> state, std::uint64_t id)
+            : state_(std::move(state)), id_(id) {}
+
+        std::shared_ptr<detail::CancellationState> state_;
+        std::uint64_t id_ = 0;
+    };
+
     /// Registers a callback fired on cancellation, used to tear down a child
     /// process's pipes. If cancellation already happened, runs immediately so
-    /// there is no race between registration and the cancel call.
-    void onCancel(std::function<void()> callback) const {
+    /// there is no race between registration and the cancel call -- in that
+    /// case the returned Registration is already empty, since there is
+    /// nothing left to unregister. The caller owns the returned Registration
+    /// and must keep it alive for exactly as long as the callback's captures
+    /// are valid.
+    [[nodiscard]] Registration onCancel(std::function<void()> callback) const {
         if (!state_) {
-            return;
+            return Registration{};
         }
         {
             std::lock_guard<std::mutex> lock(state_->mutex);
             if (!state_->cancelled.load(std::memory_order_acquire)) {
-                state_->callbacks.push_back(std::move(callback));
-                return;
+                const std::uint64_t id = state_->nextCallbackId++;
+                state_->callbacks.emplace_back(id, std::move(callback));
+                return Registration(state_, id);
             }
         }
         callback();
+        return Registration{};
     }
 
 private:
@@ -64,7 +134,7 @@ public:
     /// Idempotent and thread-safe. Callbacks run on the calling thread exactly
     /// once, outside the lock so a callback may re-enter safely.
     void cancel() {
-        std::vector<std::function<void()>> toRun;
+        std::vector<std::pair<std::uint64_t, std::function<void()>>> toRun;
         {
             std::lock_guard<std::mutex> lock(state_->mutex);
             if (state_->cancelled.exchange(true, std::memory_order_acq_rel)) {
@@ -72,7 +142,7 @@ public:
             }
             toRun.swap(state_->callbacks);
         }
-        for (auto& callback : toRun) {
+        for (auto& [id, callback] : toRun) {
             callback();
         }
     }

--- a/src/core/git/CatFileBatch.cpp
+++ b/src/core/git/CatFileBatch.cpp
@@ -352,13 +352,20 @@ bool CatFileBatch::isRunning() const {
     return impl_ && impl_->isRunning() && !poisoned_;
 }
 
-GitResult<CatFileBatch::Object> CatFileBatch::read(std::string_view revision) {
+GitResult<CatFileBatch::Object> CatFileBatch::read(std::string_view revision,
+                                                   CancellationToken token) {
     GBM_ASSERT_NOT_UI_THREAD();
 
     // A revision containing a newline would inject a second request into the
     // protocol stream. Reject rather than sanitise: no legitimate caller does it.
     if (revision.empty() || revision.find('\n') != std::string_view::npos) {
         return fail(GitError::Code::InvalidArgument, "Invalid object revision");
+    }
+
+    // Checked before taking the lock and before any I/O -- see the doc comment
+    // on this method for what this does and does not bound.
+    if (token.isCancelled()) {
+        return fail(GitError::Code::Cancelled, "Read cancelled");
     }
 
     std::lock_guard<std::mutex> lock(mutex_);
@@ -453,11 +460,11 @@ GitResult<CatFileBatch::Object> CatFileBatch::read(std::string_view revision) {
     return object;
 }
 
-GitResult<CommitMeta> CatFileBatch::readCommit(const ObjectId& oid) {
+GitResult<CommitMeta> CatFileBatch::readCommit(const ObjectId& oid, CancellationToken token) {
     if (oid.isNull()) {
         return fail(GitError::Code::InvalidArgument, "Null object id");
     }
-    auto object = read(oid.hex());
+    auto object = read(oid.hex(), token);
     if (!object) {
         return fail(std::move(object).error());
     }
@@ -468,11 +475,20 @@ GitResult<CommitMeta> CatFileBatch::readCommit(const ObjectId& oid) {
     return CommitMeta::parseRawCommit(oid, object->content);
 }
 
-std::vector<CommitMeta> CatFileBatch::readCommits(const std::vector<ObjectId>& oids) {
+std::vector<CommitMeta> CatFileBatch::readCommits(const std::vector<ObjectId>& oids,
+                                                  CancellationToken token) {
     std::vector<CommitMeta> result;
     result.reserve(oids.size());
     for (const auto& oid : oids) {
-        auto meta = readCommit(oid);
+        // Checked per-oid, not just once before the loop: a viewport request
+        // can carry hundreds of oids, and a session close or repository
+        // switch cancelling mid-batch must stop issuing requests immediately
+        // rather than running the loop to completion against a CatFileBatch
+        // that may already be mid-stop() on another thread.
+        if (token.isCancelled()) {
+            break;
+        }
+        auto meta = readCommit(oid, token);
         if (meta) {
             result.push_back(std::move(*meta));
         }

--- a/src/core/git/CatFileBatch.h
+++ b/src/core/git/CatFileBatch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/base/CancellationToken.h"
 #include "core/base/Error.h"
 #include "core/git/CommitMeta.h"
 #include "core/git/RepoPaths.h"
@@ -48,15 +49,36 @@ public:
     /// Reads one object by any revision expression git accepts (`<oid>`,
     /// `HEAD:path`, `<oid>^{tree}`). Returns NotFound for a missing object
     /// without tearing down the co-process.
-    GitResult<Object> read(std::string_view revision);
+    ///
+    /// `token` is checked once at entry, before any I/O, so a request that is
+    /// still queued behind a cancellation (repository switch, closing the
+    /// session) never starts. It is *not* checked mid-flight: the read/write
+    /// calls to the child's pipe are plain blocking calls with no deadline, so
+    /// a request already in progress runs to completion (or to the child's own
+    /// I/O error) before this returns. That is a real, currently-unbounded
+    /// wait if the child process itself hangs. It is accepted rather than
+    /// fixed here because the child is a `git cat-file --batch` process this
+    /// app spawns and owns, expected to answer promptly -- a hang there is a
+    /// distinct failure mode from the freed-object crash this cancellation
+    /// exists to prevent (see `ThreadPool::cancelQueuedAndDrain`).
+    GitResult<Object> read(std::string_view revision, CancellationToken token = {});
 
     /// Reads and parses a commit. The common case, called in viewport batches.
-    GitResult<CommitMeta> readCommit(const ObjectId& oid);
+    GitResult<CommitMeta> readCommit(const ObjectId& oid, CancellationToken token = {});
 
     /// Batch form. A failure on one object does not abort the rest; missing
     /// entries are simply absent from the result, so a partially-corrupt
     /// repository still browses.
-    std::vector<CommitMeta> readCommits(const std::vector<ObjectId>& oids);
+    ///
+    /// `token` is checked before each object, not just once before the whole
+    /// batch: a viewport request can ask for hundreds of oids, and this is
+    /// what lets a cancellation (repository switch, closing the session) stop
+    /// the loop from *starting* further requests immediately, rather than
+    /// continuing to issue them against a `CatFileBatch` that may already be
+    /// mid-`stop()` on another thread. See `read()`'s doc for what this does
+    /// not cover: a request already in flight when cancellation fires still
+    /// runs to completion.
+    std::vector<CommitMeta> readCommits(const std::vector<ObjectId>& oids, CancellationToken token);
 
 private:
     class Impl;

--- a/src/core/git/HistoryProvider.cpp
+++ b/src/core/git/HistoryProvider.cpp
@@ -45,13 +45,22 @@ std::vector<std::string> HistoryQuery::toRevListArgs() const {
         args.emplace_back("--until=" + std::to_string(*until));
     }
 
-    // Explicit tips first, then --all. rev-list de-duplicates, and the graph
-    // builder assigns lane 0 to the first tip it encounters, so this ordering is
-    // what pins the trunk to the leftmost column.
-    for (const std::string& ref : includeRefs) {
-        args.push_back(ref);
+    // includeRefs narrows the walk (the branch filter): no --all, only what's
+    // reachable from these tips. Otherwise seedRefs (usually HEAD's branch
+    // plus its upstream and the trunk) go first purely to order the tips --
+    // rev-list de-duplicates, and the graph builder assigns lane 0 to the
+    // first tip it encounters, so this ordering is what pins the trunk to the
+    // leftmost column -- and --all still supplies everything else.
+    if (!includeRefs.empty()) {
+        for (const std::string& ref : includeRefs) {
+            args.push_back(ref);
+        }
+    } else {
+        for (const std::string& ref : seedRefs) {
+            args.push_back(ref);
+        }
+        args.emplace_back("--all");
     }
-    args.emplace_back("--all");
 
     for (const std::string& ref : excludeRefs) {
         args.emplace_back("--not");

--- a/src/core/git/HistoryProvider.h
+++ b/src/core/git/HistoryProvider.h
@@ -20,7 +20,20 @@ namespace gbm {
 /// orders of magnitude faster inside git, and a filter proxy in front of 500k
 /// rows would be unusable. Changing a filter restarts the walk.
 struct HistoryQuery {
-    std::vector<std::string> includeRefs;  ///< Empty means --all.
+    /// Tips to walk from before `--all`, purely to order them ahead of it --
+    /// the graph builder gives lane 0 to the first tip it sees, which is how
+    /// HEAD's branch (or the trunk) stays leftmost. Every commit reachable
+    /// from any ref is still included; this never narrows the walk. Populated
+    /// automatically from the refs whenever includeRefs is empty -- see
+    /// RepositorySession::refreshHistory.
+    std::vector<std::string> seedRefs;
+    /// When non-empty, narrows the walk to only what's reachable from these
+    /// refs -- no implicit `--all`. This is what "Branches…" (the graph
+    /// branch filter) sets. Every ref here must exist in the current
+    /// RefSnapshot before being handed to rev-list: a name that's gone stale
+    /// (e.g. a pruned `refs/remotes/origin/*`) aborts the whole walk with
+    /// "unknown revision" rather than just being skipped.
+    std::vector<std::string> includeRefs;
     std::vector<std::string> excludeRefs;
     std::optional<std::string> pathFilter;
     std::optional<std::string> grep;

--- a/src/core/git/ProcessRunner.cpp
+++ b/src/core/git/ProcessRunner.cpp
@@ -775,9 +775,20 @@ private:
 
         // Cancelling closes the child down. Registered after a successful spawn
         // so there is no window in which we could signal a pid we do not own.
-        std::atomic_bool cancelObserved{false};
-        token.onCancel([child, &cancelObserved] {
-            cancelObserved.store(true);
+        //
+        // `cancelObserved` is a shared_ptr, not a stack local captured by
+        // reference: without the Registration below, a cancel firing after
+        // this function had already returned (readCancel_ was only replaced
+        // on the next explicit cancelPendingReads(), so a session could
+        // accumulate one registered callback per git process for its whole
+        // lifetime, and cancelPendingReads() fired all of them at once on
+        // repo switch) wrote into a long-dead stack frame. `cancelReg`
+        // unregisters the callback on every return path below, and the
+        // shared_ptr is belt-and-braces against any callback that is already
+        // mid-fire when that happens.
+        auto cancelObserved = std::make_shared<std::atomic_bool>(false);
+        CancellationToken::Registration cancelReg = token.onCancel([child, cancelObserved] {
+            cancelObserved->store(true);
             child->terminate();
         });
 
@@ -795,7 +806,14 @@ private:
         result.exitCode = child->wait();
         result.duration =
             std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - started);
-        result.cancelled = cancelObserved.load() || token.isCancelled();
+        result.cancelled = cancelObserved->load() || token.isCancelled();
+
+        // The child has been waited on (reaped) by this point, and every
+        // path below only reports the result -- nothing past here needs the
+        // callback to stay registered, so unregister it now rather than
+        // leaving it live until the caller's CancellationSource is
+        // eventually replaced or destroyed.
+        cancelReg.reset();
 
         recordOperation(
             command, argv, result.err, result.exitCode, started, result.cancelled, result.timedOut);

--- a/src/core/git/RefStore.cpp
+++ b/src/core/git/RefStore.cpp
@@ -43,6 +43,11 @@ void parseTrack(std::string_view track, RefInfo& info) {
     }
     info.hasTrackingInfo = true;
 
+    if (track.find("[gone]") != std::string_view::npos) {
+        info.isGone = true;
+        return;
+    }
+
     auto readNumberAfter = [&track](std::string_view keyword) -> int {
         const std::size_t at = track.find(keyword);
         if (at == std::string_view::npos) {
@@ -260,6 +265,12 @@ GitResult<RefSnapshotPtr> RefStore::load(CancellationToken token) {
     return RefSnapshotPtr(snapshot);
 }
 
+bool RefStore::refExists(const RefSnapshot& refs, const std::string& fullName) {
+    return std::any_of(refs.refs.begin(), refs.refs.end(), [&fullName](const RefInfo& ref) {
+        return ref.fullName == fullName;
+    });
+}
+
 std::vector<std::string> RefStore::historySeedRefs(const RefSnapshot& refs) {
     // Order matters: the graph builder gives lane 0 to the first tip it sees, so
     // HEAD and the trunk must come before --all. Everything after that is just
@@ -280,9 +291,18 @@ std::vector<std::string> RefStore::historySeedRefs(const RefSnapshot& refs) {
         push("HEAD");
     }
 
-    // The upstream of HEAD, so the graph shows what the remote has too.
+    // The upstream of HEAD, so the graph shows what the remote has too --
+    // but only if it still exists. `%(upstream)` comes from
+    // `branch.<name>.remote`/`.merge` config, which survives the
+    // remote-tracking ref being pruned (the remote was removed, or the
+    // branch was deleted upstream and pruned locally): git then reports
+    // `%(upstream:track)` as `[gone]` (parsed into RefInfo::isGone above),
+    // but the stale name itself is still handed back. Passing it to rev-list
+    // unchecked aborts the *entire* walk with "unknown revision", not just
+    // this one seed -- so both signals from the same for-each-ref call are
+    // checked before trusting it.
     for (const RefInfo& ref : refs.refs) {
-        if (ref.isHead && !ref.upstream.empty()) {
+        if (ref.isHead && !ref.upstream.empty() && !ref.isGone && refExists(refs, ref.upstream)) {
             push(ref.upstream);
         }
     }
@@ -290,11 +310,7 @@ std::vector<std::string> RefStore::historySeedRefs(const RefSnapshot& refs) {
     // Conventional trunk names, whichever exists.
     for (const char* trunk :
          {"refs/heads/main", "refs/heads/master", "refs/heads/develop", "refs/heads/trunk"}) {
-        const bool exists =
-            std::any_of(refs.refs.begin(), refs.refs.end(), [trunk](const RefInfo& ref) {
-                return ref.fullName == trunk;
-            });
-        if (exists) {
+        if (refExists(refs, trunk)) {
             push(trunk);
         }
     }

--- a/src/core/git/RefStore.h
+++ b/src/core/git/RefStore.h
@@ -27,6 +27,11 @@ struct RefInfo {
     int ahead = 0;
     int behind = 0;
     bool hasTrackingInfo = false;
+    /// True when `%(upstream:track)` reported `[gone]`: `upstream` is a name
+    /// git still remembers from `branch.<name>.remote`/`.merge` config, but
+    /// the remote-tracking ref it names no longer exists (the remote was
+    /// removed, or the branch was deleted upstream and pruned locally).
+    bool isGone = false;
     bool isHead = false;
     bool isSymbolic = false;
     std::string worktreePath;  ///< Set when checked out in a linked worktree.
@@ -83,7 +88,18 @@ public:
     /// Ref tips to seed the history walk with, in the order they must be passed
     /// to rev-list. Seeding order is what assigns lane 0 to the trunk, so this
     /// deliberately lists HEAD and the trunk branch before anything else.
+    /// Every tip has already passed refExists() -- a stale name (a deleted
+    /// branch, or an upstream whose remote-tracking ref was pruned) is never
+    /// returned here.
     static std::vector<std::string> historySeedRefs(const RefSnapshot& refs);
+
+    /// Whether `fullName` (e.g. "refs/heads/main" or
+    /// "refs/remotes/origin/main") names a ref actually present in `refs`
+    /// right now. Every revision handed to `rev-list` as an explicit argument
+    /// -- a seed tip, a branch-filter selection -- must pass this first: git
+    /// rejects an unknown one with "fatal: ambiguous argument", which aborts
+    /// the *entire* walk rather than just omitting that one tip.
+    static bool refExists(const RefSnapshot& refs, const std::string& fullName);
 
     /// Whether a ref name is one git will accept, checked before we try to
     /// create it so the user gets a clear message instead of raw git output.

--- a/src/core/workers/ThreadPool.cpp
+++ b/src/core/workers/ThreadPool.cpp
@@ -59,6 +59,12 @@ void ThreadPool::drain() {
     idle_.wait(lock, [this] { return tasks_.empty() && activeTasks_ == 0; });
 }
 
+void ThreadPool::cancelQueuedAndDrain() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    tasks_.clear();
+    idle_.wait(lock, [this] { return activeTasks_ == 0; });
+}
+
 void ThreadPool::shutdown() {
     {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/src/core/workers/ThreadPool.h
+++ b/src/core/workers/ThreadPool.h
@@ -39,8 +39,28 @@ public:
     std::size_t queueDepth() const;
 
     /// Blocks until the queue drains. For tests and shutdown only — never call
-    /// this from the UI thread.
+    /// this from the UI thread: it waits for every currently-queued task too,
+    /// which is unbounded.
     void drain();
+
+    /// Discards every not-yet-started task, then blocks until whatever is
+    /// currently *executing* finishes. Unlike drain(), this is meant to be
+    /// called from the UI thread -- typically right after cancelling the
+    /// token(s) those tasks carry, so "currently executing" resolves quickly
+    /// in the common case: a task built on ProcessRunner kills its child and
+    /// returns within roughly one process-kill round trip; a task built on
+    /// CatFileBatch stops *issuing further requests* within roughly one
+    /// cat-file round trip (checked before each object, not mid-request), but
+    /// a single request already in flight when cancellation fires is a plain
+    /// blocking pipe read with no deadline and runs to completion against
+    /// whatever the child process does. That is only unbounded if the child
+    /// itself hangs, which is not expected of a process this app spawns and
+    /// owns, but it is not a hard guarantee this method makes. This is what
+    /// makes it safe to destroy a RepositorySession right after calling this
+    /// (no queued lambda capturing `this` can run, and nothing is still
+    /// running when it returns) -- not a promise of a bounded wait time. See
+    /// MainWindow::closeRepository.
+    void cancelQueuedAndDrain();
 
     void shutdown();
 

--- a/tests/tools/graph_check.cpp
+++ b/tests/tools/graph_check.cpp
@@ -83,17 +83,43 @@ int main(int argc, char** argv) {
     const gbm::RepoPaths paths(repoPath, repoPath / ".git", repoPath / ".git");
 
     // --- refs ---------------------------------------------------------------
+    // Timed, and run twice, to make the single-call cost and the
+    // "if something ran for-each-ref twice" cost both visible on whatever
+    // repository this is pointed at -- not just the rev-list walk
+    // docs/PERFORMANCE.md already measures. This is what motivated
+    // RepositorySession::refreshRefsAndHistory(), which shares one load
+    // between refreshRefs() and refreshHistory() instead of each
+    // independently re-running it (every call site that needs both now uses
+    // it); the second timing below is what that fix avoids paying for. See
+    // docs/PERFORMANCE.md's "UI refresh path" section for the numbers this
+    // produced on a repository with a few thousand refs.
     gbm::RefStore refStore(*runner, paths);
+    const auto refsStart = std::chrono::steady_clock::now();
     auto refs = refStore.load(gbm::CancellationToken{});
+    const auto refsFirstMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::steady_clock::now() - refsStart)
+                                 .count();
     if (!refs) {
         std::fprintf(stderr, "could not read refs: %s\n", refs.error().message.c_str());
         return 1;
     }
-    std::fprintf(stderr, "refs: %zu\n", (*refs)->totalRefCount);
+
+    const auto refsSecondStart = std::chrono::steady_clock::now();
+    auto refsAgain = refStore.load(gbm::CancellationToken{});
+    const auto refsSecondMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  std::chrono::steady_clock::now() - refsSecondStart)
+                                  .count();
+    check(static_cast<bool>(refsAgain), "second for-each-ref call failed");
+
+    std::fprintf(stderr,
+                 "refs: %zu (for-each-ref: %lldms once, %lldms twice back-to-back)\n",
+                 (*refs)->totalRefCount,
+                 static_cast<long long>(refsFirstMs),
+                 static_cast<long long>(refsFirstMs + refsSecondMs));
 
     // --- walk ---------------------------------------------------------------
     gbm::HistoryQuery query;
-    query.includeRefs = gbm::RefStore::historySeedRefs(**refs);
+    query.seedRefs = gbm::RefStore::historySeedRefs(**refs);
 
     const auto start = std::chrono::steady_clock::now();
     std::chrono::steady_clock::time_point firstChunk{};
@@ -147,7 +173,7 @@ int main(int argc, char** argv) {
     // The single most valuable assertion here: a plausible-looking graph built
     // from a misparsed walk is far worse than an obvious failure.
     std::vector<std::string> expectedArgs{"rev-list", "--topo-order"};
-    for (const std::string& ref : query.includeRefs) {
+    for (const std::string& ref : query.seedRefs) {
         expectedArgs.push_back(ref);
     }
     expectedArgs.emplace_back("--all");

--- a/tests/ui/ThemeTest.cpp
+++ b/tests/ui/ThemeTest.cpp
@@ -26,17 +26,20 @@ using namespace gbm;
 
 namespace {
 
-constexpr std::array<Token, 37> kAllTokens{
-    Token::SurfaceApp,    Token::SurfacePanel,    Token::SurfacePanelRaised, Token::SurfaceSunken,
-    Token::SurfaceHover,  Token::SurfaceSelected, Token::SurfaceOverlay,     Token::BorderSubtle,
-    Token::BorderDefault, Token::BorderStrong,    Token::BorderFocus,        Token::TextPrimary,
-    Token::TextSecondary, Token::TextTertiary,    Token::TextOnAccent,       Token::TextLink,
-    Token::Accent,        Token::AccentHover,     Token::AccentActive,       Token::AccentSubtle,
-    Token::Success,       Token::Danger,          Token::DangerHover,        Token::Warning,
-    Token::DiffAddBg,     Token::DiffAddText,     Token::DiffDelBg,          Token::DiffDelText,
-    Token::DiffAddStrong, Token::DiffDelStrong,   Token::ScrollbarThumb,     Token::GraphLane1,
-    Token::GraphLane2,    Token::GraphLane3,      Token::GraphLane4,         Token::GraphLane5,
-    Token::GraphLane6,
+constexpr std::array<Token, 39> kAllTokens{
+    Token::SurfaceApp,     Token::SurfacePanel,  Token::SurfacePanelRaised,
+    Token::SurfaceSunken,  Token::SurfaceHover,  Token::SurfaceSelected,
+    Token::SurfaceOverlay, Token::BorderSubtle,  Token::BorderDefault,
+    Token::BorderStrong,   Token::BorderFocus,   Token::TextPrimary,
+    Token::TextSecondary,  Token::TextTertiary,  Token::TextOnAccent,
+    Token::TextLink,       Token::Accent,        Token::AccentHover,
+    Token::AccentActive,   Token::AccentSubtle,  Token::RefChipFill,
+    Token::RefChipText,    Token::Success,       Token::Danger,
+    Token::DangerHover,    Token::Warning,       Token::DiffAddBg,
+    Token::DiffAddText,    Token::DiffDelBg,     Token::DiffDelText,
+    Token::DiffAddStrong,  Token::DiffDelStrong, Token::ScrollbarThumb,
+    Token::GraphLane1,     Token::GraphLane2,    Token::GraphLane3,
+    Token::GraphLane4,     Token::GraphLane5,    Token::GraphLane6,
 };
 
 constexpr std::array<ThemeId, 3> kAllThemes{

--- a/tests/unit/CoreBasicsTest.cpp
+++ b/tests/unit/CoreBasicsTest.cpp
@@ -132,7 +132,7 @@ TEST(CancellationToken, FiresCallbacksExactlyOnce) {
     EXPECT_FALSE(token.isCancelled());
 
     std::atomic_int calls{0};
-    token.onCancel([&calls] { ++calls; });
+    auto reg = token.onCancel([&calls] { ++calls; });
 
     source.cancel();
     source.cancel();  // Idempotent.
@@ -148,8 +148,72 @@ TEST(CancellationToken, RunsCallbackImmediatelyIfAlreadyCancelled) {
     source.cancel();
 
     std::atomic_bool ran{false};
-    source.token().onCancel([&ran] { ran = true; });
+    auto reg = source.token().onCancel([&ran] { ran = true; });
     EXPECT_TRUE(ran.load());
+}
+
+TEST(CancellationToken, UnregisteringABeforeCancelPreventsItFromFiring) {
+    // This is what ProcessRunner::execute() relies on: a callback capturing
+    // stack state that has already gone out of scope must never fire, even
+    // if cancel() is called afterward on the same CancellationSource (e.g.
+    // RepositorySession::cancelPendingReads() firing once for a whole
+    // session's worth of already-finished reads).
+    CancellationSource source;
+    CancellationToken token = source.token();
+
+    std::atomic_int calls{0};
+    {
+        auto reg = token.onCancel([&calls] { ++calls; });
+        reg.reset();  // Explicit unregister -- the case a destructor also covers.
+    }
+
+    source.cancel();
+    EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(CancellationToken, RegistrationDestructorUnregisters) {
+    CancellationSource source;
+    CancellationToken token = source.token();
+
+    std::atomic_int calls{0};
+    {
+        auto reg = token.onCancel([&calls] { ++calls; });
+        // reg destructs here, at the end of this block, before cancel() runs.
+    }
+
+    source.cancel();
+    EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(CancellationToken, MovedRegistrationStillUnregisters) {
+    CancellationSource source;
+    CancellationToken token = source.token();
+
+    std::atomic_int calls{0};
+    auto reg = token.onCancel([&calls] { ++calls; });
+    auto moved = std::move(reg);
+
+    moved.reset();
+    source.cancel();
+    EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(CancellationToken, SeveralRegistrationsAreIndependent) {
+    // Unregistering one callback must not disturb another registered on the
+    // same token -- the id-based removal has to target exactly one entry.
+    CancellationSource source;
+    CancellationToken token = source.token();
+
+    std::atomic_int firstCalls{0};
+    std::atomic_int secondCalls{0};
+    auto first = token.onCancel([&firstCalls] { ++firstCalls; });
+    auto second = token.onCancel([&secondCalls] { ++secondCalls; });
+
+    first.reset();
+    source.cancel();
+
+    EXPECT_EQ(firstCalls.load(), 0);
+    EXPECT_EQ(secondCalls.load(), 1);
 }
 
 // --- thread pool -----------------------------------------------------------
@@ -181,6 +245,62 @@ TEST(ThreadPool, DefaultSizeLeavesRoomForTheUiThread) {
     const std::size_t size = ThreadPool::defaultThreadCount();
     EXPECT_GE(size, 2u);
     EXPECT_LE(size, 6u);
+}
+
+TEST(ThreadPool, CancelQueuedAndDrainDiscardsQueuedWorkButWaitsForTheActiveTask) {
+    // This is exactly the shape MainWindow::closeRepository() relies on: cancel
+    // the token(s) a running task carries, then call this so no queued lambda
+    // capturing the about-to-be-destroyed RepositorySession ever runs, and
+    // nothing is still touching it when the call returns.
+    ThreadPool pool("test", 1);  // One worker: makes queue-vs-active deterministic.
+    std::atomic_bool activeTaskStarted{false};
+    std::atomic_bool activeTaskMayFinish{false};
+    std::atomic_bool activeTaskFinished{false};
+    std::atomic_int queuedTasksRun{0};
+
+    pool.post([&] {
+        activeTaskStarted.store(true);
+        while (!activeTaskMayFinish.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        activeTaskFinished.store(true);
+    });
+
+    // Wait until the pool has actually picked up the first task, so the
+    // remaining posts land in the queue behind it (single worker) instead of
+    // racing to start first.
+    while (!activeTaskStarted.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    for (int i = 0; i < 10; ++i) {
+        pool.post([&queuedTasksRun] { ++queuedTasksRun; });
+    }
+    EXPECT_GT(pool.queueDepth(), 0u);
+
+    // Let the active task finish shortly after cancelQueuedAndDrain() starts
+    // waiting, from a second thread, so this actually exercises the "blocks
+    // until currently-executing work finishes" half of the contract rather
+    // than returning instantly because nothing was active.
+    std::thread releaser([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        activeTaskMayFinish.store(true);
+    });
+
+    pool.cancelQueuedAndDrain();
+    releaser.join();
+
+    EXPECT_TRUE(activeTaskFinished.load())
+        << "must wait for the active task, not just clear the queue";
+    EXPECT_EQ(queuedTasksRun.load(), 0) << "queued-but-not-started work must be discarded, not run";
+    EXPECT_EQ(pool.queueDepth(), 0u);
+
+    // The pool itself is still usable afterward -- cancelQueuedAndDrain() is
+    // not a shutdown.
+    std::atomic_int total{0};
+    pool.post([&total] { ++total; });
+    pool.drain();
+    EXPECT_EQ(total.load(), 1);
 }
 
 // --- debouncer -------------------------------------------------------------
@@ -288,7 +408,7 @@ TEST(HistoryProvider, RejectsMalformedRecordsWithoutThrowing) {
 
 TEST(HistoryQuery, UsesTopoOrderAndSeedsTipsBeforeAll) {
     HistoryQuery query;
-    query.includeRefs = {"refs/heads/main"};
+    query.seedRefs = {"refs/heads/main"};
     const auto args = query.toRevListArgs();
 
     ASSERT_FALSE(args.empty());
@@ -298,13 +418,27 @@ TEST(HistoryQuery, UsesTopoOrderAndSeedsTipsBeforeAll) {
     EXPECT_NE(std::find(args.begin(), args.end(), "--parents"), args.end());
     EXPECT_NE(std::find(args.begin(), args.end(), "--timestamp"), args.end());
 
-    // The explicit tip must precede --all: the graph builder gives lane 0 to the
+    // The seed tip must precede --all: the graph builder gives lane 0 to the
     // first tip it sees, which is how the trunk stays leftmost.
     const auto tipAt = std::find(args.begin(), args.end(), "refs/heads/main");
     const auto allAt = std::find(args.begin(), args.end(), "--all");
     ASSERT_NE(tipAt, args.end());
     ASSERT_NE(allAt, args.end());
     EXPECT_LT(tipAt - args.begin(), allAt - args.begin());
+}
+
+TEST(HistoryQuery, NarrowsToIncludeRefsWithoutAll) {
+    // includeRefs (the graph branch filter) must actually narrow the walk,
+    // not just reorder --all's tips -- --all must be absent entirely.
+    HistoryQuery query;
+    query.seedRefs = {"refs/heads/main"};  // Must be ignored once includeRefs is set.
+    query.includeRefs = {"refs/heads/feature-a", "refs/heads/feature-b"};
+    const auto args = query.toRevListArgs();
+
+    EXPECT_EQ(std::find(args.begin(), args.end(), "--all"), args.end());
+    EXPECT_EQ(std::find(args.begin(), args.end(), "refs/heads/main"), args.end());
+    EXPECT_NE(std::find(args.begin(), args.end(), "refs/heads/feature-a"), args.end());
+    EXPECT_NE(std::find(args.begin(), args.end(), "refs/heads/feature-b"), args.end());
 }
 
 TEST(HistoryQuery, PushesFilteringDownIntoGit) {

--- a/tests/unit/ProcessRunnerTest.cpp
+++ b/tests/unit/ProcessRunnerTest.cpp
@@ -336,13 +336,76 @@ TEST(RefStore, SeedsHistoryWithHeadBeforeTrunk) {
     main.fullName = "refs/heads/main";
     main.kind = RefKind::LocalBranch;
 
-    snapshot.refs = {feature, main};
+    // The upstream ref itself must be present for historySeedRefs to trust
+    // it -- see RefStore::refExists.
+    RefInfo upstream;
+    upstream.fullName = "refs/remotes/origin/feature";
+    upstream.kind = RefKind::RemoteBranch;
+
+    snapshot.refs = {feature, main, upstream};
 
     const auto seeds = RefStore::historySeedRefs(snapshot);
     ASSERT_GE(seeds.size(), 3u);
     EXPECT_EQ(seeds[0], "refs/heads/feature") << "HEAD must be seeded first";
     EXPECT_NE(std::find(seeds.begin(), seeds.end(), "refs/remotes/origin/feature"), seeds.end());
     EXPECT_NE(std::find(seeds.begin(), seeds.end(), "refs/heads/main"), seeds.end());
+}
+
+TEST(RefStore, ExcludesAGoneUpstreamFromHistorySeeds) {
+    // `branch.<name>.remote`/`.merge` config still names an upstream after
+    // its remote-tracking ref is pruned (e.g. `git remote remove origin`, or
+    // the branch was deleted upstream and pruned locally) -- git reports
+    // that as `[gone]` in %(upstream:track), but still hands back the dead
+    // name in %(upstream). Seeding rev-list with it aborts the entire walk
+    // with "unknown revision", so it must never reach historySeedRefs'
+    // output even though `upstream` is non-empty.
+    RefSnapshot snapshot;
+    snapshot.head.kind = HeadInfo::Kind::Branch;
+    snapshot.head.fullRef = "refs/heads/feature";
+
+    RefInfo feature;
+    feature.fullName = "refs/heads/feature";
+    feature.kind = RefKind::LocalBranch;
+    feature.isHead = true;
+    feature.upstream = "refs/remotes/origin/feature";
+    feature.hasTrackingInfo = true;
+    feature.isGone = true;
+    // Deliberately no "refs/remotes/origin/feature" entry in snapshot.refs --
+    // that is exactly the pruned state being tested.
+
+    snapshot.refs = {feature};
+
+    const auto seeds = RefStore::historySeedRefs(snapshot);
+    EXPECT_EQ(std::find(seeds.begin(), seeds.end(), "refs/remotes/origin/feature"), seeds.end());
+    EXPECT_NE(std::find(seeds.begin(), seeds.end(), "refs/heads/feature"), seeds.end());
+}
+
+TEST(RefStore, ParsesGoneTrackFieldWithoutCountingAsAheadOrBehind) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response symbolic;
+    symbolic.out = "refs/heads/feature";
+    runner.whenArgsContain({"symbolic-ref"}, symbolic);
+
+    FakeProcessRunner::Response revParse;
+    revParse.out = std::string(40, 'a');
+    runner.whenArgsContain({"rev-parse"}, revParse);
+
+    const char sep = '\x1f';
+    FakeProcessRunner::Response refs;
+    refs.out = std::string("refs/heads/feature") + sep + "commit" + sep + std::string(40, 'a') +
+               sep + "" + sep + "refs/remotes/origin/feature" + sep + "[gone]" + sep + "*" + sep +
+               "" + "\n";
+    runner.whenArgsContain({"for-each-ref"}, refs);
+
+    RefStore store(runner, testPaths());
+    auto snapshot = store.load(CancellationToken{});
+    ASSERT_TRUE(snapshot) << snapshot.error().message;
+
+    ASSERT_EQ((*snapshot)->refs.size(), 1u);
+    EXPECT_TRUE((*snapshot)->refs[0].isGone);
+    EXPECT_TRUE((*snapshot)->refs[0].hasTrackingInfo);
+    EXPECT_EQ((*snapshot)->refs[0].ahead, 0);
+    EXPECT_EQ((*snapshot)->refs[0].behind, 0);
 }
 
 }  // namespace


### PR DESCRIPTION
1. HistoryQuery 拆分 seedRefs/includeRefs，讓分支過濾器真正限縮 rev-list 走訪範圍
2. RefStore 新增 isGone 與 refExists 驗證，避免已刪除遠端造成 ambiguous revision 走訪失敗
3. MainWindow 依 applicationStateChanged 新增視窗重新聚焦自動同步 working copy、stash、refs 與 history
4. Refresh 動作改為僅作用於 repo 列表頁，並在 graph 頁隱藏
5. fetchRemote/fetchRemoteSilently 補上 refreshHistory，讓已抓取但未拉取的 commit 立即顯示於 graph
6. 新增 RefChipFill/RefChipText token 修正 ref chip 於選取列上對比度不足的問題
7. 新增 refreshRefsAndHistory 合併重複的 for-each-ref 呼叫，並記錄 UI refresh path 效能量測
8. 修正 Windows 上 CancellationToken 回呼未解除註冊、以及 session 於背景讀取工作仍在執行時被釋放造成的 use-after-free；CatFileBatch::read/readCommit/readCommits 統一接受 CancellationToken
9. 補充 QSS 樣式覆蓋稽核報告（docs/design/qss-coverage.md）與對應單元測試