### PR TITLE
fix: 刪除未合併分支時的重複對話框與訊息

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -36,7 +36,13 @@ Everything below works end to end on Linux, macOS and Windows.
   Branches section header can select every such branch in one go — excluding
   HEAD and branches checked out in a linked worktree — so the user still
   deletes them through the normal multi-select Delete rather than a one-click
-  bulk action.
+  bulk action. When Git refuses that delete because the branch is not fully
+  merged, the app checks whether a remote-tracking ref (other than the
+  branch's own) already contains it — the state left by merging a PR without
+  having fetched since — and says so plainly rather than showing Git's raw
+  wording; when it genuinely cannot tell, it suggests fetching rather than
+  claiming the branch was never merged anywhere. A failed operation is
+  reported exactly once, never as two stacked dialogs for the same failure.
 - **Worktrees, stash and tags**: add/remove/lock/prune worktrees; save/apply/
   pop/drop/branch stashes; create/delete/push annotated or lightweight tags.
 - **Fetch, pull and push**, with credential prompts routed through an askpass

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -568,7 +568,16 @@ void MainWindow::buildUi() {
                 // working-copy actions. Still surfaced via the status bar and
                 // operation log so nothing is silently dropped.
                 if (armedFeedbackHandlers_ > 0) {
-                    onCoreError(error);
+                    // Same destinations as onCoreError (status bar + operation
+                    // log), but using `summary` rather than error.message: for
+                    // a delete blocked by an unmerged branch, error.message is
+                    // still git's raw "not fully merged" text, while summary is
+                    // what BranchOps rewrote it to (possibly after comparing
+                    // against remote-tracking refs) -- onCoreError would have
+                    // thrown that improvement away.
+                    statusLabel_->setText(summary);
+                    logMessage(LogLevel::Error,
+                               error.message + (error.detail.empty() ? "" : ": " + error.detail));
                     return;
                 }
                 showError(summary, error);
@@ -1457,6 +1466,12 @@ void MainWindow::closeRepository() {
     workingCopyView_->setSession(nullptr);
     sidebar_->setSession(nullptr);
     repositoryPage_->setSession(nullptr);
+    // Any runWithFeedback()/armWorkingCopyChoiceHandler() connection still
+    // armed against this session dies with it below without ever running its
+    // lambda, so the decrement it would have done never happens -- reset the
+    // count explicitly here rather than leaving it stuck above zero for the
+    // rest of the window's life (see armedFeedbackHandlers_'s doc comment).
+    armedFeedbackHandlers_ = 0;
     session_.reset();
     pendingCheckoutTarget_.clear();
     setWindowTitle(QStringLiteral("git-branch-manager"));

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -559,7 +559,20 @@ void MainWindow::buildUi() {
     connect(workingCopyView_,
             &WorkingCopyView::errorOccurred,
             this,
-            [this](const QString& summary, const GitError& error) { showError(summary, error); });
+            [this](const QString& summary, const GitError& error) {
+                // If a runWithFeedback()/armWorkingCopyChoiceHandler() caller is
+                // already waiting on this same workingCopyOperationFinished, that
+                // caller owns showing the outcome (see armedFeedbackHandlers_'s
+                // declaration) -- popping a second modal here duplicated it for
+                // every operation the sidebar or a dialog initiated, not just
+                // working-copy actions. Still surfaced via the status bar and
+                // operation log so nothing is silently dropped.
+                if (armedFeedbackHandlers_ > 0) {
+                    onCoreError(error);
+                    return;
+                }
+                showError(summary, error);
+            });
     connect(workingCopyView_,
             &WorkingCopyView::viewFileDiffRequested,
             this,
@@ -2329,6 +2342,7 @@ void MainWindow::armWorkingCopyChoiceHandler(std::function<void(bool)> submit,
                                              bool announceSuccess) {
     // A one-shot connection: the handler disconnects itself the moment it runs,
     // so it never reacts to an unrelated working-copy operation finishing later.
+    ++armedFeedbackHandlers_;
     auto connection = std::make_shared<QMetaObject::Connection>();
     *connection =
         connect(session_.get(),
@@ -2336,6 +2350,7 @@ void MainWindow::armWorkingCopyChoiceHandler(std::function<void(bool)> submit,
                 this,
                 [this, submit, connection, announceSuccess](const OperationOutcome& outcome) {
                     QObject::disconnect(*connection);
+                    --armedFeedbackHandlers_;
 
                     if (outcome.succeeded) {
                         const QString summary = QString::fromStdString(outcome.summary);
@@ -2412,6 +2427,10 @@ void MainWindow::showError(const QString& summary, const GitError& error) {
 
 void MainWindow::runWithFeedback(std::function<void()> submit,
                                  std::function<void(OperationChoice::Kind)> onChoice) {
+    // See armWorkingCopyChoiceHandler's matching comment: this is the M3
+    // equivalent one-shot connection, and it owns reporting the next outcome
+    // exactly the same way.
+    ++armedFeedbackHandlers_;
     auto connection = std::make_shared<QMetaObject::Connection>();
     *connection =
         connect(session_.get(),
@@ -2419,6 +2438,7 @@ void MainWindow::runWithFeedback(std::function<void()> submit,
                 this,
                 [this, onChoice, connection](const OperationOutcome& outcome) {
                     QObject::disconnect(*connection);
+                    --armedFeedbackHandlers_;
 
                     if (outcome.succeeded) {
                         statusLabel_->setText(QString::fromStdString(outcome.summary));

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -350,6 +350,15 @@ private:
     /// first click that merely changed the selection.
     int lastClickedCommitRow_ = -1;
 
+    /// Number of one-shot `workingCopyOperationFinished` listeners currently
+    /// armed by runWithFeedback()/armWorkingCopyChoiceHandler(). While this is
+    /// positive, one of those listeners owns reporting the next outcome to the
+    /// user, so the always-connected WorkingCopyView::errorOccurred handler
+    /// must not also pop a dialog for it -- see the connection at the top of
+    /// the constructor. A counter rather than a bool because StashAndRetry
+    /// re-arms armWorkingCopyChoiceHandler for the same round trip.
+    int armedFeedbackHandlers_ = 0;
+
     QLabel* statusLabel_ = nullptr;
     QLabel* toolBarRepoNameLabel_ = nullptr;
     QLabel* toolBarBranchLabel_ = nullptr;

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -357,6 +357,13 @@ private:
     /// must not also pop a dialog for it -- see the connection at the top of
     /// the constructor. A counter rather than a bool because StashAndRetry
     /// re-arms armWorkingCopyChoiceHandler for the same round trip.
+    ///
+    /// Both arming sites connect to session_, so closeRepository() destroying
+    /// session_ silently drops any still-armed connection without ever running
+    /// its lambda -- the decrement lives only inside that lambda, so without an
+    /// explicit reset there the count would stay stuck above zero for the rest
+    /// of the window's life, permanently downgrading every later error to the
+    /// status bar. See closeRepository().
     int armedFeedbackHandlers_ = 0;
 
     QLabel* statusLabel_ = nullptr;

--- a/src/core/git/ops/BranchOps.cpp
+++ b/src/core/git/ops/BranchOps.cpp
@@ -281,14 +281,15 @@ public:
             }
             // The "Delete anyway" explanation must agree with whatever summary
             // is now showing above it: when the probe found the commits on
-            // another remote-tracking ref, outcome.summary already says
-            // deleting loses nothing -- pairing that with "only reachable
-            // through the reflog" here would tell the user two contradictory
-            // things in the same dialog.
+            // another remote-tracking ref, reuse outcome.summary verbatim
+            // (it already names the concrete ref, e.g. "origin/main") rather
+            // than writing a second, looser sentence that could drift out of
+            // sync with it again -- pairing "will not lose anything" with
+            // "only reachable through the reflog" here would tell the user
+            // two contradictory things in the same dialog.
             const std::string deleteAnywayExplanation =
                 probeOutcome == RemoteRefProbeOutcome::FoundElsewhere
-                    ? "This branch's commits already exist on another remote-tracking ref, so "
-                      "deleting it will not lose anything."
+                    ? outcome.summary
                     : (request_.names.size() > 1
                            ? "These branches have commits that are not merged anywhere else. After "
                              "deleting, they are only reachable through the reflog."

--- a/src/core/git/ops/BranchOps.cpp
+++ b/src/core/git/ops/BranchOps.cpp
@@ -11,6 +11,18 @@ namespace gbm {
 
 namespace {
 
+/// What refineSummaryFromRemoteRefs found, so the caller can pick a "Delete
+/// anyway" explanation that agrees with the summary it just wrote -- without
+/// this, a FoundElsewhere summary ("...will not lose anything") sat next to
+/// an explanation that still claimed "only reachable through the reflog",
+/// two directly contradictory claims in the one dialog the whole probe exists
+/// to make trustworthy.
+enum class RemoteRefProbeOutcome {
+    ProbeFailed,
+    NotFoundElsewhere,
+    FoundElsewhere,
+};
+
 /// After `git branch -d <name>` refuses because the branch is "not fully
 /// merged", checks whether a remote-tracking ref other than the branch's own
 /// already contains it -- the exact state left by squash- or merge-committing
@@ -22,11 +34,11 @@ namespace {
 /// view" -- refs/remotes/ is a local cache, not the remote's live state -- so
 /// the "not found" branch below must say exactly that rather than asserting
 /// the branch was never merged anywhere.
-void refineSummaryFromRemoteRefs(IProcessRunner& runner,
-                                 const RepoPaths& paths,
-                                 const std::string& name,
-                                 CancellationToken token,
-                                 OperationOutcome& outcome) {
+RemoteRefProbeOutcome refineSummaryFromRemoteRefs(IProcessRunner& runner,
+                                                  const RepoPaths& paths,
+                                                  const std::string& name,
+                                                  CancellationToken token,
+                                                  OperationOutcome& outcome) {
     GitCommand probe(paths.commandDir(),
                      {"for-each-ref", "--format=%(refname)", "--contains", name, "refs/remotes/"});
     probe.timeout = std::chrono::milliseconds(5000);
@@ -36,7 +48,7 @@ void refineSummaryFromRemoteRefs(IProcessRunner& runner,
         // The probe failing (offline, corrupt ref, timeout) must not mask the
         // real delete failure with something less informative -- leave
         // outcome.summary exactly as the caller already set it.
-        return;
+        return RemoteRefProbeOutcome::ProbeFailed;
     }
 
     static constexpr std::string_view kRemotesPrefix = "refs/remotes/";
@@ -77,7 +89,7 @@ void refineSummaryFromRemoteRefs(IProcessRunner& runner,
             "This branch's commits were not found on any remote-tracking ref from your last "
             "fetch. If it was just merged on the remote, fetch and try again -- otherwise "
             "deleting it makes them reachable only through the reflog";
-        return;
+        return RemoteRefProbeOutcome::NotFoundElsewhere;
     }
 
     const std::string label = elsewhere.rfind(kRemotesPrefix, 0) == 0
@@ -85,6 +97,7 @@ void refineSummaryFromRemoteRefs(IProcessRunner& runner,
                                   : elsewhere;
     outcome.summary = "This branch's commits already exist on " + label +
                       "; deleting it will not lose anything, your local branch is just behind";
+    return RemoteRefProbeOutcome::FoundElsewhere;
 }
 
 class CreateBranchOperation final : public Operation {
@@ -261,15 +274,30 @@ public:
             // not yet pulling) fails `-d` too, even though deleting it loses
             // nothing. Single-branch only, matching the shape of the summary
             // this produces; a multi-branch delete keeps the message above.
+            RemoteRefProbeOutcome probeOutcome = RemoteRefProbeOutcome::ProbeFailed;
             if (request_.names.size() == 1) {
-                refineSummaryFromRemoteRefs(runner, paths, request_.names.front(), token, outcome);
+                probeOutcome = refineSummaryFromRemoteRefs(
+                    runner, paths, request_.names.front(), token, outcome);
             }
-            outcome.choices.push_back(
-                {OperationChoice::Kind::ForceDiscard,
-                 "Delete anyway",
-                 "This branch has commits that are not merged anywhere else. After deleting, they "
-                 "are only reachable through the reflog.",
-                 true});
+            // The "Delete anyway" explanation must agree with whatever summary
+            // is now showing above it: when the probe found the commits on
+            // another remote-tracking ref, outcome.summary already says
+            // deleting loses nothing -- pairing that with "only reachable
+            // through the reflog" here would tell the user two contradictory
+            // things in the same dialog.
+            const std::string deleteAnywayExplanation =
+                probeOutcome == RemoteRefProbeOutcome::FoundElsewhere
+                    ? "This branch's commits already exist on another remote-tracking ref, so "
+                      "deleting it will not lose anything."
+                    : (request_.names.size() > 1
+                           ? "These branches have commits that are not merged anywhere else. After "
+                             "deleting, they are only reachable through the reflog."
+                           : "This branch has commits that are not merged anywhere else. After "
+                             "deleting, they are only reachable through the reflog.");
+            outcome.choices.push_back({OperationChoice::Kind::ForceDiscard,
+                                       "Delete anyway",
+                                       deleteAnywayExplanation,
+                                       true});
             outcome.choices.push_back(
                 {OperationChoice::Kind::Abort, "Cancel", "Keep the branch.", false});
         }

--- a/src/core/git/ops/BranchOps.cpp
+++ b/src/core/git/ops/BranchOps.cpp
@@ -246,9 +246,15 @@ public:
         // already avoids exactly that.
         const bool notMerged = error.detail.find("not fully merged") != std::string::npos;
         if (notMerged && !request_.force) {
-            outcome.summary =
-                "This branch has commits that are not merged into any other "
-                "branch you have locally";
+            // Matches describe()'s singular/plural split above: a multi-branch
+            // delete can legitimately hit this with more than one name in
+            // request_.names, and "This branch" reads wrong when several were
+            // selected.
+            outcome.summary = request_.names.size() > 1
+                                  ? "These branches have commits that are not merged into any "
+                                    "other branch you have locally"
+                                  : "This branch has commits that are not merged into any other "
+                                    "branch you have locally";
             // "Not merged locally" and "genuinely unmerged" are different claims:
             // a local integration branch that is simply behind its remote (the
             // exact situation right after squash- or merge-committing a PR and

--- a/src/core/git/ops/BranchOps.cpp
+++ b/src/core/git/ops/BranchOps.cpp
@@ -161,9 +161,16 @@ public:
         outcome.summary = error.message;
 
         // `-d` refuses to delete unmerged work. Offering `-D` is legitimate, but
-        // it has to be labelled honestly.
+        // it has to be labelled honestly. Left unhandled this falls through to
+        // classifyGitStderr's generic "Git reported an error" fallback, which
+        // sends the user hunting through a collapsed Details pane for git's own
+        // "not fully merged" phrasing -- see the worktree case below, which
+        // already avoids exactly that.
         const bool notMerged = error.detail.find("not fully merged") != std::string::npos;
         if (notMerged && !request_.force) {
+            outcome.summary =
+                "This branch has commits that are not merged into any other "
+                "branch you have locally";
             outcome.choices.push_back(
                 {OperationChoice::Kind::ForceDiscard,
                  "Delete anyway",

--- a/src/core/git/ops/BranchOps.cpp
+++ b/src/core/git/ops/BranchOps.cpp
@@ -3,11 +3,89 @@
 #include "core/base/FsUtil.h"
 #include "core/git/RefStore.h"
 
+#include <sstream>
+#include <string_view>
 #include <utility>
 
 namespace gbm {
 
 namespace {
+
+/// After `git branch -d <name>` refuses because the branch is "not fully
+/// merged", checks whether a remote-tracking ref other than the branch's own
+/// already contains it -- the exact state left by squash- or merge-committing
+/// a PR without having pulled the integration branch since. `-d` only checks
+/// reachability from local refs, so it cannot tell "genuinely unmerged" apart
+/// from "merged on the remote, local view is stale" on its own.
+///
+/// This can only narrow "not found" down to "not found in the last-fetched
+/// view" -- refs/remotes/ is a local cache, not the remote's live state -- so
+/// the "not found" branch below must say exactly that rather than asserting
+/// the branch was never merged anywhere.
+void refineSummaryFromRemoteRefs(IProcessRunner& runner,
+                                 const RepoPaths& paths,
+                                 const std::string& name,
+                                 CancellationToken token,
+                                 OperationOutcome& outcome) {
+    GitCommand probe(paths.commandDir(),
+                     {"for-each-ref", "--format=%(refname)", "--contains", name, "refs/remotes/"});
+    probe.timeout = std::chrono::milliseconds(5000);
+
+    auto probeResult = runner.run(probe, token);
+    if (!probeResult) {
+        // The probe failing (offline, corrupt ref, timeout) must not mask the
+        // real delete failure with something less informative -- leave
+        // outcome.summary exactly as the caller already set it.
+        return;
+    }
+
+    static constexpr std::string_view kRemotesPrefix = "refs/remotes/";
+    std::string elsewhere;
+    std::istringstream lines(probeResult->out);
+    std::string line;
+    while (std::getline(lines, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        // The branch's own remote-tracking ref (e.g. refs/remotes/origin/<name>)
+        // only means it was pushed, not that anything merged it -- exclude it
+        // so a plain `git push` doesn't get misread as "safe to delete".
+        const bool isOwnUpstream =
+            line.size() > name.size() + 1 &&
+            line.compare(line.size() - name.size(), name.size(), name) == 0 &&
+            line[line.size() - name.size() - 1] == '/';
+        if (isOwnUpstream) {
+            continue;
+        }
+        // refs/remotes/<remote>/HEAD is a symref alias for that remote's
+        // default branch, not a real one -- `for-each-ref` lists it
+        // alongside the branches it points at (and, sorting alphabetically,
+        // before them), so without this it would win as "the" remote to
+        // name and tell the user their commits are safe on a ref that means
+        // nothing to them.
+        static constexpr std::string_view kHeadSuffix = "/HEAD";
+        if (line.size() >= kHeadSuffix.size() &&
+            line.compare(line.size() - kHeadSuffix.size(), kHeadSuffix.size(), kHeadSuffix) == 0) {
+            continue;
+        }
+        elsewhere = line;
+        break;
+    }
+
+    if (elsewhere.empty()) {
+        outcome.summary =
+            "This branch's commits were not found on any remote-tracking ref from your last "
+            "fetch. If it was just merged on the remote, fetch and try again -- otherwise "
+            "deleting it makes them reachable only through the reflog";
+        return;
+    }
+
+    const std::string label = elsewhere.rfind(kRemotesPrefix, 0) == 0
+                                  ? elsewhere.substr(kRemotesPrefix.size())
+                                  : elsewhere;
+    outcome.summary = "This branch's commits already exist on " + label +
+                      "; deleting it will not lose anything, your local branch is just behind";
+}
 
 class CreateBranchOperation final : public Operation {
 public:
@@ -171,6 +249,15 @@ public:
             outcome.summary =
                 "This branch has commits that are not merged into any other "
                 "branch you have locally";
+            // "Not merged locally" and "genuinely unmerged" are different claims:
+            // a local integration branch that is simply behind its remote (the
+            // exact situation right after squash- or merge-committing a PR and
+            // not yet pulling) fails `-d` too, even though deleting it loses
+            // nothing. Single-branch only, matching the shape of the summary
+            // this produces; a multi-branch delete keeps the message above.
+            if (request_.names.size() == 1) {
+                refineSummaryFromRemoteRefs(runner, paths, request_.names.front(), token, outcome);
+            }
             outcome.choices.push_back(
                 {OperationChoice::Kind::ForceDiscard,
                  "Delete anyway",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,15 @@ add_test(NAME no_embedded_conflict_panel
             -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckNoEmbeddedConflictPanel.cmake")
 set_tests_properties(no_embedded_conflict_panel PROPERTIES LABELS "unit")
 
+# Same rationale again: pins the fix for a failed working-copy-adjacent
+# operation (e.g. a sidebar branch delete) popping two "Git reported an
+# error" dialogs back to back -- see CheckSingleErrorDialogOwner.cmake.
+add_test(NAME single_error_dialog_owner
+    COMMAND "${CMAKE_COMMAND}"
+            -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckSingleErrorDialogOwner.cmake")
+set_tests_properties(single_error_dialog_owner PROPERTIES LABELS "unit")
+
 # Test doubles live here rather than in the shipped library.
 add_library(gbm_test_support STATIC support/FakeProcessRunner.cpp)
 target_include_directories(gbm_test_support PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(gbm_test_support PUBLIC gbm_core PRIVATE gbm_warnings)
 
 # --- core unit + integration tests (no Qt needed) --------------------------
 add_executable(gbm_core_tests
+    unit/BranchOpsTest.cpp
     unit/ConflictBatchTest.cpp
     unit/ConflictMarkerParserTest.cpp
     unit/CoreBasicsTest.cpp

--- a/tests/cmake/CheckSingleErrorDialogOwner.cmake
+++ b/tests/cmake/CheckSingleErrorDialogOwner.cmake
@@ -67,13 +67,49 @@ string(FIND "${cpp_text}" "WorkingCopyView::errorOccurred" error_occurred_pos)
 if(error_occurred_pos EQUAL -1)
     list(APPEND failures "could not locate the WorkingCopyView::errorOccurred connection in MainWindow.cpp to inspect")
 else()
-    string(SUBSTRING "${cpp_text}" ${error_occurred_pos} 700 handler_window)
+    string(SUBSTRING "${cpp_text}" ${error_occurred_pos} 1000 handler_window)
     string(FIND "${handler_window}" "armedFeedbackHandlers_" guard_pos)
     string(FIND "${handler_window}" "showError(summary" show_error_pos)
     if(show_error_pos EQUAL -1)
-        list(APPEND failures "expected to find a showError(summary, ...) call within 700 characters of the WorkingCopyView::errorOccurred connection")
+        list(APPEND failures "expected to find a showError(summary, ...) call within 1000 characters of the WorkingCopyView::errorOccurred connection")
     elseif(guard_pos EQUAL -1 OR guard_pos GREATER show_error_pos)
         list(APPEND failures "WorkingCopyView::errorOccurred handler calls showError() without checking armedFeedbackHandlers_ first -- this duplicates the dialog runWithFeedback()/armWorkingCopyChoiceHandler() already shows")
+    endif()
+
+    # When the counter suppresses the dialog, the fallback text must still be
+    # `summary` (BranchOps's rewritten message, e.g. after comparing against
+    # remote-tracking refs), not error.message (git's raw, often-useless
+    # "not fully merged" text) -- onCoreError(error) only has the latter, so
+    # calling it here would silently regress the wording Task 2/3 fixed for
+    # the one case (armed handler present) where it matters.
+    string(FIND "${handler_window}" "statusLabel_->setText(summary)" summary_used_pos)
+    if(summary_used_pos EQUAL -1)
+        list(APPEND failures "WorkingCopyView::errorOccurred's suppressed branch does not use statusLabel_->setText(summary) -- it must show BranchOps's rewritten summary, not error.message, when downgrading to the status bar")
+    endif()
+    if(handler_window MATCHES "onCoreError\\(error\\)")
+        list(APPEND failures "WorkingCopyView::errorOccurred's suppressed branch calls onCoreError(error), which uses error.message instead of the caller's rewritten summary")
+    endif()
+endif()
+
+# closeRepository() must reset the counter, not just leave it to the
+# arming lambdas: those lambdas are connected to session_, so
+# session_.reset() destroys any still-armed connection without ever
+# running it, and the decrement lives only inside that lambda. Without an
+# explicit reset here the count would stay stuck above zero across a repo
+# switch/close made while an operation was in flight, permanently
+# downgrading every later WorkingCopyView error to the status bar instead
+# of the dialog it should get.
+string(FIND "${cpp_text}" "session_.reset();" session_reset_pos)
+if(session_reset_pos EQUAL -1)
+    list(APPEND failures "could not locate session_.reset() in MainWindow.cpp to inspect")
+else()
+    math(EXPR reset_window_start "${session_reset_pos} - 400")
+    if(reset_window_start LESS 0)
+        set(reset_window_start 0)
+    endif()
+    string(SUBSTRING "${cpp_text}" ${reset_window_start} 400 reset_window)
+    if(NOT reset_window MATCHES "armedFeedbackHandlers_[ \t\r\n]*=[ \t\r\n]*0;")
+        list(APPEND failures "closeRepository() does not reset armedFeedbackHandlers_ to 0 before session_.reset() -- a connection armed against the old session dies silently without decrementing, leaking the count")
     endif()
 endif()
 

--- a/tests/cmake/CheckSingleErrorDialogOwner.cmake
+++ b/tests/cmake/CheckSingleErrorDialogOwner.cmake
@@ -1,0 +1,85 @@
+# Fails if WorkingCopyView::errorOccurred is wired straight to showError()
+# without first checking armedFeedbackHandlers_.
+#
+# A source check rather than a behavioural one, and that is the point (see
+# CheckNoDuplicateRefRefresh.cmake for the same rationale). The bug this pins:
+# WorkingCopyView keeps a permanent connection to workingCopyOperationFinished
+# and pops a QMessageBox::Critical for *any* failure, even for operations it
+# did not initiate -- e.g. a sidebar branch delete. runWithFeedback() and
+# armWorkingCopyChoiceHandler() also listen, one-shot, and pop their own
+# dialog for the same outcome. The result was two "Git reported an error"
+# boxes back to back for a single failed `git branch -d`. Reproducing that at
+# runtime needs a live QApplication and two connected signal paths racing each
+# other -- an async harness this repository does not have -- so this instead
+# asserts the ownership guard is present in the source.
+
+if(NOT SOURCE_DIR)
+    message(FATAL_ERROR "CheckSingleErrorDialogOwner.cmake requires SOURCE_DIR")
+endif()
+
+set(main_window_cpp "${SOURCE_DIR}/src/app/views/MainWindow.cpp")
+set(main_window_h "${SOURCE_DIR}/src/app/views/MainWindow.h")
+
+if(NOT EXISTS "${main_window_cpp}")
+    message(FATAL_ERROR "Expected to find ${main_window_cpp}")
+endif()
+if(NOT EXISTS "${main_window_h}")
+    message(FATAL_ERROR "Expected to find ${main_window_h}")
+endif()
+
+file(READ "${main_window_cpp}" cpp_text)
+file(READ "${main_window_h}" h_text)
+
+# Comments stripped first, same greedy-safe pattern as
+# CheckNoDuplicateRefRefresh.cmake -- this file's own doc comments name
+# armedFeedbackHandlers_ in prose and would otherwise trip the check.
+string(REGEX REPLACE "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/" "" cpp_text "${cpp_text}")
+string(REGEX REPLACE "//[^\n]*" "" cpp_text "${cpp_text}")
+
+set(failures "")
+
+# The counter must exist as a member.
+if(NOT h_text MATCHES "armedFeedbackHandlers_")
+    list(APPEND failures "MainWindow.h no longer declares armedFeedbackHandlers_")
+endif()
+
+# runWithFeedback() and armWorkingCopyChoiceHandler() must both increment it
+# before arming their one-shot connection, and decrement it once their
+# connection fires (each disconnects itself with QObject::disconnect(*connection)
+# immediately beforehand, so that call is the anchor to search near).
+if(NOT cpp_text MATCHES "\\+\\+armedFeedbackHandlers_")
+    list(APPEND failures "no ++armedFeedbackHandlers_ found -- a feedback handler must arm the counter when it connects")
+endif()
+if(NOT cpp_text MATCHES "QObject::disconnect\\(\\*connection\\);[ \t\r\n]*--armedFeedbackHandlers_")
+    list(APPEND failures "no --armedFeedbackHandlers_ immediately after QObject::disconnect(*connection) -- the counter must be released as soon as a one-shot handler fires, in every runWithFeedback()/armWorkingCopyChoiceHandler() lambda")
+endif()
+
+# The errorOccurred connection must check the counter before calling
+# showError(); otherwise it duplicates whatever runWithFeedback()/
+# armWorkingCopyChoiceHandler() already shows for the same outcome. A fixed
+# window rather than brace-matching: CMake's regex engine has no recursion, so
+# capturing "everything between this connect()'s matched braces" cannot be
+# expressed when the lambda body itself contains a nested if-block's braces --
+# the greedy [^{}]* would just backtrack to the nearest unrelated brace pair
+# anywhere later in the file. A window sized to comfortably hold this one
+# lambda is a robust enough proxy for "the same handler".
+string(FIND "${cpp_text}" "WorkingCopyView::errorOccurred" error_occurred_pos)
+if(error_occurred_pos EQUAL -1)
+    list(APPEND failures "could not locate the WorkingCopyView::errorOccurred connection in MainWindow.cpp to inspect")
+else()
+    string(SUBSTRING "${cpp_text}" ${error_occurred_pos} 700 handler_window)
+    string(FIND "${handler_window}" "armedFeedbackHandlers_" guard_pos)
+    string(FIND "${handler_window}" "showError(summary" show_error_pos)
+    if(show_error_pos EQUAL -1)
+        list(APPEND failures "expected to find a showError(summary, ...) call within 700 characters of the WorkingCopyView::errorOccurred connection")
+    elseif(guard_pos EQUAL -1 OR guard_pos GREATER show_error_pos)
+        list(APPEND failures "WorkingCopyView::errorOccurred handler calls showError() without checking armedFeedbackHandlers_ first -- this duplicates the dialog runWithFeedback()/armWorkingCopyChoiceHandler() already shows")
+    endif()
+endif()
+
+if(failures)
+    string(REPLACE ";" "\n  - " pretty "${failures}")
+    message(FATAL_ERROR "Single-error-dialog-owner invariant violated:\n  - ${pretty}")
+endif()
+
+message(STATUS "MainWindow's feedback-handler ownership guard is in place")

--- a/tests/unit/BranchOpsTest.cpp
+++ b/tests/unit/BranchOpsTest.cpp
@@ -4,7 +4,6 @@
 // it does not) are exactly the git responses a fake runner can script on
 // demand, without depending on git's own timing to reach either state.
 #include "core/git/ops/BranchOps.h"
-
 #include "support/FakeProcessRunner.h"
 
 #include <gtest/gtest.h>
@@ -106,6 +105,31 @@ TEST(DeleteBranchOperation, SuggestsFetchingWhenNoRemoteRefContainsIt) {
     // Must not overclaim: this is "not found in the last-fetched view", not a
     // confirmed "this really was never merged anywhere".
     EXPECT_EQ(outcome.summary.find("Git reported an error"), std::string::npos);
+}
+
+TEST(DeleteBranchOperation, PluralizesTheNotMergedSummaryForAMultiBranchDelete) {
+    FakeProcessRunner runner;
+
+    // Same "not fully merged" stderr, but for a request naming several
+    // branches at once -- the refineSummaryFromRemoteRefs probe only runs for
+    // a single-name request, so this exercises the summary BranchOps sets
+    // before that guard, which must read "These branches", not "This branch".
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 1;
+    failure.err =
+        "error: the branch 'multi-a' is not fully merged\n"
+        "hint: If you are sure you want to delete it, run 'git branch -D multi-a'\n";
+    runner.whenArgsContain({"branch", "-d", "multi-a", "multi-b"}, failure);
+
+    DeleteBranchRequest request;
+    request.names = {"multi-a", "multi-b"};
+    auto operation = makeDeleteBranchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    EXPECT_NE(outcome.summary.find("These branches"), std::string::npos);
+    EXPECT_EQ(outcome.summary.find("This branch "), std::string::npos);
 }
 
 TEST(DeleteBranchOperation, KeepsExistingSummaryWhenTheProbeItselfFails) {

--- a/tests/unit/BranchOpsTest.cpp
+++ b/tests/unit/BranchOpsTest.cpp
@@ -55,6 +55,14 @@ TEST(DeleteBranchOperation, ReportsSafeToDeleteWhenAnotherRemoteRefContainsIt) {
     EXPECT_NE(outcome.summary.find("not lose"), std::string::npos);
     // Never claims certainty it does not have.
     EXPECT_EQ(outcome.summary.find("Git reported an error"), std::string::npos);
+
+    // The "Delete anyway" choice must agree with the summary above it: once
+    // the probe found the commits elsewhere, the explanation must not still
+    // warn that deleting makes them "only reachable through the reflog" --
+    // that directly contradicts "will not lose anything" in the summary.
+    ASSERT_FALSE(outcome.choices.empty());
+    EXPECT_NE(outcome.choices.front().explanation.find("will not lose"), std::string::npos);
+    EXPECT_EQ(outcome.choices.front().explanation.find("reflog"), std::string::npos);
 }
 
 TEST(DeleteBranchOperation, SkipsOriginHeadAsTheReportedRemote) {
@@ -130,6 +138,11 @@ TEST(DeleteBranchOperation, PluralizesTheNotMergedSummaryForAMultiBranchDelete) 
     EXPECT_FALSE(outcome.succeeded);
     EXPECT_NE(outcome.summary.find("These branches"), std::string::npos);
     EXPECT_EQ(outcome.summary.find("This branch "), std::string::npos);
+    // The choice explanation must be pluralized the same way -- it is a
+    // separate string built independently of the summary.
+    ASSERT_FALSE(outcome.choices.empty());
+    EXPECT_NE(outcome.choices.front().explanation.find("These branches"), std::string::npos);
+    EXPECT_EQ(outcome.choices.front().explanation.find("This branch "), std::string::npos);
 }
 
 TEST(DeleteBranchOperation, KeepsExistingSummaryWhenTheProbeItselfFails) {

--- a/tests/unit/BranchOpsTest.cpp
+++ b/tests/unit/BranchOpsTest.cpp
@@ -57,10 +57,14 @@ TEST(DeleteBranchOperation, ReportsSafeToDeleteWhenAnotherRemoteRefContainsIt) {
     EXPECT_EQ(outcome.summary.find("Git reported an error"), std::string::npos);
 
     // The "Delete anyway" choice must agree with the summary above it: once
-    // the probe found the commits elsewhere, the explanation must not still
-    // warn that deleting makes them "only reachable through the reflog" --
-    // that directly contradicts "will not lose anything" in the summary.
+    // the probe found the commits elsewhere, the explanation is the same
+    // string as the summary (naming the concrete ref), not a separate,
+    // looser sentence that could drift out of sync with it -- and it must
+    // not still warn that deleting makes them "only reachable through the
+    // reflog", which directly contradicts "will not lose anything".
     ASSERT_FALSE(outcome.choices.empty());
+    EXPECT_EQ(outcome.choices.front().explanation, outcome.summary);
+    EXPECT_NE(outcome.choices.front().explanation.find("origin/main"), std::string::npos);
     EXPECT_NE(outcome.choices.front().explanation.find("will not lose"), std::string::npos);
     EXPECT_EQ(outcome.choices.front().explanation.find("reflog"), std::string::npos);
 }

--- a/tests/unit/BranchOpsTest.cpp
+++ b/tests/unit/BranchOpsTest.cpp
@@ -1,0 +1,139 @@
+// Tests for DeleteBranchOperation's handling of an unmerged local delete,
+// using FakeProcessRunner instead of a real repository -- the two branches
+// that matter here (the remote-tracking view knows the commit is elsewhere /
+// it does not) are exactly the git responses a fake runner can script on
+// demand, without depending on git's own timing to reach either state.
+#include "core/git/ops/BranchOps.h"
+
+#include "support/FakeProcessRunner.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace gbm {
+namespace {
+
+using testing::FakeProcessRunner;
+
+RepoPaths testPaths() {
+    return RepoPaths("/repo", "/repo/.git", "/repo/.git");
+}
+
+constexpr const char* kNotFullyMergedStderr =
+    "error: the branch 'feature' is not fully merged\n"
+    "hint: If you are sure you want to delete it, run 'git branch -D feature'\n"
+    "hint: Disable this message with \"git config set advice.forceDeleteBranch false\"\n";
+
+void scriptFailedDelete(FakeProcessRunner& runner) {
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 1;
+    failure.err = kNotFullyMergedStderr;
+    runner.whenArgsContain({"branch", "-d", "feature"}, failure);
+}
+
+TEST(DeleteBranchOperation, ReportsSafeToDeleteWhenAnotherRemoteRefContainsIt) {
+    FakeProcessRunner runner;
+    scriptFailedDelete(runner);
+
+    // The branch's own upstream ref is present (it was pushed) but that alone
+    // does not mean it is merged -- origin/main containing it is the signal
+    // that deleting locally loses nothing.
+    FakeProcessRunner::Response probe;
+    probe.exitCode = 0;
+    probe.out = "refs/remotes/origin/feature\nrefs/remotes/origin/main\n";
+    runner.whenArgsContain({"for-each-ref", "--contains", "feature", "refs/remotes/"}, probe);
+
+    DeleteBranchRequest request;
+    request.names = {"feature"};
+    auto operation = makeDeleteBranchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    // Names the remote it found the commits on, and is explicit that nothing
+    // is lost -- this is the "actually safe, just a local view problem" case.
+    EXPECT_NE(outcome.summary.find("origin/main"), std::string::npos);
+    EXPECT_NE(outcome.summary.find("not lose"), std::string::npos);
+    // Never claims certainty it does not have.
+    EXPECT_EQ(outcome.summary.find("Git reported an error"), std::string::npos);
+}
+
+TEST(DeleteBranchOperation, SkipsOriginHeadAsTheReportedRemote) {
+    FakeProcessRunner runner;
+    scriptFailedDelete(runner);
+
+    // `for-each-ref` on a real repo returns refs/remotes/<remote>/HEAD (a
+    // symref, always sorted first because 'H' < 'm') alongside the actual
+    // branches it points at. Reporting "already exists on origin/HEAD" would
+    // be meaningless to a user -- the real, nameable branch (origin/main)
+    // must be what gets surfaced.
+    FakeProcessRunner::Response probe;
+    probe.exitCode = 0;
+    probe.out = "refs/remotes/origin/HEAD\nrefs/remotes/origin/main\n";
+    runner.whenArgsContain({"for-each-ref", "--contains", "feature", "refs/remotes/"}, probe);
+
+    DeleteBranchRequest request;
+    request.names = {"feature"};
+    auto operation = makeDeleteBranchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    EXPECT_NE(outcome.summary.find("origin/main"), std::string::npos);
+    EXPECT_EQ(outcome.summary.find("origin/HEAD"), std::string::npos);
+}
+
+TEST(DeleteBranchOperation, SuggestsFetchingWhenNoRemoteRefContainsIt) {
+    FakeProcessRunner runner;
+    scriptFailedDelete(runner);
+
+    // Only the branch's own upstream ref shows up -- pushed, but nothing else
+    // known locally contains it. This is exactly the state a stale
+    // remote-tracking view produces, so the summary must not claim certainty.
+    FakeProcessRunner::Response probe;
+    probe.exitCode = 0;
+    probe.out = "refs/remotes/origin/feature\n";
+    runner.whenArgsContain({"for-each-ref", "--contains", "feature", "refs/remotes/"}, probe);
+
+    DeleteBranchRequest request;
+    request.names = {"feature"};
+    auto operation = makeDeleteBranchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    EXPECT_NE(outcome.summary.find("fetch"), std::string::npos);
+    // Must not overclaim: this is "not found in the last-fetched view", not a
+    // confirmed "this really was never merged anywhere".
+    EXPECT_EQ(outcome.summary.find("Git reported an error"), std::string::npos);
+}
+
+TEST(DeleteBranchOperation, KeepsExistingSummaryWhenTheProbeItselfFails) {
+    FakeProcessRunner runner;
+    scriptFailedDelete(runner);
+
+    FakeProcessRunner::Response probeFailure;
+    probeFailure.exitCode = 128;
+    probeFailure.err = "fatal: not a git repository\n";
+    runner.whenArgsContain({"for-each-ref", "--contains", "feature", "refs/remotes/"},
+                           probeFailure);
+
+    DeleteBranchRequest request;
+    request.names = {"feature"};
+    auto operation = makeDeleteBranchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    // A secondary probe failure must never mask the primary delete failure
+    // with something less informative.
+    EXPECT_NE(outcome.summary.find("not merged"), std::string::npos);
+    bool offersForce = false;
+    for (const OperationChoice& choice : outcome.choices) {
+        offersForce = offersForce || choice.kind == OperationChoice::Kind::ForceDiscard;
+    }
+    EXPECT_TRUE(offersForce);
+}
+
+}  // namespace
+}  // namespace gbm

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -687,6 +687,12 @@ TEST_F(RealRepoTest, RefusesToDeleteAnUnmergedBranchWithoutConsent) {
     operations.drain();
 
     EXPECT_FALSE(outcome.succeeded);
+    // The headline the user actually reads has to say what happened, not
+    // fall back to classifyGitStderr's generic "Git reported an error" --
+    // that string carries no information and sent a real user hunting
+    // through a collapsed Details pane for git's own phrasing.
+    EXPECT_NE(outcome.summary, "Git reported an error");
+    EXPECT_NE(outcome.summary.find("not merged"), std::string::npos);
     bool offersForce = false;
     for (const OperationChoice& choice : outcome.choices) {
         if (choice.kind == OperationChoice::Kind::ForceDiscard) {

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -692,7 +692,12 @@ TEST_F(RealRepoTest, RefusesToDeleteAnUnmergedBranchWithoutConsent) {
     // that string carries no information and sent a real user hunting
     // through a collapsed Details pane for git's own phrasing.
     EXPECT_NE(outcome.summary, "Git reported an error");
-    EXPECT_NE(outcome.summary.find("not merged"), std::string::npos);
+    // This fixture has no remote configured, so the remote-ref probe
+    // (BranchOpsTest.cpp covers its branches directly against a fake runner)
+    // finds nothing and the summary must say so honestly -- "fetch and try
+    // again", not a claim that the branch was definitely never merged
+    // anywhere, which is not something a local-only check can know.
+    EXPECT_NE(outcome.summary.find("fetch"), std::string::npos);
     bool offersForce = false;
     for (const OperationChoice& choice : outcome.choices) {
         if (choice.kind == OperationChoice::Kind::ForceDiscard) {
@@ -704,6 +709,83 @@ TEST_F(RealRepoTest, RefusesToDeleteAnUnmergedBranchWithoutConsent) {
         }
     }
     EXPECT_TRUE(offersForce);
+}
+
+// The scenario this whole check exists for: a PR merged on the remote (here,
+// a second clone standing in for "someone else merged it on GitHub", which
+// also deletes the source branch the way GitHub's "delete branch" button
+// does) while this repository's own `main` never saw that merge directly,
+// only through a later `fetch --prune`. `-d` cannot see past that -- it only
+// checks reachability from local refs and from the branch's own upstream,
+// and pruning is what removes that upstream from the local view, which is
+// what actually makes `-d` fail here (verified against real git: as long as
+// origin/feature still exists locally, unmoved, `-d` treats the branch as
+// "merged into its own unchanged upstream" and succeeds even though HEAD
+// never merged it -- pruning is required to reproduce the user-reported
+// failure at all). The remote-ref probe can see past that failure, and must
+// say so rather than defaulting to the destructive-sounding fallback.
+TEST_F(RealRepoTest, ReportsSafeToDeleteWhenAnotherClonePushedTheMergeAndPrunedTheSource) {
+    const std::filesystem::path remote = repo_.string() + "-bare-remote-safe";
+    std::filesystem::remove_all(remote);
+    std::filesystem::create_directories(remote);
+    GitCommand initBare(remote, {"init", "--quiet", "--bare", "--initial-branch=main"});
+    initBare.timeout = std::chrono::seconds(30);
+    ASSERT_TRUE(runner_->run(initBare, CancellationToken{}));
+    extraDirs_.push_back(remote);
+
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"remote", "add", "origin", remote.string()}));
+    ASSERT_TRUE(run({"push", "--quiet", "-u", "origin", "main"}));
+
+    ASSERT_TRUE(run({"switch", "--quiet", "-c", "feature"}));
+    commitFile("b.txt", "only on feature\n", "feature work");
+    ASSERT_TRUE(run({"push", "--quiet", "-u", "origin", "feature"}));
+    ASSERT_TRUE(run({"switch", "--quiet", "main"}));
+
+    // A second, independent clone merges, pushes, and deletes the source
+    // branch on the remote -- repo_'s local `main` never sees that merge
+    // except through a later `fetch`.
+    const std::filesystem::path integrator = repo_.string() + "-integrator";
+    std::filesystem::remove_all(integrator);
+    extraDirs_.push_back(integrator);
+    GitCommand clone(repo_.parent_path(),
+                     {"clone", "--quiet", remote.string(), integrator.string()});
+    clone.timeout = std::chrono::seconds(30);
+    ASSERT_TRUE(runner_->run(clone, CancellationToken{}));
+
+    auto runIntegrator = [&](std::vector<std::string> args) {
+        GitCommand command(integrator, std::move(args));
+        command.timeout = std::chrono::seconds(30);
+        return runner_->run(command, CancellationToken{});
+    };
+    ASSERT_TRUE(runIntegrator({"config", "user.email", "test@example.invalid"}));
+    ASSERT_TRUE(runIntegrator({"config", "user.name", "Test"}));
+    ASSERT_TRUE(runIntegrator({"config", "commit.gpgsign", "false"}));
+    ASSERT_TRUE(runIntegrator({"fetch", "--quiet", "origin", "feature"}));
+    ASSERT_TRUE(
+        runIntegrator({"merge", "--quiet", "--no-ff", "-m", "Merge feature", "origin/feature"}));
+    ASSERT_TRUE(runIntegrator({"push", "--quiet", "origin", "main"}));
+    ASSERT_TRUE(runIntegrator({"push", "--quiet", "origin", "--delete", "feature"}));
+
+    // Bring repo_'s remote-tracking view up to date without touching its
+    // local `main` -- exactly what "merged and its branch auto-deleted on
+    // GitHub, haven't fetched yet" looks like. `--prune` is what removes the
+    // local origin/feature ref this branch's `-d` check would otherwise be
+    // satisfied by.
+    ASSERT_TRUE(run({"fetch", "--quiet", "--prune", "origin"}));
+
+    OperationRunner operations(*runner_, paths_);
+    DeleteBranchRequest remove;
+    remove.names = {"feature"};
+
+    OperationOutcome outcome;
+    operations.submit(makeDeleteBranchOperation(remove),
+                      [&outcome](OperationOutcome result) { outcome = std::move(result); });
+    operations.drain();
+
+    EXPECT_FALSE(outcome.succeeded);
+    EXPECT_NE(outcome.summary.find("origin/main"), std::string::npos);
+    EXPECT_NE(outcome.summary.find("not lose"), std::string::npos);
 }
 
 TEST_F(RealRepoTest, CancelsAReadOnlyWalkPromptly) {


### PR DESCRIPTION
## Summary
- 修掉刪除分支被拒時連跳兩個對話框的問題（一次性回饋監聽的所有權計數器 `armedFeedbackHandlers_`），並補上切換／關閉 repo 時的計數器重置，避免計數卡住導致往後錯誤被永久吞掉。
- 未合併時的訊息不再是原始的 `Git reported an error`：先比對遠端 tracking ref，若已在遠端合併（例如 PR 用 merge commit 進 main、但本機還沒 fetch），改為「不會遺失東西」的提醒（Warning）而非破壞性錯誤（Critical）；找不到時只建議先 Fetch，不宣稱確定未合併。
- 修正「Delete anyway」選項說明與摘要互相矛盾的問題：探查判定已在遠端合併時，兩處文字現在使用同一句話（含具體遠端名稱），不會一邊說「不會遺失東西」一邊又警告「只能透過 reflog 找回」。
- 多選分支刪除時的訊息改為複數。

## Test plan
- [x] `cmake --build --preset dev` 全綠
- [x] `ctest --preset dev --output-on-failure` 334/334 通過
- [x] `./scripts/format-check.sh` 乾淨
- [ ] 端對端手動驗證（尚未執行，需要人工操作 GUI）：
  - [ ] 建一個真的未合併分支，從側邊欄 BRANCHES 右鍵刪除 → 應只出現一個 Warning 對話框
  - [ ] 建一個已在 `origin/main` 合併但本機落後的分支 → 應顯示「已在遠端合併、可安全刪除」的提醒
  - [ ] 按 Delete anyway → 確認真的刪除成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uGrkj289en326HT1g6DXz