### PR TITLE
feat, test: 修正遺漏 commit-graph 效能瓶頸並新增自動化效能守門測試

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,0 +1,96 @@
+name: perf-nightly
+
+# The timing gate cannot live in ci.yml. tests/CMakeLists.txt already says why:
+# a shared pull-request runner is far too noisy for timing assertions to gate
+# a branch. Nightly on one pinned image instead, so a regression surfaces as a
+# break in a trend rather than as a flaky red X on somebody's PR.
+on:
+  schedule:
+    # Off the hour on purpose: GitHub's scheduler queues heavily at :00, and a
+    # perf job that waits in a queue lands on a busier runner.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+# No cancel-in-progress, unlike ci.yml: there is never a queue of these, and
+# killing a run mid-measurement throws away a fixture build for nothing.
+concurrency:
+  group: perf-nightly
+
+jobs:
+  commit-graph-ratio:
+    name: commit-graph speedup
+    # Pinned, not -latest, for the same reason the sanitizer jobs in ci.yml
+    # are pinned: a runner image rolling forward underneath a performance
+    # trend makes the trend unreadable. One OS only -- this measures a
+    # property of git and the walk, not of the platform.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Ninja and a pinned CMake
+        uses: lukka/get-cmake@latest
+
+      - name: Report the git version
+        # GIT_CONFIG_COUNT is 2.31; gbm_graph_check's A/B mode refuses to
+        # measure below that rather than silently reporting a false
+        # regression -- see tests/tools/graph_check.cpp. Logged unconditionally
+        # so a runner image bump that moves git shows up next to the numbers
+        # it moved.
+        run: git --version
+
+      # core-only: the walk under test is Qt-free, so this skips the Qt
+      # install and everything it drags in -- only the two binaries the gate
+      # needs get built.
+      - name: Configure and build
+        run: |
+          cmake --preset core-only
+          cmake --build --preset core-only --target gen_history gbm_graph_check
+
+      - name: Measure
+        run: |
+          set -o pipefail
+          ctest --preset perf 2>&1 | tee perf.log
+
+      # always(), including on failure: the numbers from the run that just
+      # tripped the gate are the entire reason to open the summary.
+      - name: Publish measurements
+        if: always()
+        run: |
+          line=$(grep -m1 'commit-graph-ab:' perf.log || true)
+          if [ -z "$line" ]; then
+            {
+              echo "## commit-graph speedup"
+              echo
+              echo 'No measurement line in `perf.log` -- the run failed before measuring.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          field() { sed -n "s/.*$1=\([0-9.]*\).*/\1/p" <<<"$line"; }
+          {
+            echo "## commit-graph speedup -- $(date -u '+%Y-%m-%d')"
+            echo
+            echo "git: $(git --version) - rows: $(field rows) - pairs: $(field pairs)"
+            echo
+            echo '| metric | graph off | graph on | speedup |'
+            echo '|---|---|---|---|'
+            printf '| full walk | %sms | %sms | **%sx** |\n' \
+              "$(field off_total_ms)" "$(field on_total_ms)" "$(field total_speedup)"
+            printf '| time to first chunk | %sms | %sms | %sx |\n' \
+              "$(field off_first_ms)" "$(field on_first_ms)" "$(field first_speedup)"
+            echo
+            echo 'Gate is on the full walk only; time-to-first-chunk is reported for the trend.'
+            echo
+            echo '```'
+            echo "$line"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the full log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-log
+          path: perf.log
+          if-no-files-found: ignore

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,8 +71,25 @@
       "output": { "outputOnFailure": true },
       "execution": { "noTestsAction": "error", "stopOnFailure": false }
     },
-    { "name": "dev", "inherits": "tbase", "configurePreset": "dev" },
-    { "name": "core-only", "inherits": "tbase", "configurePreset": "core-only" },
+    {
+      "name": "dev",
+      "inherits": "tbase",
+      "configurePreset": "dev",
+      "filter": { "exclude": { "label": "perf" } }
+    },
+    {
+      "name": "core-only",
+      "inherits": "tbase",
+      "configurePreset": "core-only",
+      "filter": { "exclude": { "label": "perf" } }
+    },
+    {
+      "name": "perf",
+      "inherits": "tbase",
+      "configurePreset": "core-only",
+      "filter": { "include": { "label": "perf" } },
+      "output": { "outputOnFailure": true, "verbosity": "verbose" }
+    },
     {
       "name": "asan-ubsan",
       "inherits": "tbase",
@@ -124,6 +141,14 @@
         { "type": "configure", "name": "core-only" },
         { "type": "build", "name": "core-only" },
         { "type": "test", "name": "core-only" }
+      ]
+    },
+    {
+      "name": "perf",
+      "steps": [
+        { "type": "configure", "name": "core-only" },
+        { "type": "build", "name": "core-only" },
+        { "type": "test", "name": "perf" }
       ]
     },
     {

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -144,14 +144,118 @@ before committing to more than the stage that dominates):
 
 ## Repository performance settings
 
