### PR TITLE
feat(m8): instrumentation for repo-switch stall and busy-spinner leak (#23, #24)

### DIFF
--- a/docs/reports/windows-repo-switch-deadlock.md
+++ b/docs/reports/windows-repo-switch-deadlock.md
@@ -1,0 +1,63 @@
+# Capturing a repo-switch deadlock log (Windows, issue #23)
+
+## Scope
+
+This is instrumentation, not a fix. It has not reproduced on macOS, so the
+only thing this round can produce is evidence: a log that shows whether a
+stuck session is stuck *inside* `ThreadPool::cancelQueuedAndDrain()` or
+somewhere else. See [#23](https://github.com/Staler2019/git-branch-manager/issues/23)
+for the suspected code path (`MainWindow::closeRepository()` calling
+`readPool_.cancelQueuedAndDrain()` on the UI thread with no deadline).
+
+## Reproducing and capturing the log
+
+1. Launch the app with `GBM_LOG_LEVEL=debug` set in the environment. The
+   default level is `Info`, which filters out the per-switch diagnostics
+   below -- they are too frequent (they fire on every repository close) to
+   leave visible otherwise.
+
+   ```
+   set GBM_LOG_LEVEL=debug
+   git-branch-manager.exe
+   ```
+
+2. Open the Operation Log panel (`Ctrl+L`) so it's visible while you work --
+   it receives every log message regardless of level, not just git command
+   records.
+3. Switch between repositories repeatedly (the reports describe several
+   switches before the window goes white and stops repainting).
+4. When the window freezes, wait a few seconds, then use the panel's
+   **Copy all** button if the UI is still responsive enough to click it. If
+   the UI is fully unresponsive, the log content up to the freeze is still
+   what's needed -- a screenshot of the panel, or the log lines from a
+   previous responsive moment, are enough.
+
+## What to look for in the captured log
+
+Two lines matter:
+
+- `<pool name> pool cancelQueuedAndDrain: discarded N queued task(s), M still
+  running` -- written by `ThreadPool::cancelQueuedAndDrain()` every time it's
+  called, at Debug level.
+- `closeRepository: cancelQueuedAndDrain took <ms>ms (queueDepth=<n>,
+  threadCount=<n>)` -- written by `MainWindow::closeRepository()` at Warn
+  level (so it appears even without `GBM_LOG_LEVEL=debug`) only when the
+  drain took at least 2 seconds.
+
+If the freeze coincides with a `closeRepository: cancelQueuedAndDrain took
+...` warning, the stall is confirmed to be inside the drain -- most likely a
+single already-in-flight read whose pipe read has no deadline (see
+`ThreadPool::cancelQueuedAndDrain`'s doc comment in
+`src/core/workers/ThreadPool.h`). If the window goes white with no such
+warning anywhere near the freeze, the stall is somewhere else, and the next
+issue should look elsewhere in `closeRepository()` or the UI thread.
+
+## Attaching the report
+
+Please attach to the GitHub issue:
+
+- The captured log lines (both kinds above, from the run that froze).
+- Windows version and whether the repository involved is local, on a
+  network share, or backed by an antivirus/EDR agent that hooks file I/O
+  (a common source of unbounded child-process reads).
+- Roughly how many repository switches preceded the freeze.

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -198,6 +198,24 @@ RepositorySession::~RepositorySession() {
     if (catFile_) {
         catFile_->stop();
     }
+
+    // busyCount_ still above zero here means some setBusy(true) never got its
+    // matching setBusy(false) -- exactly the spinner-never-stops shape from
+    // issue #24. MainWindow::closeRepository() cancels and drains readPool_
+    // before this destructor runs, so by now every legitimately in-flight
+    // read has already had its chance to call setBusy(false); what's left in
+    // outstandingBusySites_ is the actual leak, worth a log even though this
+    // session (and its indicator) is about to go away either way.
+    if (busyCount_ > 0) {
+        std::string sites;
+        for (const std::string& site : outstandingBusySites_) {
+            sites += "\n  " + site;
+        }
+        logMessage(LogLevel::Debug,
+                   "RepositorySession destroyed with busyCount_=" +
+                       std::to_string(busyCount_) + ", never-balanced setBusy(true) call site(s):" +
+                       sites);
+    }
 }
 
 QString RepositorySession::displayName() const {
@@ -208,7 +226,7 @@ RepoState RepositorySession::state() const {
     return RepoState::read(paths_);
 }
 
-void RepositorySession::setBusy(bool busy) {
+void RepositorySession::setBusy(bool busy, std::source_location loc) {
     // Reference-counted: several reads may be in flight, and the indicator should
     // only clear when the last one finishes.
     const bool wasBusy = busyCount_ > 0;
@@ -216,10 +234,28 @@ void RepositorySession::setBusy(bool busy) {
     if (busyCount_ < 0) {
         busyCount_ = 0;
     }
+    if (busy) {
+        outstandingBusySites_.push_back(std::string(loc.file_name()) + ":" +
+                                         std::to_string(loc.line()) + " (" +
+                                         loc.function_name() + ")");
+    } else if (!outstandingBusySites_.empty()) {
+        outstandingBusySites_.erase(outstandingBusySites_.begin());
+    }
     const bool isBusy = busyCount_ > 0;
     if (isBusy != wasBusy) {
         emit busyChanged(isBusy);
     }
+}
+
+std::vector<std::string> RepositorySession::debugOutstandingBusySites() const {
+    return outstandingBusySites_;
+}
+
+BusyToken RepositorySession::makeBusyToken(std::source_location loc) {
+    setBusy(true, loc);
+    return BusyToken([this] {
+        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
+    });
 }
 
 void RepositorySession::refreshHistory(HistoryQuery query) {
@@ -816,11 +852,19 @@ void RepositorySession::requestCommitMetadata(std::vector<ObjectId> oids) {
 
 void RepositorySession::requestCommitDetails(const ObjectId& commit) {
     const CancellationToken token = readCancel_.token();
-    setBusy(true);
+    BusyToken busy = makeBusyToken();
 
-    readPool_.postFront([this, commit, token] {
+    // busy is moved into a body-local (not left as a captured closure member)
+    // so it releases while this lambda is still running -- i.e. before
+    // ThreadPool::workerLoop() decrements activeTasks_ and cancelQueuedAndDrain()
+    // can conclude the task is done. A release deferred past that point would
+    // still fire eventually (when the closure itself is destroyed), but by
+    // then MainWindow::closeRepository() may already have destroyed this
+    // session, and the release callback's QMetaObject::invokeMethod(this, ...)
+    // needs `this` to still be alive.
+    readPool_.postFront([this, commit, token, busy = std::move(busy)]() mutable {
+        BusyToken busyGuard = std::move(busy);
         if (token.isCancelled()) {
-            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
             return;
         }
 
@@ -844,8 +888,6 @@ void RepositorySession::requestCommitDetails(const ObjectId& commit) {
             QMetaObject::invokeMethod(
                 this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
         }
-
-        QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
     });
 }
 
@@ -1119,81 +1161,75 @@ void RepositorySession::requestConflictSides(const std::string& path,
                                              const std::string& oursBlob,
                                              const std::string& theirsBlob) {
     const CancellationToken token = readCancel_.token();
-    setBusy(true);
+    BusyToken busy = makeBusyToken();
 
-    readPool_.postFront([this, path, ancestorBlob, oursBlob, theirsBlob, token] {
-        if (token.isCancelled()) {
-            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
-            return;
-        }
-        if (auto started = catFile_->start(); !started) {
-            GitError error = std::move(started).error();
+    // See requestCommitDetails's comment on why busy is moved into a
+    // body-local rather than left as a captured closure member.
+    readPool_.postFront(
+        [this, path, ancestorBlob, oursBlob, theirsBlob, token, busy = std::move(busy)]() mutable {
+            BusyToken busyGuard = std::move(busy);
+            if (token.isCancelled()) {
+                return;
+            }
+            if (auto started = catFile_->start(); !started) {
+                GitError error = std::move(started).error();
+                QMetaObject::invokeMethod(
+                    this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+                return;
+            }
+
+            // Best-effort: a stage that fails to read (or does not exist) shows as
+            // empty rather than failing the whole request, so the two sides that
+            // did read are still shown. Checked between the three reads (not just
+            // once above): a cancellation arriving while the first blob is being
+            // fetched should stop the remaining two from starting.
+            auto readOrEmpty = [this, token](const std::string& blob) {
+                if (blob.empty() || token.isCancelled()) {
+                    return std::string();
+                }
+                auto object = catFile_->read(blob, token);
+                return object ? object->content : std::string();
+            };
+            const std::string ancestor = readOrEmpty(ancestorBlob);
+            const std::string ours = readOrEmpty(oursBlob);
+            const std::string theirs = readOrEmpty(theirsBlob);
+            // Design A5: computed here, on the still-undecoded std::string --
+            // detectTextTraits() must see the original bytes (see TextTraits.h's
+            // own doc comment on why this cannot happen after the
+            // QString::fromStdString() conversions below).
+            const TextTraits ancestorTraits = detectTextTraits(ancestor);
+            const TextTraits oursTraits = detectTextTraits(ours);
+            const TextTraits theirsTraits = detectTextTraits(theirs);
+
+            const QString qpath = QString::fromStdString(path);
             QMetaObject::invokeMethod(
                 this,
-                [this, error] {
-                    setBusy(false);
-                    emit errorOccurred(error);
+                [this, qpath, ancestor, ours, theirs, ancestorTraits, oursTraits, theirsTraits] {
+                    emit conflictSidesReady(qpath,
+                                            QString::fromStdString(ancestor),
+                                            QString::fromStdString(ours),
+                                            QString::fromStdString(theirs));
+                    emit conflictSideTraitsReady(qpath, ancestorTraits, oursTraits, theirsTraits);
                 },
                 Qt::QueuedConnection);
-            return;
-        }
-
-        // Best-effort: a stage that fails to read (or does not exist) shows as
-        // empty rather than failing the whole request, so the two sides that
-        // did read are still shown. Checked between the three reads (not just
-        // once above): a cancellation arriving while the first blob is being
-        // fetched should stop the remaining two from starting.
-        auto readOrEmpty = [this, token](const std::string& blob) {
-            if (blob.empty() || token.isCancelled()) {
-                return std::string();
-            }
-            auto object = catFile_->read(blob, token);
-            return object ? object->content : std::string();
-        };
-        const std::string ancestor = readOrEmpty(ancestorBlob);
-        const std::string ours = readOrEmpty(oursBlob);
-        const std::string theirs = readOrEmpty(theirsBlob);
-        // Design A5: computed here, on the still-undecoded std::string --
-        // detectTextTraits() must see the original bytes (see TextTraits.h's
-        // own doc comment on why this cannot happen after the
-        // QString::fromStdString() conversions below).
-        const TextTraits ancestorTraits = detectTextTraits(ancestor);
-        const TextTraits oursTraits = detectTextTraits(ours);
-        const TextTraits theirsTraits = detectTextTraits(theirs);
-
-        const QString qpath = QString::fromStdString(path);
-        QMetaObject::invokeMethod(
-            this,
-            [this, qpath, ancestor, ours, theirs, ancestorTraits, oursTraits, theirsTraits] {
-                setBusy(false);
-                emit conflictSidesReady(qpath,
-                                        QString::fromStdString(ancestor),
-                                        QString::fromStdString(ours),
-                                        QString::fromStdString(theirs));
-                emit conflictSideTraitsReady(qpath, ancestorTraits, oursTraits, theirsTraits);
-            },
-            Qt::QueuedConnection);
-    });
+        });
 }
 
 void RepositorySession::requestFileContent(const std::string& path, const std::string& revision) {
     const CancellationToken token = readCancel_.token();
-    setBusy(true);
+    BusyToken busy = makeBusyToken();
 
-    readPool_.postFront([this, path, revision, token] {
+    // See requestCommitDetails's comment on why busy is moved into a
+    // body-local rather than left as a captured closure member.
+    readPool_.postFront([this, path, revision, token, busy = std::move(busy)]() mutable {
+        BusyToken busyGuard = std::move(busy);
         if (token.isCancelled()) {
-            QMetaObject::invokeMethod(this, [this] { setBusy(false); }, Qt::QueuedConnection);
             return;
         }
         if (auto started = catFile_->start(); !started) {
             GitError error = std::move(started).error();
             QMetaObject::invokeMethod(
-                this,
-                [this, error] {
-                    setBusy(false);
-                    emit errorOccurred(error);
-                },
-                Qt::QueuedConnection);
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
             return;
         }
 
@@ -1212,7 +1248,6 @@ void RepositorySession::requestFileContent(const std::string& path, const std::s
         QMetaObject::invokeMethod(
             this,
             [this, qpath, qrevision, content, exists] {
-                setBusy(false);
                 emit fileContentReady(qpath, qrevision, QString::fromStdString(content), exists);
             },
             Qt::QueuedConnection);

--- a/src/app/bridge/RepositorySession.cpp
+++ b/src/app/bridge/RepositorySession.cpp
@@ -212,9 +212,8 @@ RepositorySession::~RepositorySession() {
             sites += "\n  " + site;
         }
         logMessage(LogLevel::Debug,
-                   "RepositorySession destroyed with busyCount_=" +
-                       std::to_string(busyCount_) + ", never-balanced setBusy(true) call site(s):" +
-                       sites);
+                   "RepositorySession destroyed with busyCount_=" + std::to_string(busyCount_) +
+                       ", never-balanced setBusy(true) call site(s):" + sites);
     }
 }
 
@@ -236,8 +235,8 @@ void RepositorySession::setBusy(bool busy, std::source_location loc) {
     }
     if (busy) {
         outstandingBusySites_.push_back(std::string(loc.file_name()) + ":" +
-                                         std::to_string(loc.line()) + " (" +
-                                         loc.function_name() + ")");
+                                        std::to_string(loc.line()) + " (" + loc.function_name() +
+                                        ")");
     } else if (!outstandingBusySites_.empty()) {
         outstandingBusySites_.erase(outstandingBusySites_.begin());
     }
@@ -852,18 +851,27 @@ void RepositorySession::requestCommitMetadata(std::vector<ObjectId> oids) {
 
 void RepositorySession::requestCommitDetails(const ObjectId& commit) {
     const CancellationToken token = readCancel_.token();
-    BusyToken busy = makeBusyToken();
+    // shared_ptr, not BusyToken by value: ThreadPool::postFront takes a
+    // std::function<void()>, which requires its target to be
+    // copy-constructible even though it is only ever invoked once -- a
+    // lambda that captured the move-only BusyToken directly would not
+    // compile (static_assert in <functional>). The shared_ptr is copyable;
+    // the BusyToken it owns is moved out into a body-local further down so
+    // it still releases while this lambda is running rather than whenever
+    // the last shared_ptr reference happens to be destroyed.
+    auto busy = std::make_shared<BusyToken>(makeBusyToken());
 
-    // busy is moved into a body-local (not left as a captured closure member)
-    // so it releases while this lambda is still running -- i.e. before
-    // ThreadPool::workerLoop() decrements activeTasks_ and cancelQueuedAndDrain()
-    // can conclude the task is done. A release deferred past that point would
-    // still fire eventually (when the closure itself is destroyed), but by
-    // then MainWindow::closeRepository() may already have destroyed this
+    // busy's BusyToken is moved into a body-local (not left inside the
+    // captured shared_ptr) so it releases while this lambda is still
+    // running -- i.e. before ThreadPool::workerLoop() decrements
+    // activeTasks_ and cancelQueuedAndDrain() can conclude the task is done.
+    // A release deferred past that point would still fire eventually (when
+    // the closure itself is destroyed), but by then
+    // MainWindow::closeRepository() may already have destroyed this
     // session, and the release callback's QMetaObject::invokeMethod(this, ...)
     // needs `this` to still be alive.
-    readPool_.postFront([this, commit, token, busy = std::move(busy)]() mutable {
-        BusyToken busyGuard = std::move(busy);
+    readPool_.postFront([this, commit, token, busy] {
+        BusyToken busyGuard = std::move(*busy);
         if (token.isCancelled()) {
             return;
         }
@@ -1161,68 +1169,67 @@ void RepositorySession::requestConflictSides(const std::string& path,
                                              const std::string& oursBlob,
                                              const std::string& theirsBlob) {
     const CancellationToken token = readCancel_.token();
-    BusyToken busy = makeBusyToken();
+    // See requestCommitDetails's comment on why this is a shared_ptr<BusyToken>
+    // rather than a BusyToken captured by value.
+    auto busy = std::make_shared<BusyToken>(makeBusyToken());
 
-    // See requestCommitDetails's comment on why busy is moved into a
-    // body-local rather than left as a captured closure member.
-    readPool_.postFront(
-        [this, path, ancestorBlob, oursBlob, theirsBlob, token, busy = std::move(busy)]() mutable {
-            BusyToken busyGuard = std::move(busy);
-            if (token.isCancelled()) {
-                return;
-            }
-            if (auto started = catFile_->start(); !started) {
-                GitError error = std::move(started).error();
-                QMetaObject::invokeMethod(
-                    this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
-                return;
-            }
-
-            // Best-effort: a stage that fails to read (or does not exist) shows as
-            // empty rather than failing the whole request, so the two sides that
-            // did read are still shown. Checked between the three reads (not just
-            // once above): a cancellation arriving while the first blob is being
-            // fetched should stop the remaining two from starting.
-            auto readOrEmpty = [this, token](const std::string& blob) {
-                if (blob.empty() || token.isCancelled()) {
-                    return std::string();
-                }
-                auto object = catFile_->read(blob, token);
-                return object ? object->content : std::string();
-            };
-            const std::string ancestor = readOrEmpty(ancestorBlob);
-            const std::string ours = readOrEmpty(oursBlob);
-            const std::string theirs = readOrEmpty(theirsBlob);
-            // Design A5: computed here, on the still-undecoded std::string --
-            // detectTextTraits() must see the original bytes (see TextTraits.h's
-            // own doc comment on why this cannot happen after the
-            // QString::fromStdString() conversions below).
-            const TextTraits ancestorTraits = detectTextTraits(ancestor);
-            const TextTraits oursTraits = detectTextTraits(ours);
-            const TextTraits theirsTraits = detectTextTraits(theirs);
-
-            const QString qpath = QString::fromStdString(path);
+    readPool_.postFront([this, path, ancestorBlob, oursBlob, theirsBlob, token, busy] {
+        BusyToken busyGuard = std::move(*busy);
+        if (token.isCancelled()) {
+            return;
+        }
+        if (auto started = catFile_->start(); !started) {
+            GitError error = std::move(started).error();
             QMetaObject::invokeMethod(
-                this,
-                [this, qpath, ancestor, ours, theirs, ancestorTraits, oursTraits, theirsTraits] {
-                    emit conflictSidesReady(qpath,
-                                            QString::fromStdString(ancestor),
-                                            QString::fromStdString(ours),
-                                            QString::fromStdString(theirs));
-                    emit conflictSideTraitsReady(qpath, ancestorTraits, oursTraits, theirsTraits);
-                },
-                Qt::QueuedConnection);
-        });
+                this, [this, error] { emit errorOccurred(error); }, Qt::QueuedConnection);
+            return;
+        }
+
+        // Best-effort: a stage that fails to read (or does not exist) shows as
+        // empty rather than failing the whole request, so the two sides that
+        // did read are still shown. Checked between the three reads (not just
+        // once above): a cancellation arriving while the first blob is being
+        // fetched should stop the remaining two from starting.
+        auto readOrEmpty = [this, token](const std::string& blob) {
+            if (blob.empty() || token.isCancelled()) {
+                return std::string();
+            }
+            auto object = catFile_->read(blob, token);
+            return object ? object->content : std::string();
+        };
+        const std::string ancestor = readOrEmpty(ancestorBlob);
+        const std::string ours = readOrEmpty(oursBlob);
+        const std::string theirs = readOrEmpty(theirsBlob);
+        // Design A5: computed here, on the still-undecoded std::string --
+        // detectTextTraits() must see the original bytes (see TextTraits.h's
+        // own doc comment on why this cannot happen after the
+        // QString::fromStdString() conversions below).
+        const TextTraits ancestorTraits = detectTextTraits(ancestor);
+        const TextTraits oursTraits = detectTextTraits(ours);
+        const TextTraits theirsTraits = detectTextTraits(theirs);
+
+        const QString qpath = QString::fromStdString(path);
+        QMetaObject::invokeMethod(
+            this,
+            [this, qpath, ancestor, ours, theirs, ancestorTraits, oursTraits, theirsTraits] {
+                emit conflictSidesReady(qpath,
+                                        QString::fromStdString(ancestor),
+                                        QString::fromStdString(ours),
+                                        QString::fromStdString(theirs));
+                emit conflictSideTraitsReady(qpath, ancestorTraits, oursTraits, theirsTraits);
+            },
+            Qt::QueuedConnection);
+    });
 }
 
 void RepositorySession::requestFileContent(const std::string& path, const std::string& revision) {
     const CancellationToken token = readCancel_.token();
-    BusyToken busy = makeBusyToken();
+    // See requestCommitDetails's comment on why this is a shared_ptr<BusyToken>
+    // rather than a BusyToken captured by value.
+    auto busy = std::make_shared<BusyToken>(makeBusyToken());
 
-    // See requestCommitDetails's comment on why busy is moved into a
-    // body-local rather than left as a captured closure member.
-    readPool_.postFront([this, path, revision, token, busy = std::move(busy)]() mutable {
-        BusyToken busyGuard = std::move(busy);
+    readPool_.postFront([this, path, revision, token, busy] {
+        BusyToken busyGuard = std::move(*busy);
         if (token.isCancelled()) {
             return;
         }

--- a/src/app/bridge/RepositorySession.h
+++ b/src/app/bridge/RepositorySession.h
@@ -38,6 +38,7 @@
 #include "core/git/ops/UndoOps.h"
 #include "core/git/ops/WorktreeOps.h"
 #include "core/graph/GraphSnapshot.h"
+#include "core/workers/BusyToken.h"
 #include "core/workers/RefreshCoalescer.h"
 #include "core/workers/StartupReadGate.h"
 #include "core/workers/ThreadPool.h"
@@ -50,6 +51,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <source_location>
 #include <vector>
 
 class QTimer;
@@ -595,8 +597,30 @@ signals:
     void lineHistoryReady(std::vector<LineHistoryChunk> chunks);
     void reflogReady(std::vector<ReflogEntry> entries);
 
+public:
+    /// Source locations of outstanding (not yet balanced by a setBusy(false))
+    /// setBusy(true) calls, formatted "file:line (function)", oldest first.
+    /// Always empty once busyCount_ returns to 0. Exists so a session that
+    /// never stops looking busy (issue #24 -- graph view's spinner that never
+    /// stops) can be asked which call site is holding it open, instead of
+    /// having to add temporary logging to find out.
+    std::vector<std::string> debugOutstandingBusySites() const;
+
 private:
-    void setBusy(bool busy);
+    /// `loc` defaults to the caller's own location, so none of the ~30
+    /// existing call sites need to change -- it exists purely to feed
+    /// outstandingBusySites_. See debugOutstandingBusySites().
+    void setBusy(bool busy, std::source_location loc = std::source_location::current());
+
+    /// Returns a token that has already done the setBusy(true) this call
+    /// represents; destroying (or resetting) the token does the matching
+    /// setBusy(false), hopping back to the UI thread first if needed since
+    /// tokens are typically destroyed from a readPool_ worker. Prefer this
+    /// over a manual setBusy(true)/setBusy(false) pair for any new call site:
+    /// letting the token's destructor run on every return path (including
+    /// ones added later) is what makes forgetting the decrement impossible.
+    [[nodiscard]] BusyToken makeBusyToken(
+        std::source_location loc = std::source_location::current());
     /// Runs a staging/commit Operation and, on success, refreshes whatever it
     /// could have changed. Shared by stageFiles/unstageFiles/applyPatch/commitChanges
     /// so each stays a one-line call.
@@ -796,6 +820,13 @@ private:
     static constexpr std::chrono::minutes kAutoFetchMinInterval{5};
 
     int busyCount_ = 0;
+    /// One entry per outstanding setBusy(true), oldest first; a setBusy(false)
+    /// pops the oldest entry (an approximation -- true/false calls do not
+    /// carry a shared identity to pair exactly, but since legitimately
+    /// finished requests always eventually pop their own entry, whatever is
+    /// left once the session is otherwise idle is genuinely unpaired). See
+    /// debugOutstandingBusySites().
+    std::vector<std::string> outstandingBusySites_;
 };
 
 }  // namespace gbm

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -159,7 +159,27 @@ int main(int argc, char** argv) {
     // the saved choice instead of flashing the default theme first.
     gbm::ThemeManager::apply(gbm::ThemeManager::loadSetting());
 
-    gbm::Log::instance().setLevel(gbm::LogLevel::Info);
+    // GBM_LOG_LEVEL=trace|debug|info|warn|error: lowers the sink threshold
+    // below the Info default. Needed to capture the Debug-level
+    // ThreadPool::cancelQueuedAndDrain diagnostics (issue #23) when
+    // reproducing the Windows repo-switch stall -- those are too frequent
+    // (fire on every close/switch) to leave visible at the default level.
+    gbm::LogLevel logLevel = gbm::LogLevel::Info;
+    if (const char* levelEnv = std::getenv("GBM_LOG_LEVEL"); levelEnv != nullptr) {
+        const std::string_view level(levelEnv);
+        if (level == "trace") {
+            logLevel = gbm::LogLevel::Trace;
+        } else if (level == "debug") {
+            logLevel = gbm::LogLevel::Debug;
+        } else if (level == "info") {
+            logLevel = gbm::LogLevel::Info;
+        } else if (level == "warn") {
+            logLevel = gbm::LogLevel::Warn;
+        } else if (level == "error") {
+            logLevel = gbm::LogLevel::Error;
+        }
+    }
+    gbm::Log::instance().setLevel(logLevel);
 
     // GBM_TIMING=1: writes the `gbm-timing walk ...` line RepositorySession
     // logs per history refresh straight to stderr, so a headless run (how

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -1450,7 +1450,26 @@ void MainWindow::closeRepository() {
     // already in flight when cancellation fires still blocks until the child
     // answers it. See ThreadPool::cancelQueuedAndDrain's doc for the same
     // caveat spelled out in full.
+    //
+    // This has been observed to hang the UI thread on Windows after several
+    // repository switches (issue #23), but not reproduced on macOS -- so this
+    // measures rather than changes behavior: log a warning if the drain takes
+    // longer than kDrainWarnThresholdMs, with the queue depth and thread count
+    // at the moment the drain started, so a report from a stuck session can
+    // say whether it is stuck *in* the drain or somewhere else.
+    const std::size_t queueDepthBeforeDrain = readPool_.queueDepth();
+    const std::size_t threadCountAtDrain = readPool_.threadCount();
+    QElapsedTimer drainTimer;
+    drainTimer.start();
     readPool_.cancelQueuedAndDrain();
+    constexpr qint64 kDrainWarnThresholdMs = 2000;
+    const qint64 drainMs = drainTimer.elapsed();
+    if (drainMs >= kDrainWarnThresholdMs) {
+        logMessage(LogLevel::Warn,
+                   "closeRepository: cancelQueuedAndDrain took " + std::to_string(drainMs) +
+                       "ms (queueDepth=" + std::to_string(queueDepthBeforeDrain) +
+                       ", threadCount=" + std::to_string(threadCountAtDrain) + ")");
+    }
     // commitModel_->setSession(nullptr) resets the model, which fires
     // modelAboutToBeReset and collapses any inline expansion -- see the
     // connection in buildUi() -- but the closing-repository case is worth

--- a/src/app/views/MainWindow.cpp
+++ b/src/app/views/MainWindow.cpp
@@ -635,12 +635,38 @@ void MainWindow::buildUi() {
     setupPersistentSplitter(rightSplitter_, QStringLiteral("right"));
     setupPersistentSplitter(detailSplitter_, QStringLiteral("detail"));
 
-    repoLayout->addWidget(outerSplitter, 1);
-
     logView_ = new OperationLogView(repoPage);
-    logView_->setMaximumHeight(160);
+    // A floor, not a ceiling: the panel used to carry a hard
+    // setMaximumHeight(160) with no splitter handle, so it could never be
+    // made bigger than a few lines -- exactly what made a long stderr dump
+    // unreadable without scrolling one line at a time.
+    logView_->setMinimumHeight(80);
     logView_->setVisible(false);
-    repoLayout->addWidget(logView_);
+
+    // Vertical splitter so the operation log panel gets a drag handle like
+    // every other pane in this window, instead of the fixed-height strip it
+    // was before.
+    auto* logSplitter = new QSplitter(Qt::Vertical, repoPage);
+    logSplitter_ = logSplitter;
+    logSplitter->setHandleWidth(6);
+    logSplitter->setChildrenCollapsible(false);
+    logSplitter->addWidget(outerSplitter);
+    logSplitter->addWidget(logView_);
+    // The log panel keeps roughly its own size on window resize rather than
+    // growing with the rest of the window -- stretch factor 0 vs. the main
+    // content's 1, same relationship outerSplitter uses between the sidebar
+    // and everything else below.
+    logSplitter->setStretchFactor(0, 1);
+    logSplitter->setStretchFactor(1, 0);
+    // Deferred for the same reason outerSplitter's own default-sizing lambda
+    // is: setSizes() before the splitter has a real geometry gets recomputed
+    // from the stretch factors on the first resize instead of being honored.
+    // Scheduled before setupPersistentSplitter() below so a saved size wins
+    // over this default instead of being clobbered by it.
+    QTimer::singleShot(0, logSplitter, [logSplitter] { logSplitter->setSizes({800, 220}); });
+    setupPersistentSplitter(logSplitter_, QStringLiteral("log"));
+
+    repoLayout->addWidget(logSplitter, 1);
 
     stack_->addWidget(repoPage);
 

--- a/src/app/views/MainWindow.h
+++ b/src/app/views/MainWindow.h
@@ -334,6 +334,7 @@ private:
     QSplitter* outerSplitter_ = nullptr;
     QSplitter* rightSplitter_ = nullptr;
     QSplitter* detailSplitter_ = nullptr;
+    QSplitter* logSplitter_ = nullptr;
 
     /// The row currently showing its inline expansion panel, or -1 if none.
     /// Invariant: at most one row is ever expanded, it is always the selected

--- a/src/core/workers/BusyToken.h
+++ b/src/core/workers/BusyToken.h
@@ -22,6 +22,7 @@ namespace gbm {
 class BusyToken {
 public:
     BusyToken() = default;
+
     explicit BusyToken(std::function<void()> release) : release_(std::move(release)) {}
 
     BusyToken(const BusyToken&) = delete;

--- a/src/core/workers/BusyToken.h
+++ b/src/core/workers/BusyToken.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <functional>
+#include <utility>
+
+namespace gbm {
+
+/// RAII guard for one unit of a reference-counted busy/spinner indicator.
+/// Constructed with the callback that undoes whatever `setBusy(true)` (or
+/// equivalent) the caller already did; that callback fires exactly once --
+/// on an explicit reset(), on destruction, or (if neither happens first)
+/// never, but never twice and never zero times for a token that was ever
+/// non-empty. Move-only: a token cannot be duplicated into two places that
+/// would each try to release it, so "this one busy unit" always has exactly
+/// one owner.
+///
+/// The point is to make the early-return bugs that manual setBusy(true)/
+/// setBusy(false) pairing invites structurally impossible: a function that
+/// takes a BusyToken by value (or captures one into a lambda) releases it
+/// automatically on every return path, including ones added later by
+/// someone who never thinks about the busy indicator at all.
+class BusyToken {
+public:
+    BusyToken() = default;
+    explicit BusyToken(std::function<void()> release) : release_(std::move(release)) {}
+
+    BusyToken(const BusyToken&) = delete;
+    BusyToken& operator=(const BusyToken&) = delete;
+
+    BusyToken(BusyToken&& other) noexcept : release_(std::move(other.release_)) {
+        other.release_ = nullptr;
+    }
+
+    BusyToken& operator=(BusyToken&& other) noexcept {
+        if (this != &other) {
+            fire();
+            release_ = std::move(other.release_);
+            other.release_ = nullptr;
+        }
+        return *this;
+    }
+
+    ~BusyToken() { fire(); }
+
+    /// True if this token still owns a release callback (i.e. destroying it
+    /// now would actually do something).
+    explicit operator bool() const noexcept { return static_cast<bool>(release_); }
+
+    /// Releases early, without waiting for destruction. Safe to call at most
+    /// once's worth of effect even if invoked from a moved-from or
+    /// already-fired token -- both leave release_ null.
+    void reset() { fire(); }
+
+private:
+    void fire() {
+        if (release_) {
+            std::function<void()> release = std::move(release_);
+            release_ = nullptr;
+            release();
+        }
+    }
+
+    std::function<void()> release_;
+};
+
+}  // namespace gbm

--- a/src/core/workers/ThreadPool.cpp
+++ b/src/core/workers/ThreadPool.cpp
@@ -61,7 +61,12 @@ void ThreadPool::drain() {
 
 void ThreadPool::cancelQueuedAndDrain() {
     std::unique_lock<std::mutex> lock(mutex_);
+    const std::size_t discarded = tasks_.size();
+    const std::size_t stillRunning = activeTasks_;
     tasks_.clear();
+    logMessage(LogLevel::Debug, name_ + " pool cancelQueuedAndDrain: discarded " +
+                                     std::to_string(discarded) + " queued task(s), " +
+                                     std::to_string(stillRunning) + " still running");
     idle_.wait(lock, [this] { return activeTasks_ == 0; });
 }
 

--- a/src/core/workers/ThreadPool.cpp
+++ b/src/core/workers/ThreadPool.cpp
@@ -64,9 +64,9 @@ void ThreadPool::cancelQueuedAndDrain() {
     const std::size_t discarded = tasks_.size();
     const std::size_t stillRunning = activeTasks_;
     tasks_.clear();
-    logMessage(LogLevel::Debug, name_ + " pool cancelQueuedAndDrain: discarded " +
-                                     std::to_string(discarded) + " queued task(s), " +
-                                     std::to_string(stillRunning) + " still running");
+    logMessage(LogLevel::Debug,
+               name_ + " pool cancelQueuedAndDrain: discarded " + std::to_string(discarded) +
+                   " queued task(s), " + std::to_string(stillRunning) + " still running");
     idle_.wait(lock, [this] { return activeTasks_ == 0; });
 }
 

--- a/tests/unit/CoreBasicsTest.cpp
+++ b/tests/unit/CoreBasicsTest.cpp
@@ -508,8 +508,8 @@ TEST(RefreshCoalescer, ABurstOfRequestsInsideTheWindowYieldsOneFire) {
 
     EXPECT_EQ(coalescer.request(true, true, GraphUpdateOrigin::Explicit, start),
               RefreshCoalescer::RefreshAction::Arm);
-    EXPECT_EQ(coalescer.request(true, true, GraphUpdateOrigin::Explicit,
-                                start + std::chrono::milliseconds(50)),
+    EXPECT_EQ(coalescer.request(
+                  true, true, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(50)),
               RefreshCoalescer::RefreshAction::Arm)
         << "still idle -- no refresh has started firing yet";
 
@@ -523,9 +523,11 @@ TEST(RefreshCoalescer, RefreshRefsFoldsIntoAPendingRefreshRefsAndHistoryAsTheUni
     RefreshCoalescer coalescer;
     const auto start = RefreshCoalescer::Clock::now();
 
-    coalescer.request(/*wantsRefs=*/true, /*wantsHistory=*/true, GraphUpdateOrigin::Explicit,
-                      start);
-    coalescer.request(/*wantsRefs=*/true, /*wantsHistory=*/false, GraphUpdateOrigin::Explicit,
+    coalescer.request(
+        /*wantsRefs=*/true, /*wantsHistory=*/true, GraphUpdateOrigin::Explicit, start);
+    coalescer.request(/*wantsRefs=*/true,
+                      /*wantsHistory=*/false,
+                      GraphUpdateOrigin::Explicit,
                       start + std::chrono::milliseconds(10));
 
     ASSERT_NE(coalescer.onTimeout(start + std::chrono::milliseconds(200)), 0u);
@@ -545,8 +547,8 @@ TEST(RefreshCoalescer, ARequestArrivingWhileRunningFoldsAndIsDeliveredByOnFinish
     ASSERT_NE(generation, 0u);
     coalescer.takePending();
 
-    EXPECT_EQ(coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                                start + std::chrono::milliseconds(210)),
+    EXPECT_EQ(coalescer.request(
+                  true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(210)),
               RefreshCoalescer::RefreshAction::Fold)
         << "a refresh is already running -- the timer must not be re-armed";
 
@@ -593,8 +595,8 @@ TEST(RefreshCoalescer, OnFinishedWithAStaleGenerationIsANoOp) {
 
     // A request arriving now must still correctly Fold against the newer
     // generation, proving its running_ state survived the stale report.
-    EXPECT_EQ(coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                                start + std::chrono::milliseconds(220)),
+    EXPECT_EQ(coalescer.request(
+                  true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(220)),
               RefreshCoalescer::RefreshAction::Fold);
     EXPECT_TRUE(coalescer.onFinished(currentGeneration))
         << "the current generation's own report still ends its run and delivers the fold";
@@ -622,15 +624,15 @@ TEST(RefreshCoalescer, ResetClearsPendingRunningAndDirtyState) {
         coalescer.onTimeout(start + std::chrono::milliseconds(200));
     ASSERT_NE(generation, 0u);
     // Folds while running, which would otherwise leave a dirty follow-up owed.
-    coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                      start + std::chrono::milliseconds(210));
+    coalescer.request(
+        true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(210));
 
     coalescer.reset();
 
     EXPECT_FALSE(coalescer.onFinished(generation))
         << "reset must drop the fold -- a torn-down session cannot leave one wedged";
-    EXPECT_EQ(coalescer.request(true, true, GraphUpdateOrigin::Explicit,
-                                start + std::chrono::milliseconds(220)),
+    EXPECT_EQ(coalescer.request(
+                  true, true, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(220)),
               RefreshCoalescer::RefreshAction::Arm)
         << "reset must also clear running_, or every request after teardown would fold forever";
 }
@@ -640,8 +642,8 @@ TEST(RefreshCoalescer, ExplicitOutranksAutoFetchResyncInTheMerge) {
     const auto start = RefreshCoalescer::Clock::now();
 
     coalescer.request(true, true, GraphUpdateOrigin::AutoFetchResync, start);
-    coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                      start + std::chrono::milliseconds(10));
+    coalescer.request(
+        true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(10));
 
     ASSERT_NE(coalescer.onTimeout(start + std::chrono::milliseconds(200)), 0u);
     EXPECT_EQ(coalescer.takePending().origin, GraphUpdateOrigin::Explicit)
@@ -661,8 +663,8 @@ TEST(RefreshCoalescer, TakePendingClearsTheBatchForTheNextWindow) {
 
     // A fresh window after the run finished must start from an empty batch,
     // not still report the previous window's flags.
-    coalescer.request(false, true, GraphUpdateOrigin::AutoFetchResync,
-                      start + std::chrono::milliseconds(400));
+    coalescer.request(
+        false, true, GraphUpdateOrigin::AutoFetchResync, start + std::chrono::milliseconds(400));
     ASSERT_NE(coalescer.onTimeout(start + std::chrono::milliseconds(600)), 0u);
     const RefreshCoalescer::PendingRefresh pending = coalescer.takePending();
     EXPECT_FALSE(pending.wantsRefs);
@@ -681,8 +683,8 @@ TEST(RefreshCoalescer, FireNowMarksRunningSoALaterRequestFoldsInstead) {
 
     coalescer.fireNow(false, true, GraphUpdateOrigin::Explicit, start);
 
-    EXPECT_EQ(coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                                start + std::chrono::milliseconds(10)),
+    EXPECT_EQ(coalescer.request(
+                  true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(10)),
               RefreshCoalescer::RefreshAction::Fold);
 }
 
@@ -693,8 +695,8 @@ TEST(RefreshCoalescer, ARequestDuringAnImmediateFireIsDeliveredByOnFinished) {
     const RefreshCoalescer::Generation generation =
         coalescer.fireNow(false, true, GraphUpdateOrigin::Explicit, start);
     coalescer.takePending();
-    coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                      start + std::chrono::milliseconds(10));
+    coalescer.request(
+        true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(10));
 
     EXPECT_TRUE(coalescer.onFinished(generation))
         << "the folded request must run once the fire completes";
@@ -727,10 +729,12 @@ TEST(RefreshCoalescer, FireNowMergesRatherThanDiscardsAnyAlreadyPendingBatch) {
     RefreshCoalescer coalescer;
     const auto start = RefreshCoalescer::Clock::now();
 
-    coalescer.request(/*wantsRefs=*/true, /*wantsHistory=*/false,
-                      GraphUpdateOrigin::AutoFetchResync, start);
+    coalescer.request(
+        /*wantsRefs=*/true, /*wantsHistory=*/false, GraphUpdateOrigin::AutoFetchResync, start);
     const RefreshCoalescer::Generation generation = coalescer.fireNow(
-        /*wantsRefs=*/false, /*wantsHistory=*/true, GraphUpdateOrigin::Explicit,
+        /*wantsRefs=*/false,
+        /*wantsHistory=*/true,
+        GraphUpdateOrigin::Explicit,
         start + std::chrono::milliseconds(5));
 
     const RefreshCoalescer::PendingRefresh pending = coalescer.takePending();
@@ -763,8 +767,8 @@ TEST(RefreshCoalescer, FireNowWhileAlreadyRunningSupersedesTheOlderGeneration) {
 
     // A request arriving now correctly folds against the newer generation --
     // proof running_ survived the stale report above.
-    EXPECT_EQ(coalescer.request(true, false, GraphUpdateOrigin::Explicit,
-                                start + std::chrono::milliseconds(220)),
+    EXPECT_EQ(coalescer.request(
+                  true, false, GraphUpdateOrigin::Explicit, start + std::chrono::milliseconds(220)),
               RefreshCoalescer::RefreshAction::Fold);
     EXPECT_TRUE(coalescer.onFinished(newerGeneration))
         << "the newer generation's own report correctly ends its run and delivers the fold";

--- a/tests/unit/CoreBasicsTest.cpp
+++ b/tests/unit/CoreBasicsTest.cpp
@@ -8,6 +8,7 @@
 #include "core/git/HistoryProvider.h"
 #include "core/git/RefStore.h"
 #include "core/git/RepoPaths.h"
+#include "core/workers/BusyToken.h"
 #include "core/workers/Debouncer.h"
 #include "core/workers/RefreshCoalescer.h"
 #include "core/workers/StartupReadGate.h"
@@ -304,6 +305,94 @@ TEST(ThreadPool, CancelQueuedAndDrainDiscardsQueuedWorkButWaitsForTheActiveTask)
     pool.post([&total] { ++total; });
     pool.drain();
     EXPECT_EQ(total.load(), 1);
+}
+
+// --- busy token --------------------------------------------------------------
+
+TEST(BusyToken, EmptyTokenReleasesNothing) {
+    BusyToken token;
+    EXPECT_FALSE(static_cast<bool>(token));
+    token.reset();  // must not crash or call anything
+}
+
+TEST(BusyToken, ReleasesOnDestruction) {
+    int releaseCount = 0;
+    {
+        BusyToken token([&] { ++releaseCount; });
+        EXPECT_TRUE(static_cast<bool>(token));
+        EXPECT_EQ(releaseCount, 0);
+    }
+    EXPECT_EQ(releaseCount, 1);
+}
+
+TEST(BusyToken, ResetReleasesExactlyOnceEvenIfDestructorAlsoFires) {
+    int releaseCount = 0;
+    {
+        BusyToken token([&] { ++releaseCount; });
+        token.reset();
+        EXPECT_EQ(releaseCount, 1);
+        EXPECT_FALSE(static_cast<bool>(token));
+        token.reset();  // idempotent: already fired
+        EXPECT_EQ(releaseCount, 1);
+    }
+    EXPECT_EQ(releaseCount, 1);  // destructor of an already-empty token is a no-op
+}
+
+TEST(BusyToken, MoveConstructionTransfersOwnership) {
+    int releaseCount = 0;
+    BusyToken original([&] { ++releaseCount; });
+    BusyToken moved(std::move(original));
+
+    EXPECT_FALSE(static_cast<bool>(original));
+    EXPECT_TRUE(static_cast<bool>(moved));
+
+    // The moved-from token must not also release -- exactly one release.
+    original.reset();
+    EXPECT_EQ(releaseCount, 0);
+
+    moved.reset();
+    EXPECT_EQ(releaseCount, 1);
+}
+
+TEST(BusyToken, MoveAssignmentReleasesWhateverTheTargetOwnedFirst) {
+    int firstReleaseCount = 0;
+    int secondReleaseCount = 0;
+    BusyToken first([&] { ++firstReleaseCount; });
+    BusyToken second([&] { ++secondReleaseCount; });
+
+    first = std::move(second);
+    // Assigning into `first` must release the busy unit it owned before the
+    // assignment, exactly like destroying it would -- otherwise the busy
+    // count that token was guarding never gets decremented.
+    EXPECT_EQ(firstReleaseCount, 1);
+    EXPECT_EQ(secondReleaseCount, 0);
+    EXPECT_FALSE(static_cast<bool>(second));
+    EXPECT_TRUE(static_cast<bool>(first));
+
+    first.reset();
+    EXPECT_EQ(secondReleaseCount, 1);
+}
+
+TEST(BusyToken, NestedTokensEachReleaseIndependently) {
+    // Mirrors the reference-counted busy indicator: several tokens in flight
+    // at once, each must decrement exactly once regardless of destruction order.
+    int busyCount = 0;
+    auto acquire = [&] {
+        ++busyCount;
+        return BusyToken([&] { --busyCount; });
+    };
+
+    BusyToken a = acquire();
+    BusyToken b = acquire();
+    BusyToken c = acquire();
+    EXPECT_EQ(busyCount, 3);
+
+    b.reset();
+    EXPECT_EQ(busyCount, 2);
+
+    a.reset();
+    c.reset();
+    EXPECT_EQ(busyCount, 0);
 }
 
 // --- debouncer -------------------------------------------------------------


### PR DESCRIPTION
#23 (observation only, no behavior change): logs discarded/still-running
task counts in ThreadPool::cancelQueuedAndDrain(), and warns in
MainWindow::closeRepository() when the drain takes >=2s along with queue
depth and thread count -- so a Windows repro can show whether the UI
thread is stuck inside the drain or elsewhere. GBM_LOG_LEVEL=debug (new)
makes the per-switch diagnostics visible; see
docs/reports/windows-repo-switch-deadlock.md for the repro/capture steps.

#24: adds a move-only BusyToken RAII type (core/workers/BusyToken.h) so a
busy/spinner reference count can only be released once, automatically, on
every return path. RepositorySession::setBusy() now records the source
location of each outstanding call for debugOutstandingBusySites() and logs
them if a session is destroyed with busyCount_ still above zero.
requestCommitDetails/requestConflictSides/requestFileContent -- the
viewport-driven batch requests named in the issue -- are migrated to
makeBusyToken(); requestCommitMetadata was audited and intentionally never
drove the indicator (by design, to avoid spinner flicker while scrolling),
so it is unchanged. No leak was found in current code; this is
preventative hardening plus the tooling to diagnose one if it recurs.