-`commit-graph` and `multi-pack-index` are the difference between a fast browse and a
-slow one, but they write into your repository, so the app asks first and remembers
-your answer:
+`commit-graph` is the single largest lever this app controls, and until now
+it was entirely unmitigated: an investigation against a real 162,368-commit
+`microsoft/vscode` clone (`docs/reports/vscode-graph-performance.md`) found
+that removing the commit-graph moved time-to-first-chunk **62 ms -> 898 ms
+(14x)** and the full walk **195 ms -> 1027 ms (5.3x)** -- and that this
+section previously *described* an opt-in prompt for building one that had
+never actually been built. It writes into your repository, so the app asks
+first and remembers your answer, non-modally, after the first history paint
+(`MainWindow`'s dismissible perf hint) -- with the same choice also available
+any time from Repository Settings > Performance > "Keep commit-graph up to
+date". See `core/git/ops/MaintenanceOps.h` for the decision logic
+(`shouldOfferCommitGraph`, pure and unit-tested) and
+`RepositorySession::writeCommitGraph()` for the write itself
+(`git commit-graph write --reachable [--changed-paths] [--split]`, gated on
+the git version's `GitCapabilities::commitGraphSplit`/`changedPathBloom`).
+
+Not yet wired to an in-app prompt -- worth revisiting the same way, once
+there's a measurement to justify it:
 
 ```bash
-git commit-graph write --reachable --changed-paths --split
 git multi-pack-index write --bitmap
 git config feature.manyFiles true      # index v4
 git config core.fsmonitor true         # git >= 2.37; huge win for status
 git config core.untrackedCache true
 ```
+
+## Commit-graph speedup gate
+
+A same-run A/B ratio test (`commit_graph_speedup_ratio`, `perf` label) proves
+the commit-graph delivers the speedup above and keeps delivering it. It is
+**not** a pull-request gate -- `tests/CMakeLists.txt`'s own label comment
+explains why: a shared CI runner is far too noisy for an absolute-millisecond
+assertion. This session's own measurements make the point directly: the
+identical operation on the identical warm repository swung **83 ms -> 1069
+ms** across five back-to-back runs of an unchanged binary. An absolute gate
+wide enough to survive that spread would catch nothing; a ratio measured
+seconds apart on one machine, in one process, is stable in a way neither
+arm's absolute value is.
+
+**Mechanism:** `gbm_graph_check --commit-graph-ab N --min-graph-speedup F`
+toggles git's use of an *existing* commit-graph via the `GIT_CONFIG_COUNT` /
+`GIT_CONFIG_KEY_0=core.commitGraph` / `GIT_CONFIG_VALUE_0` environment
+variables (needs git >= 2.31; the tool refuses to measure below that rather
+than silently reporting a false ~1.0x "regression"), rather than writing or
+deleting the commit-graph file between arms. Nothing on disk changes between
+the two measurements -- same pack, same inodes, same warm page cache -- which
+is what a physically-mutating A/B would confound. `N` off/on pairs run with a
+discarded warm-up walk first and the no-graph arm always first in each pair
+(biasing *toward understating* the speedup, so a pass can never be an
+ordering artefact); the gate asserts on the **median** of the `total` walk time,
+and reports (but does not gate on) time-to-first-chunk, which is the more
+dramatic number but a single instant, one descheduling away from a wrong
+answer.
+
+**Calibration** (this machine, git 2.55.0, `gen_history --branches 12
+--merge-rate 0.10 --octopus 3 --tags 25 --seed 42`, median of 5 pairs):
+
+| Commits | graph off (median) | graph on (median) | speedup | on-arm vs. 50ms floor |
+|---|---|---|---|---|
+| 25,000 | 113 ms | 32 ms | 3.5x | **fails** -- under the floor |
+| 50,000 | 229 ms | 57 ms | 4.0x | 7 ms margin |
+| 75,000 | 347 ms | 85 ms | 4.1x | 35 ms margin |
+| 100,000 | 449 ms | 107 ms | 4.2x | 57 ms margin |
+
+`gbm_graph_check` refuses to trust a measurement below a 50 ms floor: under
+that, 1 ms clock resolution and process-spawn cost are a large fraction of
+the number and the ratio stops meaning anything. 25,000 commits -- a
+reasonable-looking fixture size on paper -- fails that floor outright with
+this measurement method, which is exactly the failure mode the floor exists
+to catch loudly rather than silently pass on noise. **Chosen: 100,000
+commits, `MIN_SPEEDUP=2.0`** (roughly half the measured median, leaving
+headroom for a CI runner meaningfully faster or slower than this one) --
+`GBM_PERF_COMMITS`/`GBM_PERF_SAMPLES`/`GBM_PERF_MIN_SPEEDUP` in
+`tests/CMakeLists.txt`. Full cycle (fixture generation + import +
+commit-graph write + 5 measured pairs) is ~30 s locally.
+
+Reproduce by hand:
+
+```bash
+cmake --build --preset core-only --target gen_history gbm_graph_check
+R=/tmp/gbm-perf-fixture
+git init --quiet --bare $R/.git && git -C $R config core.bare false
+./build/core-only/tests/gen_history --commits 100000 --branches 12 --merge-rate 0.10 \
+    --octopus 3 --tags 25 --seed 42 | git -C $R fast-import --quiet
+git -C $R commit-graph write --reachable --changed-paths
+
+./build/core-only/tests/gbm_graph_check $R --commit-graph-ab 5 --min-graph-speedup 2.0
+```
+
+Or via CTest: `ctest --preset perf` (excluded from `dev`/`core-only`'s default
+run; wired into CI only via the nightly `.github/workflows/perf-nightly.yml`,
+which publishes the measured numbers to the run's Step Summary rather than
+just pass/fail, following this file's own "range, not a single digit"
+convention above).
+
+**Companion PR-gate tests**, both deterministic and label `unit` (they gate
+every preset including the sanitizers), catching the exact regression class
+that motivated the fix in "UI refresh path" above without any timing
+involved:
+
+- `RefStore.LoadsEveryRefWithASingleForEachRefInvocation`
+  (`tests/unit/ProcessRunnerTest.cpp`) -- asserts `for-each-ref` is invoked
+  exactly once per `RefStore::load()`, via `FakeProcessRunner`'s invocation
+  log.
+- `no_duplicate_ref_refresh_call_sites`
+  (`tests/cmake/CheckNoDuplicateRefRefresh.cmake`) -- a source check, not a
+  runtime one, following the precedent of `ci.yml`'s "core must not depend on
+  Qt" grep. `RepositorySession` builds its own `IProcessRunner` in its
+  constructor with no injection seam and delivers everything through a
+  `ThreadPool` and queued Qt signals, so a runtime assertion here would need a
+  seam this codebase doesn't have (see "No test in this codebase exercises
+  `RepositorySession` directly" above, which remains true and is now
+  deliberately so) for a bug whose entire shape -- `refreshRefs()` and
+  `refreshHistory()` called back to back instead of
+  `refreshRefsAndHistory()` -- is visible in the source text.

--- a/docs/design/qss-coverage.md
+++ b/docs/design/qss-coverage.md
@@ -50,6 +50,15 @@ rule; `QDialog`, `QComboBox` (including its popup `QAbstractItemView`),
 `QDialogButtonBox`, `QScrollBar` (handle + groove), `QMenuBar`/`QMenu`
 (including separators) all have dedicated rules already.
 
+## Added since this audit, with coverage from the start
+
+`QWidget#gbmPerfHint` / `QLabel#gbmPerfHintLabel` (MainWindow's dismissible
+commit-graph advice row): styled alongside `gbmBanner`/`gbmBannerLabel` in the
+same commit that added the widget, using `@accent-subtle` rather than
+`gbmBanner`'s warning-red `@diff-del-bg` -- this is a suggestion, not a
+warning. Verified via `ThemeTest::qssSubstitutionLeavesNoUnresolvedPlaceholder`
+and `everyTokenResolvesInEveryTheme`.
+
 ## Inline `setStyleSheet` call sites (bypass the token system on purpose or not)
 
 `DiffPage.cpp`, `WorkingCopyView.cpp` (x2), `CommitExpansionPanel.cpp` each

--- a/docs/reports/vscode-graph-performance.md
+++ b/docs/reports/vscode-graph-performance.md
@@ -1,0 +1,104 @@
+# Git graph page performance: microsoft/vscode
+
+Investigation report, 2026-08-04. Ad hoc test against a real large open-source
+repository, done by hand — not automated, not part of CI. See "Performance gate
+design" below for what should move into CI.
+
+## Method
+
+Cloned `microsoft/vscode` shallow (`git clone --depth 1`), then unshallowed it
+(`git fetch --unshallow`). A depth-1 clone gives the graph algorithm nothing to
+walk (1 commit) — it only exercises repository discovery on a large working
+tree (17,157 files). Testing the graph page itself needs real history, so the
+clone was deepened to get the repository's actual 162,368-commit history.
+
+Built both the `core-only` preset (`gbm_graph_check`, `gen_history` — no Qt)
+and the full `dev` Qt app. `MainWindow::openRepository` /
+`onGraphUpdated` were temporarily instrumented with timing prints, the real
+app was run headlessly (`QT_QPA_PLATFORM=offscreen`) against the vscode clone
+several times, and the instrumentation was reverted afterward (not committed).
+
+Repository shape after unshallowing: 162,368 commits, 30 refs (27 tags, 1
+local branch — a fork clone, so far fewer refs than the live GitHub repo),
+1.2 GB `.git`, 17,157 tracked files, commit-graph present.
+
+## Bottleneck table
+
+| # | Bottleneck | Evidence (this session, real vscode repo unless noted) | Root cause | Resolution |
+|---|---|---|---|---|
+| 1 | **Missing commit-graph** | First chunk 62ms→**898ms** (14x), full walk 195ms→**1027ms** (5.3x) on the same 162k-commit repo with the commit-graph removed vs present | `git rev-list --topo-order` must compute generation numbers/reachability from raw objects instead of the precomputed index | **Correction (this row was wrong):** this was *not* already implemented. `docs/PERFORMANCE.md`'s "Repository performance settings" described an opt-in prompt in the present tense, but the only trace in `src/` was a dormant, unread `GitExecutable::commitGraphSplit` capability flag — no prompt, no trigger, nothing on first repo add. Since fixed: `MainWindow` offers a non-modal, dismissible hint after the first history paint on a large repository with no commit-graph (`shouldOfferCommitGraph()` in `core/git/ops/MaintenanceOps.h`, pure and unit-tested), persisted per repository and also reachable from Repository Settings > Performance. See `docs/PERFORMANCE.md`'s "Commit-graph speedup gate" section for the same-run A/B test that now guards this regressing silently again. |
+| 2 | **Cold first-touch filesystem I/O after a fresh clone** | `git status --porcelain=v2` (what `WorkingCopyStatusReader` runs) took **34.7s / 45.0s / 56.3s wall** (vs 1–3.6s CPU — 7-8% utilization) on first run after cloning 17,157 files; warm reruns: **~30ms**. Controlled A/B ruled out fsmonitor: disabling it made the cold run *slower* (56.3s vs 45.0s), not faster. | Not git or app logic — page-cache misses / metadata journaling / OS-level first-touch cost across ~17k newly written files. | Not fixable in-app. **Confirmed not to block the graph**: `readPool_` has ≥2 threads (`clamp(cores-1,2,6)`), and `refreshWorkingCopyStatus()`/`refreshRefsAndHistory()` run as separate concurrent pool tasks — so this is a resource-contention risk on constrained/CI/spinning-disk machines, not a serialization bottleneck. Worth capping concurrency or deferring the status scan slightly behind first graph paint specifically on first-open of a newly added repo. |
+| 3 | **Silent second graph rebuild from auto-fetch** *(new finding)* | Headless app runs against vscode: 2 of 4 runs printed a **second** `graphUpdated(complete=true)` 750ms–1s after the first. Not visible in `gbm_graph_check` (no network path) or in `docs/PERFORMANCE.md`. | `openRepository()` unconditionally calls `maybeAutoFetch()` (Settings › `autoFetchOnOpen`, default true); the resulting real fetch against `github.com` moves refs and re-triggers the history walk. | Likely correct behavior, but currently indistinguishable from "the first walk was just slow." Add a distinct signal/log for "post-autofetch resync" vs "initial walk complete" so the UI and any future gate can tell them apart. |
+| 4 | **Qt/bridge-layer overhead is undocumented and volatile** | Core-only first-chunk on this exact repo/state: **62ms**. Real Qt app, same repo, 5 runs: **83, 94, 172, 916, 1069ms**. | `docs/PERFORMANCE.md` explicitly scopes itself to the Qt-free core: *"not evidence about what the running app feels like end to end."* That gap is real and currently unmeasured/untracked. | Add permanent (env-gated, not throwaway) timing hooks at the `bridge/` boundary so this delta is visible over time instead of invisible. |
+| 5 | **Memory margin is thinner than it looks** | 124.2 bytes/commit on real vscode — matches the synthetic fixture almost exactly (124.2 vs 124.0) — projecting to 59.2 MB at 500k against a **64 MB target: 7% headroom**. | Fixed per-row struct cost in `GraphSnapshot`, consistent across synthetic and real data — structural, not a topology artifact. | Profile `GraphSnapshot`'s row layout for compression *before* the next larger benchmark (500k+ commit monorepo) blows the budget. Track this ratio in CI now, while margin still exists. |
+| 6 | **`for-each-ref` scales with ref count, not commit count** | 25–49ms on this repo (only 30 refs after the fork clone) — but `docs/PERFORMANCE.md`'s own 3,798-ref fixture measured 0.8–2.2s for *one* call, more than the entire 50k-commit commit-graph-accelerated walk. Not reproducible here since this vscode fork only carries 30 refs. | `%(upstream:track)` per-ref cost (doc: ~440ms refname-only vs ~770ms full format, same repo). | Duplicate-load already fixed (`refreshRefsAndHistory()`). Remaining, not-yet-applied mitigation: `core/workers/Debouncer.h` exists unused — wire it so a burst of refreshes collapses into one load. |
+| 7 | **Lane-cap overflow** (checked, downgraded) | 2,406 / 179,779 edges (1.3%) in the overflow lane on real vscode vs ~12% on the synthetic random-merge fixture. | Real large-repo topology is *less* tangled than the synthetic stress fixture, as the docs already note. | Not a performance finding — rendering fidelity only, costs no time. Don't rank it as a bottleneck. |
+| 8 | **cat-file batch metadata fetch** (verified non-issue) | 60-commit batch: 16–37ms warm. | The persistent `git cat-file --batch` co-process design already avoids the 20-40ms-per-spawn cost the code comments warn about. | No action — flagging this as confirmation the architecture doc's stated invariant holds under real data, not a bottleneck. |
+
+## Performance gate design
+
+Checked what already exists before designing anything new:
+
+- `tests/CMakeLists.txt` already runs `graph_matches_git_on_generated_history`
+  on every PR (4,000-commit fixture) and it **already enforces** a memory
+  ceiling (`graph_check.cpp`'s `check(bytesPerCommit < maxBytesPerCommit,
+  ...)`, default 140 bytes/commit) — just not a timing one.
+- A code comment already states the intended split: *"Labels let CI gate on
+  the fast suites and run perf separately: runners are far too noisy for
+  timing assertions to gate a pull request"* — but no perf-labeled job or
+  nightly workflow actually exists in `.github/workflows/` yet.
+- `HistoryProvider.PublishesChunksOnAGeometricSchedule` already demonstrates
+  the right pattern: gate a **counted invariant**, not wall-clock time.
+
+Given that, and given this session's own numbers swung 83ms→1069ms for the
+identical operation on the identical warm repo, an absolute-millisecond PR
+gate would flake constantly. Design, in order of reliability:
+
+### Tier 1 — PR gate (fast, deterministic, extends existing infra)
+
+1. Keep `graph_matches_git_on_generated_history` as-is (correctness + memory
+   ceiling).
+2. **New:** `refstore_dedup_regression` — using the existing
+   `FakeProcessRunner` test double, assert `for-each-ref` is invoked exactly
+   once per `refreshRefsAndHistory()` call. This is a real regression test
+   for the exact bug `docs/PERFORMANCE.md` already describes fixing —
+   currently *no test exercises `RepositorySession` at all* (the doc says so
+   directly).
+3. **New:** `commit_graph_speedup_ratio` — build the same small (4,000-commit)
+   fixture twice, with and without a commit-graph, and assert `withGraphMs <
+   withoutGraphMs / 2`. A same-run, same-machine **ratio** is far more
+   flake-resistant than an absolute ceiling, and this session's 5.3–14x
+   real-world delta gives huge margin.
+4. **New:** subprocess spawn-count assertions (via `FakeProcessRunner` or a
+   wrapping mock) for the refs+history sequence — catches "someone
+   reintroduced a duplicate git call" with zero timing involved.
+
+### Tier 2 — scheduled workflow (new `.github/workflows/perf-nightly.yml`, doesn't exist today)
+
+- `schedule:` + `workflow_dispatch:` triggers, not `pull_request`.
+- Job A: the 200k-commit synthetic fixture already documented in
+  `docs/PERFORMANCE.md`, run with **generous** absolute ceilings (e.g., 3-8x
+  the documented numbers) purely to catch gross regressions over time via
+  trend, not to gate merges.
+- Job B (weekly or manual-only, given the network/size cost): formalize
+  exactly what this session did by hand — shallow-clone + unshallow a pinned
+  real OSS repo, run `gbm_graph_check`, and **publish** the numbers (Step
+  Summary / artifact) rather than hard-pass/fail, for the same reason the
+  docs already use ranges ("0.8-2.2s, machine-load dependent") instead of
+  single numbers.
+
+### Tier 3 — manual/local only, not automated
+
+vscode-scale commit-graph A/B and cold-vs-warm working-copy status, as
+reproduced this session. Document the repro steps in `docs/PERFORMANCE.md`
+the same way the existing sections already do, but don't wire real
+network-dependent multi-GB clones into CI.
+
+## Caveat
+
+This vscode fork ended up with only 30 refs after `fetch --unshallow`, so
+it's a good commit-count fixture (162k, close to the doc's 200k synthetic
+target) but a poor ref-count fixture — it doesn't exercise the "thousands of
+stale refs" case the README names as the target workload. Only `gen_history
+--branches 3000` (already used in the existing 50k/3798-ref doc fixture)
+covers that axis; any gate needs both.

--- a/resources/qss/app.qss
+++ b/resources/qss/app.qss
@@ -188,6 +188,19 @@ QLabel#gbmBannerLabel {
     color: @diff-del-text;
 }
 
+/* Sibling of gbmBanner, not a reuse: gbmBanner is a repository-state warning
+ * (dirty merge/rebase), this is a dismissible performance advisory -- see the
+ * doc comment on MainWindow::perfHintRow_. @accent-subtle instead of the
+ * warning-red @diff-del-bg above: nothing is wrong, this is a suggestion. */
+QWidget#gbmPerfHint {
+    background: @accent-subtle;
+    border-bottom: 1px solid @border-subtle;
+}
+
+QLabel#gbmPerfHintLabel {
+    color: @text-primary;
+}
+
 /* --- buttons --------------------------------------------------------------*/
 
 QPushButton {

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -60,6 +60,26 @@ bool autoFetchOnOpenSetting(const RepoPaths& paths) {
     return settings.value(prefix + QStringLiteral("autoFetchOnOpen"), true).toBool();
 }
 
+/// Mirrors RepositoryPage's "Keep commit-graph up to date" checkbox, same key
+/// format note as above. Defaults to Unset (never written before), which is
+/// the only state shouldOfferCommitGraph() treats as "still worth asking".
+CommitGraphPreference commitGraphPreferenceSetting(const RepoPaths& paths) {
+    const QString prefix = performanceSettingsKeyPrefix(paths);
+    if (prefix.isEmpty()) {
+        return CommitGraphPreference::Unset;
+    }
+    QSettings settings;
+    const QString value =
+        settings.value(prefix + QStringLiteral("commitGraph"), QStringLiteral("unset")).toString();
+    if (value == QStringLiteral("enabled")) {
+        return CommitGraphPreference::Enabled;
+    }
+    if (value == QStringLiteral("declined")) {
+        return CommitGraphPreference::Declined;
+    }
+    return CommitGraphPreference::Unset;
+}
+
 std::uint64_t combineHash(std::uint64_t seed, std::uint64_t value) {
     // boost::hash_combine's mixing constant/shifts; good enough for a cache
     // key, no cryptographic properties needed.
@@ -998,6 +1018,33 @@ void RepositorySession::maybeAutoFetch() {
     }
     lastAutoFetchAt_ = now;
     fetchRemoteSilently();
+}
+
+// --- Commit-graph maintenance -----------------------------------------------
+
+bool RepositorySession::hasCommitGraph() const {
+    return gbm::hasCommitGraph(paths_);
+}
+
+CommitGraphPreference RepositorySession::commitGraphPreference() const {
+    return commitGraphPreferenceSetting(paths_);
+}
+
+void RepositorySession::writeCommitGraph() {
+    WriteCommitGraphRequest request;
+    request.split = installation_.capabilities.commitGraphSplit;
+    request.changedPaths = installation_.capabilities.changedPathBloom;
+    // No refreshRefsAndHistory() on success, unlike every other mutation above:
+    // the commits are unchanged, so the ref fingerprint walkHistoryWithRefs()
+    // caches is unchanged too, and a re-walk would just short-circuit on that
+    // cache while still paying for a second for-each-ref -- see
+    // walkHistoryWithRefs()'s fingerprint check above. The graph is consulted
+    // lazily by the next real history walk regardless of whether one runs now.
+    // afterFinished already runs on the UI thread -- submitAndRefresh's own
+    // completion lambda is what does the hop, same as every other caller
+    // below (e.g. initSubmodules) -- so this just emits directly.
+    submitAndRefresh(makeWriteCommitGraphOperation(request),
+                     [this](bool succeeded) { emit commitGraphWriteFinished(succeeded); });
 }
 
 void RepositorySession::pullChanges(PullRequest request) {

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -22,6 +22,7 @@
 #include "core/git/ops/ConfigOps.h"
 #include "core/git/ops/ConflictOps.h"
 #include "core/git/ops/LfsOps.h"
+#include "core/git/ops/MaintenanceOps.h"
 #include "core/git/ops/MergeOps.h"
 #include "core/git/ops/PatchOps.h"
 #include "core/git/ops/RebaseOps.h"
@@ -286,6 +287,25 @@ public:
     /// every History-tab visit does not hammer the remote.
     void maybeAutoFetch();
 
+    // --- Commit-graph maintenance -------------------------------------------
+
+    /// Filesystem check only, no subprocess -- see hasCommitGraph(RepoPaths)
+    /// in core/git/ops/MaintenanceOps.h. Safe to call on the UI thread, unlike
+    /// nearly everything else on this class.
+    bool hasCommitGraph() const;
+
+    /// The user's saved answer to the commit-graph advice banner/settings
+    /// checkbox for this repository. Mirrors RepositoryPage's checkbox state --
+    /// see the key-format note on commitGraphPreferenceSetting() in the .cpp.
+    CommitGraphPreference commitGraphPreference() const;
+
+    /// `git commit-graph write`, run through the same operation queue as every
+    /// other mutation. Unlike fetchRemoteSilently(), this is always something
+    /// the user explicitly asked for (the perf banner's "Optimize" button or
+    /// the settings card's "Optimize now"), so it drives the busy indicator
+    /// like a normal operation instead of running invisibly.
+    void writeCommitGraph();
+
     /// Answers or dismisses the credential prompt currently outstanding, if
     /// any. A no-op if none is.
     void provideCredential(const QString& secret);
@@ -441,6 +461,11 @@ signals:
     /// (stash/discard choices) does not apply to staging and commit, so the
     /// working-copy panel gets its own completion signal to react to.
     void workingCopyOperationFinished(OperationOutcome outcome);
+
+    /// Reply to writeCommitGraph(). Separate from workingCopyOperationFinished
+    /// so MainWindow's perf banner can react to exactly this operation instead
+    /// of filtering every operation outcome for one it happens to recognise.
+    void commitGraphWriteFinished(bool succeeded);
 
     void stashesUpdated();
     /// Reply to requestStashDiff.

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -82,6 +82,22 @@ namespace {
 /// stats, so only what is on screen gets probed.
 constexpr int kProbeMargin = 20;
 
+/// Same `repositoryPerf/<path>/commitGraph` key RepositoryPage's checkbox and
+/// RepositorySession::commitGraphPreference() read -- see the key-format note
+/// on RepositoryPage::settingsKeyPrefix() for why this tiny snippet is
+/// duplicated per UI class rather than shared, and follow that same
+/// convention here: RepositorySession only ever reads this setting, the UI
+/// that shows the choice writes it. "Not now" deliberately does not write --
+/// it leaves the preference Unset, which is what makes it "ask again later"
+/// instead of "never ask".
+QString commitGraphSettingsKey(const RepositorySession& session) {
+    QString path = QString::fromStdString(session.paths().commandDir().string());
+    path.replace(QLatin1Char('/'), QLatin1Char('_'));
+    path.replace(QLatin1Char('\\'), QLatin1Char('_'));
+    path.replace(QLatin1Char(':'), QLatin1Char('_'));
+    return QStringLiteral("repositoryPerf/%1/commitGraph").arg(path);
+}
+
 /// The minimum acceptable danger treatment for a destructive menu action,
 /// mirroring `SidebarPanel.cpp`'s `markDanger`: QSS cannot select one
 /// `QMenu::item` out of many, so this tints the action's icon instead.
@@ -288,6 +304,45 @@ void MainWindow::buildUi() {
 
     bannerRow->setVisible(false);
     repoLayout->addWidget(bannerRow);
+
+    // A performance advisory, not a repository-state warning -- see the
+    // sibling-of-bannerRow_ comment on perfHintRow_ in the header for why this
+    // is a separate widget rather than another mode of the banner above.
+    perfHintRow_ = new QWidget(repoPage);
+    perfHintRow_->setObjectName(QStringLiteral("gbmPerfHint"));
+    auto* perfHintRow = perfHintRow_;
+    auto* perfHintLayout = new QHBoxLayout(perfHintRow);
+    perfHintLayout->setContentsMargins(kSpace4, kSpace2, kSpace4, kSpace2);
+    perfHintLayout->setSpacing(kSpace3);
+
+    perfHintLabel_ = new QLabel(perfHintRow);
+    perfHintLabel_->setObjectName(QStringLiteral("gbmPerfHintLabel"));
+    perfHintLabel_->setWordWrap(true);
+    perfHintLabel_->setText(
+        tr("This repository has no commit-graph. Building one makes history load faster."));
+    perfHintLayout->addWidget(perfHintLabel_, 1);
+
+    perfHintDismissButton_ = new QPushButton(QStringLiteral("✕"), perfHintRow);
+    perfHintDismissButton_->setObjectName(QStringLiteral("secondaryButton"));
+    perfHintDismissButton_->setAccessibleName(QStringLiteral("Dismiss performance hint"));
+    perfHintNotNowButton_ = new QPushButton(tr("Not now"), perfHintRow);
+    perfHintNotNowButton_->setObjectName(QStringLiteral("secondaryButton"));
+    perfHintOptimizeButton_ = new QPushButton(tr("Optimize"), perfHintRow);
+    perfHintOptimizeButton_->setObjectName(QStringLiteral("primaryButton"));
+    connect(perfHintOptimizeButton_,
+            &QPushButton::clicked,
+            this,
+            &MainWindow::onPerfHintOptimizeClicked);
+    connect(
+        perfHintNotNowButton_, &QPushButton::clicked, this, &MainWindow::onPerfHintNotNowClicked);
+    connect(
+        perfHintDismissButton_, &QPushButton::clicked, this, &MainWindow::onPerfHintDismissClicked);
+    perfHintLayout->addWidget(perfHintNotNowButton_);
+    perfHintLayout->addWidget(perfHintOptimizeButton_);
+    perfHintLayout->addWidget(perfHintDismissButton_);
+
+    perfHintRow->setVisible(false);
+    repoLayout->addWidget(perfHintRow);
 
     auto* outerSplitter = new QSplitter(Qt::Horizontal, repoPage);
     outerSplitter_ = outerSplitter;
@@ -1168,6 +1223,10 @@ void MainWindow::openRepository(const RepoRecord& record) {
             this,
             [this](const OperationOutcome&) { updateStateBanner(); });
     connect(session_.get(),
+            &RepositorySession::commitGraphWriteFinished,
+            this,
+            &MainWindow::onCommitGraphWriteFinished);
+    connect(session_.get(),
             &RepositorySession::credentialRequested,
             this,
             &MainWindow::onCredentialRequested);
@@ -1313,6 +1372,15 @@ void MainWindow::closeRepository() {
     toolBarBranchLabel_->setText(QString());
     stack_->setCurrentIndex(0);
     bannerLabel_->parentWidget()->setVisible(false);
+    perfHintRow_->setVisible(false);
+    commitGraphHintShown_ = false;
+    // Undoes onPerfHintOptimizeClicked's setEnabled(false): if a
+    // writeCommitGraph() was still in flight when this repository closed,
+    // commitGraphWriteFinished never arrives to re-enable these, and the next
+    // repository's hint would otherwise render with Optimize/Not now
+    // permanently greyed out.
+    perfHintOptimizeButton_->setEnabled(true);
+    perfHintNotNowButton_->setEnabled(true);
 }
 
 void MainWindow::applyThemeAndRefresh(ThemeId theme) {
@@ -1481,9 +1549,75 @@ void MainWindow::onGraphUpdated(bool complete) {
         const int width = graphDelegate_->widthForRows(
             0, static_cast<int>(std::min<std::size_t>(snapshot->rowCount(), 200)));
         commitView_->setColumnWidth(CommitListModel::ColumnGraph, width);
+
+        // Same "every cap is visible" reasoning as the truncated/overflowedEdges
+        // text above, applied to a cap the user doesn't even know exists yet: a
+        // missing commit-graph is invisible until someone notices history feels
+        // slow. commitGraphHintShown_ is why this only ever offers once per
+        // session -- see its doc comment on why that guard is load-bearing, not
+        // defensive.
+        //
+        // rowCount() is post-cap once large-repository mode is on (see
+        // RepositorySession::maxGraphRowsSetting), so comparing it directly
+        // against kCommitGraphAdviceMinRows would mean a user who capped
+        // history at, say, 5,000 rows could never clear the threshold no
+        // matter how large the real repository is -- exactly the population
+        // most likely to benefit from a commit-graph. snapshot->truncated
+        // means the real history exceeds whatever cap is in effect, so that
+        // alone is treated as clearing the threshold rather than comparing
+        // the capped count against it.
+        const std::uint32_t rowCountForAdvice =
+            snapshot->truncated
+                ? std::max<std::uint32_t>(static_cast<std::uint32_t>(snapshot->rowCount()),
+                                          kCommitGraphAdviceMinRows)
+                : static_cast<std::uint32_t>(snapshot->rowCount());
+        if (complete && session_ && !commitGraphHintShown_ &&
+            shouldOfferCommitGraph(
+                session_->hasCommitGraph(), rowCountForAdvice, session_->commitGraphPreference())) {
+            commitGraphHintShown_ = true;
+            perfHintRow_->setVisible(true);
+        }
     }
 
     onCommitScrolled();
+}
+
+void MainWindow::onPerfHintOptimizeClicked() {
+    if (!session_) {
+        return;
+    }
+    QSettings settings;
+    settings.setValue(commitGraphSettingsKey(*session_), QStringLiteral("enabled"));
+    perfHintOptimizeButton_->setEnabled(false);
+    perfHintNotNowButton_->setEnabled(false);
+    session_->writeCommitGraph();
+}
+
+void MainWindow::onPerfHintNotNowClicked() {
+    // Preference is left Unset on purpose: this is "ask me later", not "never
+    // ask" -- unlike the dismiss (x) button below. It disappears for the rest
+    // of this session because commitGraphHintShown_ stays true, and is offered
+    // again the next time this repository is opened.
+    perfHintRow_->setVisible(false);
+}
+
+void MainWindow::onPerfHintDismissClicked() {
+    if (session_) {
+        QSettings settings;
+        settings.setValue(commitGraphSettingsKey(*session_), QStringLiteral("declined"));
+    }
+    perfHintRow_->setVisible(false);
+}
+
+void MainWindow::onCommitGraphWriteFinished(bool succeeded) {
+    perfHintOptimizeButton_->setEnabled(true);
+    perfHintNotNowButton_->setEnabled(true);
+    if (succeeded) {
+        perfHintRow_->setVisible(false);
+    }
+    // Failure leaves the hint up so the user can retry; no separate error
+    // surface here since submitAndRefresh already emits
+    // workingCopyOperationFinished, which the operation log shows.
 }
 
 void MainWindow::onCommitScrolled() {

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -153,6 +153,10 @@ private slots:
     void onBannerContinue();
     void onBannerSkip();
     void onBannerAbort();
+    void onPerfHintOptimizeClicked();
+    void onPerfHintNotNowClicked();
+    void onPerfHintDismissClicked();
+    void onCommitGraphWriteFinished(bool succeeded);
     void onCleanUntracked();
     void onOpenTerminal();
     void onShowReflog();
@@ -352,6 +356,26 @@ private:
     QPushButton* bannerContinueButton_ = nullptr;
     QPushButton* bannerSkipButton_ = nullptr;
     QPushButton* bannerAbortButton_ = nullptr;
+
+    /// A sibling of bannerRow_, not a reuse of it: bannerRow_ reflects
+    /// RepoState (merge/rebase/cherry-pick in progress) via updateStateBanner()
+    /// and is driven by workingCopyOperationFinished; this one is an
+    /// unrelated, dismissible performance hint driven by onGraphUpdated(). The
+    /// two concerns would fight over one slot's worth of space if merged.
+    QWidget* perfHintRow_ = nullptr;
+    QLabel* perfHintLabel_ = nullptr;
+    QPushButton* perfHintOptimizeButton_ = nullptr;
+    QPushButton* perfHintNotNowButton_ = nullptr;
+    QPushButton* perfHintDismissButton_ = nullptr;
+    /// Set the first time the hint is shown for the current session, and
+    /// never cleared until the next openRepository(). Without this,
+    /// MainWindow::openRepository()'s unconditional maybeAutoFetch() call
+    /// produces a second graphUpdated(complete=true) 750ms-1s later on a
+    /// successful silent fetch (see RepositorySession::fetchRemoteSilently),
+    /// which would otherwise reopen a hint the user just dismissed -- observed
+    /// in 2 of 4 headless runs against a real large clone; see
+    /// docs/reports/vscode-graph-performance.md's bottleneck #3.
+    bool commitGraphHintShown_ = false;
     QAction* undoAction_ = nullptr;
     QProgressBar* busyBar_ = nullptr;
 

--- a/src/app/views/pages/RepositoryPage.cpp
+++ b/src/app/views/pages/RepositoryPage.cpp
@@ -3,6 +3,7 @@
 #include "app/bridge/RepositorySession.h"
 #include "app/bridge/ThemeManager.h"
 #include "core/git/ops/ConfigOps.h"
+#include "core/git/ops/MaintenanceOps.h"
 #include "core/git/ops/RemoteOps.h"
 
 #include <QCheckBox>
@@ -10,6 +11,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPushButton>
 #include <QSettings>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -133,6 +135,40 @@ void RepositoryPage::buildUi() {
     captionLabel->setWordWrap(true);
     perfCardLayout->addWidget(captionLabel);
 
+    commitGraphCheck_ = new QCheckBox(tr("Keep commit-graph up to date"), perfCard);
+    perfCardLayout->addWidget(commitGraphCheck_);
+    // Its own write path, not savePerformanceSetting(): that slot is shared by
+    // largeRepoModeCheck_/maxGraphRowsSpin_/autoFetchCheck_ too, and it always
+    // rewrites all four keys from the widgets' *current displayed* state --
+    // but "unset" (never asked) and "declined" both render this checkbox
+    // unchecked (see loadPerformanceSettings() below), so toggling any of the
+    // other three would have silently turned "unset" into "declined" and
+    // permanently suppressed the perf-advice banner for a repository nobody
+    // ever actually declined it on.
+    connect(
+        commitGraphCheck_, &QCheckBox::toggled, this, &RepositoryPage::saveCommitGraphPreference);
+
+    auto* commitGraphRow = new QHBoxLayout();
+    commitGraphStatusLabel_ = new QLabel(perfCard);
+    commitGraphStatusLabel_->setObjectName(QStringLiteral("gbmPanelCaption"));
+    commitGraphRow->addWidget(commitGraphStatusLabel_, 1);
+    commitGraphOptimizeButton_ = new QPushButton(tr("Optimize now"), perfCard);
+    connect(commitGraphOptimizeButton_,
+            &QPushButton::clicked,
+            this,
+            &RepositoryPage::onCommitGraphOptimizeClicked);
+    commitGraphRow->addWidget(commitGraphOptimizeButton_);
+    perfCardLayout->addLayout(commitGraphRow);
+
+    auto* commitGraphCaption = new QLabel(
+        tr("Speeds up history loading on large repositories by writing a `commit-graph` index "
+           "into `.git/`. Same optimization the perf hint offers after opening a large "
+           "repository for the first time."),
+        perfCard);
+    commitGraphCaption->setObjectName(QStringLiteral("gbmPanelCaption"));
+    commitGraphCaption->setWordWrap(true);
+    perfCardLayout->addWidget(commitGraphCaption);
+
     outerLayout->addWidget(perfCard);
 
     // --- "Sync" -------------------------------------------------------------
@@ -192,9 +228,14 @@ void RepositoryPage::setSession(RepositorySession* session) {
             &RepositoryPage::onLocalIdentityUpdated);
     connect(
         session_, &RepositorySession::remotesUpdated, this, [this] { refreshRepositoryCard(); });
+    connect(session_,
+            &RepositorySession::commitGraphWriteFinished,
+            this,
+            &RepositoryPage::onCommitGraphWriteFinished);
 
     refreshRepositoryCard();
     loadPerformanceSettings();
+    refreshCommitGraphStatus();
     session_->refreshLocalIdentity();
 }
 
@@ -311,6 +352,16 @@ void RepositoryPage::loadPerformanceSettings() {
     autoFetchCheck_->blockSignals(true);
     autoFetchCheck_->setChecked(autoFetch);
     autoFetchCheck_->blockSignals(false);
+
+    // "unset" (never asked) reads as unchecked here, same as "declined" -- the
+    // checkbox is a plain boolean and has no third state to show it in. The
+    // perf-advice banner is where "unset" is actually distinguished, by
+    // offering the choice at all instead of assuming "no".
+    const QString commitGraph =
+        settings.value(prefix + QStringLiteral("commitGraph"), QStringLiteral("unset")).toString();
+    commitGraphCheck_->blockSignals(true);
+    commitGraphCheck_->setChecked(commitGraph == QStringLiteral("enabled"));
+    commitGraphCheck_->blockSignals(false);
 }
 
 void RepositoryPage::savePerformanceSetting() {
@@ -322,6 +373,71 @@ void RepositoryPage::savePerformanceSetting() {
     settings.setValue(prefix + QStringLiteral("largeRepoMode"), largeRepoModeCheck_->isChecked());
     settings.setValue(prefix + QStringLiteral("maxGraphRows"), maxGraphRowsSpin_->value());
     settings.setValue(prefix + QStringLiteral("autoFetchOnOpen"), autoFetchCheck_->isChecked());
+    // commitGraph is deliberately NOT written here -- see
+    // saveCommitGraphPreference() and the doc comment on commitGraphCheck_'s
+    // connect() above for why sharing this slot broke persistence.
+}
+
+void RepositoryPage::saveCommitGraphPreference() {
+    const QString prefix = settingsKeyPrefix();
+    if (prefix.isEmpty()) {
+        return;
+    }
+    QSettings settings;
+    // Unlike the other three settings, this checkbox toggling off is a
+    // deliberate choice made from Settings, not a "maybe later" -- so it maps
+    // straight to "declined", never back to "unset". "unset" is only ever the
+    // state a repository starts in, before this checkbox has been touched.
+    settings.setValue(
+        prefix + QStringLiteral("commitGraph"),
+        commitGraphCheck_->isChecked() ? QStringLiteral("enabled") : QStringLiteral("declined"));
+}
+
+void RepositoryPage::refreshCommitGraphStatus() {
+    if (!session_) {
+        commitGraphStatusLabel_->setText(QString());
+        commitGraphOptimizeButton_->setEnabled(false);
+        return;
+    }
+    const bool hasGraph = session_->hasCommitGraph();
+    commitGraphStatusLabel_->setText(hasGraph ? tr("commit-graph is up to date")
+                                              : tr("no commit-graph built yet"));
+    // Disabled while one is already present -- rebuilding an up-to-date graph
+    // is wasted work, not a mistake worth letting the user make from here.
+    commitGraphOptimizeButton_->setEnabled(!hasGraph);
+}
+
+void RepositoryPage::onCommitGraphOptimizeClicked() {
+    if (!session_) {
+        return;
+    }
+    commitGraphOptimizeButton_->setEnabled(false);
+    session_->writeCommitGraph();
+}
+
+void RepositoryPage::onCommitGraphWriteFinished(bool succeeded) {
+    // Failure leaves the button re-enabled so the user can retry; no separate
+    // error surface here since submitAndRefresh already emits
+    // workingCopyOperationFinished, which MainWindow's operation log shows.
+    (void)succeeded;
+    refreshCommitGraphStatus();
+
+    // This write can be triggered from MainWindow's perf-advice banner, not
+    // only from this page's own "Optimize now" button -- and the banner's
+    // "Optimize" path writes the commitGraph preference to "enabled" before
+    // starting the write. Without re-reading it here, a user who clicks the
+    // banner and then opens Settings would see this checkbox still showing
+    // its stale pre-click state.
+    const QString prefix = settingsKeyPrefix();
+    if (!prefix.isEmpty()) {
+        QSettings settings;
+        const QString commitGraph =
+            settings.value(prefix + QStringLiteral("commitGraph"), QStringLiteral("unset"))
+                .toString();
+        commitGraphCheck_->blockSignals(true);
+        commitGraphCheck_->setChecked(commitGraph == QStringLiteral("enabled"));
+        commitGraphCheck_->blockSignals(false);
+    }
 }
 
 }  // namespace gbm

--- a/src/app/views/pages/RepositoryPage.h
+++ b/src/app/views/pages/RepositoryPage.h
@@ -7,6 +7,7 @@
 class QCheckBox;
 class QLabel;
 class QLineEdit;
+class QPushButton;
 class QSpinBox;
 
 namespace gbm {
@@ -30,7 +31,10 @@ struct LocalIdentity;
 ///   to cap `HistoryQuery::maxCount` on the next history walk -- see
 ///   `maxGraphRowsSetting`/`performanceSettingsKeyPrefix` in
 ///   RepositorySession.cpp, which must agree with `settingsKeyPrefix()`/
-///   `kDefaultMaxGraphRows` below on the exact key format.
+///   `kDefaultMaxGraphRows` below on the exact key format. The same card's
+///   commit-graph checkbox persists through the same mechanism -- see
+///   `commitGraphPreferenceSetting` in RepositorySession.cpp -- and mirrors
+///   the choice MainWindow's perf-advice banner offers after first paint.
 class RepositoryPage : public QWidget {
     Q_OBJECT
 
@@ -51,6 +55,13 @@ private slots:
     void onLocalIdentityUpdated();
     void onOverrideToggled(bool checked);
     void onIdentityFieldEdited();
+    void onCommitGraphOptimizeClicked();
+    void onCommitGraphWriteFinished(bool succeeded);
+    /// commitGraphCheck_'s own toggled handler -- deliberately not routed
+    /// through savePerformanceSetting(), which is shared by three other
+    /// widgets and would otherwise rewrite this key from stale checkbox state
+    /// on every unrelated settings change. See the connect() call site.
+    void saveCommitGraphPreference();
 
 private:
     void buildUi();
@@ -63,6 +74,10 @@ private:
     QString settingsKeyPrefix() const;
     void loadPerformanceSettings();
     void savePerformanceSetting();
+    /// Updates the "last built" status label and the Optimize button's
+    /// enabled state from session_->hasCommitGraph(). Called after every
+    /// session attach and after a write finishes.
+    void refreshCommitGraphStatus();
 
     RepositorySession* session_ = nullptr;
 
@@ -81,6 +96,9 @@ private:
     QCheckBox* largeRepoModeCheck_ = nullptr;
     QSpinBox* maxGraphRowsSpin_ = nullptr;
     QCheckBox* autoFetchCheck_ = nullptr;
+    QCheckBox* commitGraphCheck_ = nullptr;
+    QPushButton* commitGraphOptimizeButton_ = nullptr;
+    QLabel* commitGraphStatusLabel_ = nullptr;
 
     QLabel* footerLabel_ = nullptr;
 };

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(gbm_core STATIC
     git/ops/ConfigOps.cpp
     git/ops/ConflictOps.cpp
     git/ops/LfsOps.cpp
+    git/ops/MaintenanceOps.cpp
     git/ops/MergeOps.cpp
     git/ops/PatchOps.cpp
     git/ops/RebaseOps.cpp

--- a/src/core/git/RepoPaths.h
+++ b/src/core/git/RepoPaths.h
@@ -82,6 +82,16 @@ public:
 
     std::filesystem::path shallowFile() const { return commonDir_ / "shallow"; }
 
+    /// The single-file commit-graph. Lives under commonDir(): the object store
+    /// is shared across linked worktrees, so every worktree sees one graph.
+    std::filesystem::path commitGraphFile() const { return objectsDir() / "info" / "commit-graph"; }
+
+    /// The split commit-graph chain (`commit-graph write --split`, git >= 2.24).
+    /// A repository has one form or the other, never both.
+    std::filesystem::path commitGraphChainFile() const {
+        return objectsDir() / "info" / "commit-graphs" / "commit-graph-chain";
+    }
+
     /// A human-facing name for the repository, derived from the work tree (or
     /// the git directory for bare repos).
     std::string displayName() const {

--- a/src/core/git/ops/MaintenanceOps.cpp
+++ b/src/core/git/ops/MaintenanceOps.cpp
@@ -1,0 +1,89 @@
+#include "core/git/ops/MaintenanceOps.h"
+
+#include "core/git/GitCommand.h"
+
+#include <utility>
+
+namespace gbm {
+
+bool hasCommitGraph(const RepoPaths& paths) {
+    std::error_code ec;
+    return std::filesystem::exists(paths.commitGraphFile(), ec) ||
+           std::filesystem::exists(paths.commitGraphChainFile(), ec);
+}
+
+bool shouldOfferCommitGraph(bool hasGraph,
+                            std::uint32_t rowCount,
+                            CommitGraphPreference preference) {
+    if (hasGraph) {
+        return false;
+    }
+    if (preference != CommitGraphPreference::Unset) {
+        // Enabled means the graph should already be getting written elsewhere
+        // (or was, before something removed it -- e.g. a `git gc` that pruned
+        // an out-of-date one); Declined means the user was asked and said no.
+        // Neither is "ask again".
+        return false;
+    }
+    return rowCount >= kCommitGraphAdviceMinRows;
+}
+
+namespace {
+
+class WriteCommitGraphOperation final : public Operation {
+public:
+    explicit WriteCommitGraphOperation(WriteCommitGraphRequest request)
+        : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Build commit-graph"; }
+
+    /// git writes the new graph to a temp file under objects/info/ and renames
+    /// it into place only on success, so killing this leaves the object store
+    /// exactly as it was -- unlike a checkout or rebase, there is no
+    /// half-applied state a cancel could strand the repository in.
+    bool killableMidFlight() const override { return true; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+
+        std::vector<std::string> args = {"commit-graph", "write", "--reachable"};
+        if (request_.changedPaths) {
+            args.emplace_back("--changed-paths");
+        }
+        if (request_.split) {
+            args.emplace_back("--split");
+        }
+
+        GitCommand command(paths.commandDir(), std::move(args));
+        // A commit-graph write over a repository with hundreds of thousands of
+        // commits can legitimately take a while; cancellation (not a timeout) is
+        // the right way to stop it, same reasoning as CheckoutOperation's
+        // network-op timeout of 0.
+        command.timeout = std::chrono::milliseconds(0);
+
+        auto result = runner.run(command, token);
+        if (result) {
+            outcome.succeeded = true;
+            outcome.summary = "Built commit-graph";
+            return outcome;
+        }
+
+        GitError error = std::move(result).error();
+        outcome.summary = error.message;
+        outcome.error = std::move(error);
+        return outcome;
+    }
+
+private:
+    WriteCommitGraphRequest request_;
+};
+
+}  // namespace
+
+std::unique_ptr<Operation> makeWriteCommitGraphOperation(WriteCommitGraphRequest request) {
+    return std::make_unique<WriteCommitGraphOperation>(request);
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/MaintenanceOps.h
+++ b/src/core/git/ops/MaintenanceOps.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "core/git/OperationRunner.h"
+#include "core/git/RepoPaths.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace gbm {
+
+/// Whether a commit-graph file (single-file or split-chain form) already exists
+/// for this repository. No subprocess: this is a filesystem check so it is cheap
+/// enough to call on the "should we offer to speed this up" advice path, which
+/// runs once per completed history walk.
+bool hasCommitGraph(const RepoPaths& paths);
+
+/// The user's answer to "build a commit-graph for this repository?", persisted
+/// per repository. `Unset` is the state a repository starts in and the only one
+/// in which the advice banner is offered at all -- see shouldOfferCommitGraph().
+enum class CommitGraphPreference {
+    Unset,
+    Enabled,
+    Declined,
+};
+
+/// Below this row count, `git rev-list` is already fast enough that the
+/// commit-graph write itself (and the disk space it costs) isn't worth
+/// advertising. Calibrated from the same-run A/B measurements in
+/// docs/PERFORMANCE.md's commit-graph gate section, not guessed.
+inline constexpr std::uint32_t kCommitGraphAdviceMinRows = 25000;
+
+/// Decides whether the "this repository would load faster with a commit-graph"
+/// hint should be shown. Pure and core-side (no RepositorySession, no Qt, no
+/// filesystem access beyond what the caller already did) specifically so the
+/// decision is unit-testable without a real repository -- RepositorySession
+/// itself has no test harness (see docs/PERFORMANCE.md), so pushing judgment
+/// out of it into a pure function is the only way this logic gets tested.
+bool shouldOfferCommitGraph(bool hasGraph,
+                            std::uint32_t rowCount,
+                            CommitGraphPreference preference);
+
+struct WriteCommitGraphRequest {
+    /// `commit-graph write --split`: gated on GitCapabilities::commitGraphSplit
+    /// (>= 2.24) by the caller, not assumed here -- see
+    /// RepositorySession::writeCommitGraph().
+    bool split = false;
+    /// `--changed-paths`: gated on GitCapabilities::changedPathBloom (also
+    /// >= 2.24, same flag family) by the caller.
+    bool changedPaths = true;
+};
+
+/// `git commit-graph write --reachable [--changed-paths] [--split]`.
+///
+/// Writes into the object store, but always to a temp file that is renamed into
+/// place on success -- unlike a checkout or rebase, there is no half-applied
+/// state to leave behind, so this is the rare operation that is safe to kill
+/// mid-flight.
+std::unique_ptr<Operation> makeWriteCommitGraphOperation(WriteCommitGraphRequest request);
+
+}  // namespace gbm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,16 @@
 include(GoogleTest)
 
+# Source-only, so deliberately not inside the GBM_BUILD_APP guard below: this
+# must gate the core-only, asan-ubsan and tsan presets too, not just the full
+# app builds -- it reads src/app's *text*, not anything that needs Qt to
+# compile. See CheckNoDuplicateRefRefresh.cmake for why this is a source check
+# rather than a runtime one.
+add_test(NAME no_duplicate_ref_refresh_call_sites
+    COMMAND "${CMAKE_COMMAND}"
+            -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckNoDuplicateRefRefresh.cmake")
+set_tests_properties(no_duplicate_ref_refresh_call_sites PROPERTIES LABELS "unit")
+
 # Test doubles live here rather than in the shipped library.
 add_library(gbm_test_support STATIC support/FakeProcessRunner.cpp)
 target_include_directories(gbm_test_support PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -11,6 +22,7 @@ add_executable(gbm_core_tests
     unit/DiscoveryTest.cpp
     unit/GitIntegrationTest.cpp
     unit/GraphBuilderTest.cpp
+    unit/MaintenanceOpsTest.cpp
     unit/ProcessRunnerTest.cpp
     unit/SideBySideDiffTest.cpp
     unit/UnifiedDiffParserTest.cpp
@@ -51,6 +63,45 @@ endif()
 # A small driver used by the test above and for manual profiling.
 add_executable(gbm_graph_check tools/graph_check.cpp)
 target_link_libraries(gbm_graph_check PRIVATE gbm_core gbm_warnings)
+
+# --- nightly commit-graph speedup gate --------------------------------------
+# Not a pull-request gate: it builds a ${GBM_PERF_COMMITS}-commit fixture and
+# then times things, and a shared CI runner is far too noisy for timing to
+# gate somebody's branch (see the label comment at the top of this file). The
+# `perf` label keeps it out of every CI preset's filter automatically;
+# perf-nightly.yml is the only thing that asks for it.
+set(GBM_PERF_COMMITS 100000 CACHE STRING
+    "Commits in the commit-graph perf fixture. Calibrated -- see docs/PERFORMANCE.md before changing.")
+set(GBM_PERF_SAMPLES 5 CACHE STRING
+    "Off/on walk pairs per perf run. Forced odd by graph_check so the median is a real sample.")
+set(GBM_PERF_MIN_SPEEDUP 2.0 CACHE STRING
+    "Minimum commit-graph speedup asserted by the gate, roughly half the calibrated median.")
+
+if(GIT_FOUND)
+    add_test(NAME commit_graph_speedup_ratio
+        COMMAND "${CMAKE_COMMAND}"
+                -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+                -DGEN_HISTORY=$<TARGET_FILE:gen_history>
+                -DWALKER=$<TARGET_FILE:gbm_graph_check>
+                # Not graph_matches_git_on_generated_history's fixture-repo: the
+                # two tests must never be able to delete each other's repository
+                # mid-run.
+                -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/perf-repo
+                -DCOMMITS=${GBM_PERF_COMMITS}
+                -DSAMPLES=${GBM_PERF_SAMPLES}
+                -DMIN_SPEEDUP=${GBM_PERF_MIN_SPEEDUP}
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/RunCommitGraphRatioCheck.cmake")
+    set_tests_properties(commit_graph_speedup_ratio PROPERTIES
+        LABELS "perf"
+        # ~30s at 100k commits on a dev machine; slack here is deliberate for a
+        # cold, shared runner -- a timeout on this test is a false alarm, not a
+        # finding.
+        TIMEOUT 600
+        # A ctest -j neighbour saturating the machine is the largest noise
+        # source available to a timing test. One property removes it.
+        RUN_SERIAL TRUE
+        ENVIRONMENT "GIT_OPTIONAL_LOCKS=0")
+endif()
 
 # --- Qt model tests --------------------------------------------------------
 # Only when the GUI is being built. Runs offscreen, so it needs no display in CI.

--- a/tests/cmake/CheckNoDuplicateRefRefresh.cmake
+++ b/tests/cmake/CheckNoDuplicateRefRefresh.cmake
@@ -1,0 +1,55 @@
+# Fails if any call site in src/app calls refreshRefs() and refreshHistory()
+# back to back instead of refreshRefsAndHistory().
+#
+# A source check rather than a behavioural one, and that is the point.
+# RepositorySession is a QObject that builds its own IProcessRunner in its
+# constructor and delivers everything through a ThreadPool and queued signals,
+# so asserting "exactly one for-each-ref per refresh" at runtime would need a
+# runner-injection seam, a QCoreApplication and an event loop -- an async
+# harness this repository does not have, for a bug whose entire shape is
+# visible in the source. docs/PERFORMANCE.md's "UI refresh path" section has
+# the measurement that makes it worth a gate: one for-each-ref on a
+# 3,798-ref repository cost more than the whole 50k-commit rev-list walk
+# after it, and the old code paid for it twice on every refresh.
+#
+# .github/workflows/ci.yml's "core must not depend on Qt" grep-based check is
+# the precedent for gating on source shape rather than runtime behaviour.
+
+if(NOT SOURCE_DIR)
+    message(FATAL_ERROR "CheckNoDuplicateRefRefresh.cmake requires SOURCE_DIR")
+endif()
+
+file(GLOB_RECURSE sources "${SOURCE_DIR}/src/app/*.cpp")
+
+set(offenders "")
+foreach(file IN LISTS sources)
+    file(READ "${file}" text)
+
+    # Comments are stripped first: RepositorySession.cpp's own doc comments
+    # discuss both function names in prose (explaining exactly this rule) and
+    # would otherwise trip this check. The block-comment pattern is the
+    # standard greedy-safe form, needed because CMake's regex engine has no
+    # non-greedy quantifier.
+    string(REGEX REPLACE "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/" "" text "${text}")
+    string(REGEX REPLACE "//[^\n]*" "" text "${text}")
+
+    # "refreshRefs();" followed, before the next statement ends, by
+    # "refreshHistory(" -- and the same pair in the other order. [^;]* cannot
+    # cross a semicolon, so this only matches genuinely adjacent statements,
+    # not two unrelated calls somewhere in the same function.
+    if(text MATCHES "refreshRefs\\(\\)[ \t\r\n]*;[^;]*refreshHistory\\(" OR
+       text MATCHES "refreshHistory\\([^;]*;[^;]*refreshRefs\\(\\)")
+        list(APPEND offenders "${file}")
+    endif()
+endforeach()
+
+if(offenders)
+    string(REPLACE ";" "\n  " pretty "${offenders}")
+    message(FATAL_ERROR
+        "refreshRefs() and refreshHistory() are called back to back in:\n  ${pretty}\n"
+        "Each independently re-runs `git for-each-ref`. Call "
+        "RepositorySession::refreshRefsAndHistory() instead, which shares one "
+        "load between them -- see docs/PERFORMANCE.md, \"UI refresh path\".")
+endif()
+
+message(STATUS "No duplicate refreshRefs()/refreshHistory() pairs in src/app")

--- a/tests/cmake/RunCommitGraphRatioCheck.cmake
+++ b/tests/cmake/RunCommitGraphRatioCheck.cmake
@@ -1,0 +1,117 @@
+# Builds a large synthetic repository, then measures the history walk with and
+# without git's commit-graph on that same repository and fails if the graph has
+# stopped paying for itself.
+#
+# Separate from RunFixtureCheck.cmake, which is the correctness gate: this
+# needs a much larger fixture, needs the commit-graph write to be fatal rather
+# than a warning (without one there is nothing to compare), and turns off
+# every background git job that could rewrite the repository mid-measurement.
+#
+# Run via `cmake -P` from a ctest test, so it works identically on all three
+# platforms without a shell script.
+
+if(NOT GIT_EXECUTABLE OR NOT GEN_HISTORY OR NOT WALKER OR NOT WORK_DIR)
+    message(FATAL_ERROR "RunCommitGraphRatioCheck.cmake requires GIT_EXECUTABLE, GEN_HISTORY, WALKER and WORK_DIR")
+endif()
+
+# Calibrated, not guessed -- see docs/PERFORMANCE.md's "commit-graph speedup
+# gate" section for the measurements this came from. At this size the
+# in-process A/B toggle's graph-on arm lands around 100-110ms, comfortably
+# above gbm_graph_check's 50ms floor (below which clock resolution and
+# process-spawn cost dominate and the ratio stops meaning anything) even on a
+# CI runner meaningfully faster than the machine this was calibrated on.
+if(NOT DEFINED COMMITS)
+    set(COMMITS 100000)
+endif()
+if(NOT DEFINED SAMPLES)
+    set(SAMPLES 5)
+endif()
+if(NOT DEFINED MIN_SPEEDUP)
+    set(MIN_SPEEDUP 2.0)
+endif()
+
+file(REMOVE_RECURSE "${WORK_DIR}")
+file(MAKE_DIRECTORY "${WORK_DIR}")
+
+message(STATUS "Creating a ${COMMITS}-commit perf fixture in ${WORK_DIR}")
+
+execute_process(
+    COMMAND "${GIT_EXECUTABLE}" init --quiet --bare "${WORK_DIR}/.git"
+    RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "git init failed: ${result}")
+endif()
+
+# core.bare=false gives a git dir with no checkout, which is all fast-import
+# needs. The rest turn off everything git might otherwise decide to do on its
+# own: an auto-gc, a repack, or an opportunistic commit-graph write landing
+# between the two arms would silently change what is being compared. These are
+# throwaway fixtures, so switching all of it off costs nothing.
+set(FIXTURE_CONFIG_KEYS core.bare gc.auto gc.autoDetach gc.writeCommitGraph
+    maintenance.auto fetch.writeCommitGraph core.fsmonitor core.untrackedCache)
+set(FIXTURE_CONFIG_VALUES false 0 false false false false false false)
+list(LENGTH FIXTURE_CONFIG_KEYS fixtureConfigCount)
+math(EXPR fixtureConfigLast "${fixtureConfigCount} - 1")
+foreach(fixtureConfigIndex RANGE ${fixtureConfigLast})
+    list(GET FIXTURE_CONFIG_KEYS ${fixtureConfigIndex} fixtureConfigKey)
+    list(GET FIXTURE_CONFIG_VALUES ${fixtureConfigIndex} fixtureConfigValue)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" -C "${WORK_DIR}" config "${fixtureConfigKey}" "${fixtureConfigValue}"
+        RESULT_VARIABLE result)
+    if(NOT result EQUAL 0)
+        message(FATAL_ERROR "git config ${fixtureConfigKey} failed: ${result}")
+    endif()
+endforeach()
+
+# Same topology knobs as RunFixtureCheck.cmake so the two fixtures stay
+# comparable; only the commit count is scaled up for a measurable A/B ratio.
+set(STREAM_FILE "${WORK_DIR}/history.fi")
+execute_process(
+    COMMAND "${GEN_HISTORY}" --commits ${COMMITS} --branches 12 --merge-rate 0.10
+            --octopus 3 --tags 25 --seed 42
+    OUTPUT_FILE "${STREAM_FILE}"
+    RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "gen_history failed: ${result}")
+endif()
+
+execute_process(
+    COMMAND "${GIT_EXECUTABLE}" -C "${WORK_DIR}" fast-import --quiet
+    INPUT_FILE "${STREAM_FILE}"
+    RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "git fast-import failed: ${result}")
+endif()
+file(REMOVE "${STREAM_FILE}")
+
+# FATAL here, unlike RunFixtureCheck.cmake's WARNING: without a commit-graph
+# there is nothing for the "graph on" arm to use, and the whole comparison is
+# meaningless.
+execute_process(
+    COMMAND "${GIT_EXECUTABLE}" -C "${WORK_DIR}" commit-graph write --reachable --changed-paths
+    RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "commit-graph write failed: ${result}")
+endif()
+
+# ERROR_VARIABLE, not OUTPUT_VARIABLE: gbm_graph_check prints every timing to
+# stderr and reserves stdout for the optional ASCII render. ECHO_ERROR_VARIABLE
+# keeps it visible live too, so a run that hits the ctest timeout still shows
+# how far it got.
+execute_process(
+    COMMAND "${WALKER}" "${WORK_DIR}"
+            --commit-graph-ab ${SAMPLES}
+            --min-graph-speedup ${MIN_SPEEDUP}
+    ERROR_VARIABLE measurements
+    ECHO_ERROR_VARIABLE
+    RESULT_VARIABLE result)
+
+if(NOT result EQUAL 0)
+    # Deliberately not cleaned up: a perf failure is worth re-measuring by
+    # hand, and rebuilding ${COMMITS} commits just to reproduce it wastes time
+    # that a kept fixture avoids.
+    message(FATAL_ERROR "commit-graph ratio check failed (${result}) -- fixture kept at ${WORK_DIR}")
+endif()
+
+file(REMOVE_RECURSE "${WORK_DIR}")
+message(STATUS "commit-graph ratio check passed")

--- a/tests/tools/graph_check.cpp
+++ b/tests/tools/graph_check.cpp
@@ -6,6 +6,7 @@
 // binary doubles as a profiling entry point.
 //
 //   gbm_graph_check <repo-path> [--print-rows N] [--max-bytes-per-commit F]
+//                              [--commit-graph-ab N] [--min-graph-speedup F]
 //
 #include "core/base/CancellationToken.h"
 #include "core/git/GitExecutable.h"
@@ -13,6 +14,7 @@
 #include "core/git/RefStore.h"
 #include "core/graph/GraphAsciiRenderer.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -49,6 +51,234 @@ std::vector<std::string> splitLines(const std::string& text) {
     return lines;
 }
 
+// --- timed walk, and the commit-graph A/B gate ------------------------------
+
+struct WalkTiming {
+    long long firstChunkMs = 0;
+    long long totalMs = 0;
+    std::size_t rows = 0;
+    std::size_t chunks = 0;
+    gbm::GraphSnapshotPtr snapshot;  ///< Null when the walk failed.
+};
+
+/// One timed walk. Extracted so the single-run path below and the
+/// commit-graph A/B loop measure through exactly the same code -- if the two
+/// ever drifted, the ratio the gate asserts on would be comparing two
+/// different things.
+WalkTiming timeOneWalk(gbm::HistoryProvider& provider, const gbm::HistoryQuery& query) {
+    const auto start = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point firstChunk{};
+    std::size_t chunks = 0;
+
+    auto snapshot = provider.walk(
+        query,
+        [&](gbm::GraphSnapshotPtr chunk) {
+            if (chunks == 0) {
+                firstChunk = std::chrono::steady_clock::now();
+            }
+            ++chunks;
+            (void)chunk;
+        },
+        gbm::CancellationToken{});
+    const auto done = std::chrono::steady_clock::now();
+
+    WalkTiming timing;
+    if (!snapshot) {
+        std::fprintf(stderr, "walk failed: %s\n", snapshot.error().message.c_str());
+        return timing;
+    }
+    timing.snapshot = *snapshot;
+    timing.rows = (*snapshot)->rowCount();
+    timing.chunks = chunks;
+    timing.firstChunkMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(firstChunk - start).count();
+    timing.totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(done - start).count();
+    return timing;
+}
+
+void setEnvVar(const char* key, const char* value) {
+#if defined(_WIN32)
+    ::_putenv_s(key, value);
+#else
+    ::setenv(key, value, 1);
+#endif
+}
+
+/// Turns git's use of an existing commit-graph file on or off for every git
+/// child this driver spawns from here on.
+///
+/// It has to arrive out of band, in the environment, rather than as a
+/// `git -c core.commitGraph=false` argument on the walk's own command line:
+/// HistoryProvider owns the rev-list argv, and the entire point of this
+/// measurement is to time the argv the app actually runs. ProcessRunner
+/// copies the parent's environment at spawn time, so a setenv here is picked
+/// up by the very next child and nothing spawned before it.
+///
+/// Chosen over writing/deleting the commit-graph file between arms because
+/// nothing on disk changes either way: same pack, same inodes, same warm page
+/// cache. Physically mutating the repository between arms would move the
+/// cache underneath the comparison -- exactly the confound a ratio test
+/// cannot absorb.
+///
+/// Needs GIT_CONFIG_COUNT, i.e. git >= 2.31 -- one minor above this project's
+/// 2.30 floor. The caller checks the version first: a silently ignored toggle
+/// would make both arms identical and report a false ~1.0x regression.
+void setCommitGraphEnabled(bool enabled) {
+    setEnvVar("GIT_CONFIG_COUNT", "1");
+    setEnvVar("GIT_CONFIG_KEY_0", "core.commitGraph");
+    setEnvVar("GIT_CONFIG_VALUE_0", enabled ? "true" : "false");
+}
+
+long long medianOf(std::vector<long long> values) {
+    // Median, not mean and not best-of-N. A mean is dragged by the one sample
+    // that got descheduled; best-of-N systematically flatters whichever arm
+    // happened to catch the quietest moment on the machine. With an odd
+    // sample count the median is a real observation, not an average of luck.
+    std::sort(values.begin(), values.end());
+    return values.empty() ? 0 : values[values.size() / 2];
+}
+
+std::string joinSamples(const std::vector<long long>& values) {
+    std::string text;
+    for (const long long value : values) {
+        if (!text.empty()) {
+            text += ' ';
+        }
+        text += std::to_string(value);
+    }
+    return text;
+}
+
+/// Times the same walk with and without git's commit-graph and fails if the
+/// graph has stopped buying what docs/PERFORMANCE.md claims it buys.
+///
+/// A *ratio*, deliberately, and never an absolute millisecond ceiling. On a
+/// real 162,368-commit clone, removing the commit-graph moved
+/// time-to-first-chunk 62ms -> 898ms and the full walk 195ms -> 1027ms -- but
+/// on that same warm repository the identical operation swung 83ms -> 1069ms
+/// across five runs of an unchanged binary (see
+/// docs/reports/vscode-graph-performance.md). An absolute gate wide enough to
+/// survive that spread would catch nothing; one tight enough to catch a
+/// regression would go red most nights. The ratio between two arms measured
+/// seconds apart on one machine is stable in a way neither arm's absolute
+/// value is: whatever is making the machine slow that moment is making both
+/// arms slow.
+void runCommitGraphAb(gbm::HistoryProvider& provider,
+                      const gbm::HistoryQuery& query,
+                      const gbm::GitInstallation& installation,
+                      int pairs,
+                      double minSpeedup) {
+    // GIT_CONFIG_COUNT is git 2.31; this project's floor is 2.30. Refusing
+    // here is the whole reason this check exists: on 2.30 the toggle is
+    // silently ignored, both arms use the commit-graph, and the run would
+    // report a false ~1.0x regression instead of naming the real problem.
+    if (installation.version < gbm::GitVersion{2, 31, 0}) {
+        check(false,
+              "commit-graph A/B needs git 2.31 for GIT_CONFIG_COUNT; found " +
+                  installation.version.toString());
+        return;
+    }
+
+    // A warm-up walk whose timing is discarded. The first walk pays for
+    // faulting the pack and the commit-graph file into the page cache;
+    // charging that cost to whichever arm happens to run first would bias
+    // exactly the comparison this gate exists to make fairly.
+    setCommitGraphEnabled(true);
+    const WalkTiming warmup = timeOneWalk(provider, query);
+    if (!warmup.snapshot) {
+        check(false, "commit-graph A/B warm-up walk failed");
+        return;
+    }
+
+    std::vector<long long> offTotal;
+    std::vector<long long> offFirst;
+    std::vector<long long> onTotal;
+    std::vector<long long> onFirst;
+    bool rowsAgree = true;
+
+    for (int i = 0; i < pairs; ++i) {
+        // The no-graph arm runs first in every pair on purpose. It touches a
+        // superset of the pages the graph arm needs, so any residual
+        // cold-cache cost lands on the arm already called slow: the bias runs
+        // toward *understating* the speedup, so a pass can never be an
+        // artefact of the ordering.
+        setCommitGraphEnabled(false);
+        const WalkTiming off = timeOneWalk(provider, query);
+        setCommitGraphEnabled(true);
+        const WalkTiming on = timeOneWalk(provider, query);
+        if (!off.snapshot || !on.snapshot) {
+            check(false, "a walk failed during the commit-graph A/B loop");
+            return;
+        }
+        rowsAgree = rowsAgree && off.rows == warmup.rows && on.rows == warmup.rows;
+        offTotal.push_back(off.totalMs);
+        offFirst.push_back(off.firstChunkMs);
+        onTotal.push_back(on.totalMs);
+        onFirst.push_back(on.firstChunkMs);
+    }
+    setCommitGraphEnabled(true);  // Leave the process in the state main() otherwise expects.
+
+    // If the two arms disagree on row count they did not walk the same
+    // history, and whatever ratio came out of them means nothing.
+    check(rowsAgree, "the commit-graph A/B arms walked different row counts");
+
+    const long long offMs = medianOf(offTotal);
+    const long long onMs = medianOf(onTotal);
+    const long long offFirstMs = medianOf(offFirst);
+    const long long onFirstMs = medianOf(onFirst);
+
+    std::fprintf(stderr,
+                 "commit-graph A/B (%d pairs, %zu rows):\n"
+                 "  graph off: total median=%lldms [%s] first-chunk median=%lldms\n"
+                 "  graph on : total median=%lldms [%s] first-chunk median=%lldms\n",
+                 pairs,
+                 warmup.rows,
+                 offMs,
+                 joinSamples(offTotal).c_str(),
+                 offFirstMs,
+                 onMs,
+                 joinSamples(onTotal).c_str(),
+                 onFirstMs);
+
+    // Below this floor, 1ms clock resolution and process-spawn cost are a
+    // large fraction of the measurement and the ratio stops meaning anything.
+    // This is the guard against the one realistic way the gate degenerates
+    // into passing on noise: someone shrinking the fixture to make CI faster.
+    constexpr long long kMinMeasurableMs = 50;
+    check(onMs >= kMinMeasurableMs,
+          "fixture too small to time: the commit-graph walk took " + std::to_string(onMs) +
+              "ms, under the " + std::to_string(kMinMeasurableMs) +
+              "ms floor -- raise the fixture's commit count");
+
+    const double totalSpeedup =
+        static_cast<double>(offMs) / static_cast<double>(std::max<long long>(onMs, 1));
+    const double firstSpeedup =
+        static_cast<double>(offFirstMs) / static_cast<double>(std::max<long long>(onFirstMs, 1));
+
+    // One machine-readable line for the nightly job's Step Summary to grep.
+    std::fprintf(stderr,
+                 "commit-graph-ab: rows=%zu pairs=%d off_total_ms=%lld on_total_ms=%lld "
+                 "total_speedup=%.2f off_first_ms=%lld on_first_ms=%lld first_speedup=%.2f\n",
+                 warmup.rows,
+                 pairs,
+                 offMs,
+                 onMs,
+                 totalSpeedup,
+                 offFirstMs,
+                 onFirstMs,
+                 firstSpeedup);
+
+    // Gated on total, reported on first-chunk. Time-to-first-chunk is the more
+    // dramatic number (14x vs 5.3x on a real 162k-commit clone) because
+    // streaming topo-order is exactly what the commit-graph enables -- but it
+    // is a single instant, one descheduling away from a wrong answer, whereas
+    // total aggregates the whole walk and averages that away. One gate, on
+    // the steadier metric; the other number is here for the nightly trend.
+    check(totalSpeedup >= minSpeedup,
+          "commit-graph speedup fell to " + std::to_string(totalSpeedup) + "x, under the " +
+              std::to_string(minSpeedup) + "x gate");
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -60,12 +290,23 @@ int main(int argc, char** argv) {
     const std::filesystem::path repoPath = argv[1];
     int printRows = 0;
     double maxBytesPerCommit = 140.0;
+    int commitGraphAbPairs = 0;
+    double minGraphSpeedup = 2.0;
 
     for (int i = 2; i < argc; ++i) {
         if (std::strcmp(argv[i], "--print-rows") == 0 && i + 1 < argc) {
             printRows = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--max-bytes-per-commit") == 0 && i + 1 < argc) {
             maxBytesPerCommit = std::atof(argv[++i]);
+        } else if (std::strcmp(argv[i], "--commit-graph-ab") == 0 && i + 1 < argc) {
+            commitGraphAbPairs = std::atoi(argv[++i]);
+            // Forced odd so medianOf() returns a real observation rather than
+            // averaging the two middle samples.
+            if (commitGraphAbPairs > 0 && commitGraphAbPairs % 2 == 0) {
+                ++commitGraphAbPairs;
+            }
+        } else if (std::strcmp(argv[i], "--min-graph-speedup") == 0 && i + 1 < argc) {
+            minGraphSpeedup = std::atof(argv[++i]);
         }
     }
 
@@ -227,6 +468,14 @@ int main(int argc, char** argv) {
           std::to_string(movedRight) + " first-parent chains moved right (should be 0)");
     std::fprintf(
         stderr, "first-parent edges: %zu straight, %zu moved right\n", straight, movedRight);
+
+    // Runs after correctness is established above: a broken walk should
+    // report as a walk bug, not a perf regression. Off by default (0 pairs);
+    // the commit_graph_speedup_ratio ctest is the only caller that turns it
+    // on, via RunCommitGraphRatioCheck.cmake.
+    if (commitGraphAbPairs > 0) {
+        runCommitGraphAb(provider, query, *installation, commitGraphAbPairs, minGraphSpeedup);
+    }
 
     if (printRows > 0) {
         gbm::AsciiRenderOptions options;

--- a/tests/unit/MaintenanceOpsTest.cpp
+++ b/tests/unit/MaintenanceOpsTest.cpp
@@ -1,0 +1,92 @@
+#include "core/git/RepoPaths.h"
+#include "core/git/ops/MaintenanceOps.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace gbm {
+namespace {
+
+// --- shouldOfferCommitGraph -------------------------------------------------
+// Pure decision table, no repository needed -- see the header comment on why
+// this logic was pulled out of RepositorySession instead of living there.
+
+TEST(MaintenanceOps, NeverOffersWhenAGraphAlreadyExists) {
+    EXPECT_FALSE(shouldOfferCommitGraph(
+        /*hasGraph=*/true, kCommitGraphAdviceMinRows * 10, CommitGraphPreference::Unset));
+}
+
+TEST(MaintenanceOps, NeverOffersAfterTheUserDeclined) {
+    EXPECT_FALSE(shouldOfferCommitGraph(
+        /*hasGraph=*/false, kCommitGraphAdviceMinRows * 10, CommitGraphPreference::Declined));
+}
+
+TEST(MaintenanceOps, NeverOffersOnceEnabledEvenIfTheGraphIsMissing) {
+    // Enabled means "keep this maintained", not "ask every time it happens to
+    // be missing" -- e.g. right after a `git gc` pruned an out-of-date graph,
+    // before the next write runs. Re-prompting here would be nagging, not
+    // helping; the app is expected to just rebuild it, not ask again.
+    EXPECT_FALSE(shouldOfferCommitGraph(
+        /*hasGraph=*/false, kCommitGraphAdviceMinRows * 10, CommitGraphPreference::Enabled));
+}
+
+TEST(MaintenanceOps, DoesNotOfferBelowTheAdviceThreshold) {
+    EXPECT_FALSE(shouldOfferCommitGraph(
+        /*hasGraph=*/false, kCommitGraphAdviceMinRows - 1, CommitGraphPreference::Unset));
+}
+
+TEST(MaintenanceOps, OffersAtOrAboveTheAdviceThresholdWhenUnset) {
+    EXPECT_TRUE(shouldOfferCommitGraph(
+        /*hasGraph=*/false, kCommitGraphAdviceMinRows, CommitGraphPreference::Unset));
+}
+
+// --- hasCommitGraph ----------------------------------------------------------
+
+/// A throwaway `objects/` tree, mirroring DiscoveryTest's TempTree: enough
+/// directory structure for RepoPaths::commitGraphFile()/commitGraphChainFile()
+/// to resolve against, without a real git repository.
+class CommitGraphDetection : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        root_ = std::filesystem::temp_directory_path() /
+                ("gbm-test-" + std::string(info->test_suite_name()) + "-" +
+                 std::string(info->name()));
+        std::filesystem::remove_all(root_);
+        const auto gitDir = root_ / ".git";
+        std::filesystem::create_directories(gitDir / "objects" / "info");
+        paths_ = RepoPaths(root_, gitDir, gitDir);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(root_, ec);
+    }
+
+    static void touch(const std::filesystem::path& file) {
+        std::filesystem::create_directories(file.parent_path());
+        std::ofstream(file).put('\0');
+    }
+
+    std::filesystem::path root_;
+    RepoPaths paths_;
+};
+
+TEST_F(CommitGraphDetection, FalseWhenNeitherFormExists) {
+    EXPECT_FALSE(hasCommitGraph(paths_));
+}
+
+TEST_F(CommitGraphDetection, TrueForTheSingleFileForm) {
+    touch(paths_.commitGraphFile());
+    EXPECT_TRUE(hasCommitGraph(paths_));
+}
+
+TEST_F(CommitGraphDetection, TrueForTheSplitChainForm) {
+    touch(paths_.commitGraphChainFile());
+    EXPECT_TRUE(hasCommitGraph(paths_));
+}
+
+}  // namespace
+}  // namespace gbm

--- a/tests/unit/ProcessRunnerTest.cpp
+++ b/tests/unit/ProcessRunnerTest.cpp
@@ -408,5 +408,61 @@ TEST(RefStore, ParsesGoneTrackFieldWithoutCountingAsAheadOrBehind) {
     EXPECT_EQ((*snapshot)->refs[0].behind, 0);
 }
 
+TEST(RefStore, LoadsEveryRefWithASingleForEachRefInvocation) {
+    // A counted invariant, not a wall-clock one -- same reasoning as
+    // HistoryProvider.PublishesChunksOnAGeometricSchedule above.
+    //
+    // Ahead/behind comes from %(upstream:track) inside the one for-each-ref
+    // above on purpose (see RefStore::load). The obvious-looking alternative --
+    // a `rev-list --count` per branch -- is one process per ref, which turns a
+    // sub-second load on docs/PERFORMANCE.md's 3,798-ref repository into
+    // minutes. Every parsed field would still be correct if someone did that,
+    // so the process count is the only thing that can catch it.
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response symbolic;
+    symbolic.out = "refs/heads/main";
+    runner.whenArgsContain({"symbolic-ref"}, symbolic);
+
+    FakeProcessRunner::Response revParse;
+    revParse.out = std::string(40, 'a');
+    runner.whenArgsContain({"rev-parse"}, revParse);
+
+    // Enough refs, each with tracking info, that a per-ref process would be
+    // unmistakable in the invocation list rather than a rounding error.
+    const char sep = '\x1f';
+    FakeProcessRunner::Response refs;
+    for (int i = 0; i < 200; ++i) {
+        char oid[41];
+        std::snprintf(oid, sizeof(oid), "%040d", i);
+        const std::string name = "branch-" + std::to_string(i);
+        refs.out += "refs/heads/" + name + sep + "commit" + sep + oid + sep + "" + sep +
+                    "refs/remotes/origin/" + name + sep + "[ahead 1, behind 2]" + sep + "" + sep +
+                    "" + "\n";
+    }
+    runner.whenArgsContain({"for-each-ref"}, refs);
+
+    RefStore store(runner, testPaths());
+    auto snapshot = store.load(CancellationToken{});
+    ASSERT_TRUE(snapshot) << snapshot.error().message;
+    ASSERT_EQ((*snapshot)->refs.size(), 200u);
+    EXPECT_EQ((*snapshot)->ofKind(RefKind::LocalBranch).front()->ahead, 1);
+
+    std::size_t forEachRefCalls = 0;
+    for (std::size_t i = 0; i < runner.invocationCount(); ++i) {
+        const std::vector<std::string> args = runner.invokedArgs(i);
+        if (!args.empty() && args.front() == "for-each-ref") {
+            ++forEachRefCalls;
+        }
+    }
+    EXPECT_EQ(forEachRefCalls, 1u)
+        << "one load() must cost exactly one for-each-ref, not one per ref";
+
+    // Three processes in total: symbolic-ref and rev-parse for HEAD
+    // (readHead), then the single for-each-ref. Pinned so that adding "just
+    // one more quick git call" to load() has to be a deliberate edit to this
+    // number.
+    EXPECT_EQ(runner.invocationCount(), 3u);
+}
+
 }  // namespace
 }  // namespace gbm


### PR DESCRIPTION
1. 新增 MaintenanceOps 判斷是否應建議建立 commit-graph，並在歷史圖表首次繪製完成後以非強制提示條顯示，避免與 auto-fetch 造成的第二次繪製訊號重複觸發
2. Repository Settings 新增「保持 commit-graph 最新」選項與立即優化按鈕，並與提示條共用同一組偏好設定
3. 新增 gbm_graph_check 的 --commit-graph-ab 模式，透過同一批次內切換 GIT_CONFIG_COUNT 環境變數量測 commit-graph 帶來的加速比例，避免在不同批次間改動磁碟造成快取干擾；並以 100,000 commits、2.0x 門檻設定為 perf 標籤測試，排除於 PR 檢查之外，改由新增的每日排程 CI (perf-nightly.yml) 執行並回報數據
4. 新增 RefStore 單一 for-each-ref 呼叫與原始碼掃描兩項不依賴時間量測的迴歸測試，防止 refreshRefs()/refreshHistory() 被重複呼叫的問題再次發生
5. 修正 docs/PERFORMANCE.md 與 docs/reports/vscode-graph-performance.md 中錯誤宣稱 commit-graph 提示已經實作的說明