### PR TITLE
fix: wire View > Next tab and pin flutter-version across CI/release

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+# Remote-only: local Claude Code sessions already have whatever toolchain
+# the developer's machine provides.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Pinned to match .github/workflows/ci.yml / release.yml's
+# flutter-version -- 3.44.9 is the latest 3.44.x patch still on Dart
+# 3.12.2, which is app_flutter/pubspec.yaml's `sdk: ^3.12.2` floor
+# exactly. 3.44.0-3.44.1 ship an older Dart that fails that constraint,
+# and a later Dart minor (3.13.0 shipped a `dart format` style change)
+# would flap formatting against what CI enforces -- see CLAUDE.md's
+# "Known gaps" note on this exact problem.
+FLUTTER_VERSION="3.44.9"
+FLUTTER_ROOT="/opt/flutter-sdk/flutter"
+
+# Idempotent: a checkpointed/restored container may already have this
+# from a prior session, and re-downloading a ~1.5GB archive every start
+# would defeat the point of a persistent install location.
+if [ ! -x "$FLUTTER_ROOT/bin/flutter" ]; then
+  echo "Installing Flutter $FLUTTER_VERSION to $FLUTTER_ROOT..."
+  mkdir -p /opt/flutter-sdk
+  tmp_archive="$(mktemp -u /tmp/flutter-XXXXXX.tar.xz)"
+  curl -sSL -o "$tmp_archive" \
+    "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+  tar -xJf "$tmp_archive" -C /opt/flutter-sdk
+  rm -f "$tmp_archive"
+else
+  echo "Flutter $FLUTTER_VERSION already installed at $FLUTTER_ROOT, skipping download."
+fi
+
+# `flutter`/`dart` refuse to run as the repository owner (root, in this
+# environment) without this -- see the "Woah! You appear to be trying to
+# run flutter as root" warning it prints otherwise. Harmless as a warning
+# but git operations inside the SDK's own repo (e.g. `flutter --version`
+# reading its own commit) fail outright without the exception.
+git config --global --add safe.directory "$FLUTTER_ROOT" 2>/dev/null || true
+
+export PATH="$FLUTTER_ROOT/bin:$PATH"
+echo "export PATH=\"$FLUTTER_ROOT/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+
+# Warms the pub cache so `flutter analyze`/`flutter test` don't hit a
+# cold resolve on the first real command of the session.
+if [ -f "$CLAUDE_PROJECT_DIR/app_flutter/pubspec.yaml" ]; then
+  (cd "$CLAUDE_PROJECT_DIR/app_flutter" && flutter pub get)
+fi
+
+flutter --version

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,17 @@
   "enabledPlugins": {
     "clangd-lsp@claude-plugins-official": true,
     "dart-flutter@dart-flutter": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,40 @@ jobs:
           fi
           echo "core is Qt-free"
 
+      # subosito/flutter-action's `channel: stable` floats to whatever build
+      # is current that day. dart format's output is not stable across Dart
+      # SDK versions (CLAUDE.md's "Known gaps": a local Dart 3.12.2 and a CI
+      # run on a newer stable each accept the other's output as "needs
+      # reformatting", flapping a file between two valid formattings). Pin
+      # every flutter-action use to an explicit flutter-version so all three
+      # jobs run the same SDK the contributor formatted against.
+      - name: every flutter-action use must pin flutter-version
+        run: |
+          failed=0
+          for file in .github/workflows/*.yml; do
+            for lineno in $(grep -n '^\s*- uses: subosito/flutter-action@' "$file" | cut -d: -f1); do
+              # This step's `with:` block runs from `uses:` up to (but not
+              # including) the next step (a `- uses:`/`- name:` line at the
+              # same indentation) -- not a fixed line count, since the
+              # block's own length grows whenever someone adds a comment.
+              next_step=$(tail -n "+$((lineno + 1))" "$file" | grep -n '^\s*- \(uses\|name\):' | head -1 | cut -d: -f1)
+              if [ -n "$next_step" ]; then
+                end=$((lineno + next_step - 1))
+              else
+                end=$(wc -l < "$file")
+              fi
+              block=$(sed -n "${lineno},${end}p" "$file")
+              if ! printf '%s' "$block" | grep -q 'flutter-version:'; then
+                echo "::error file=$file,line=$lineno::subosito/flutter-action use has no flutter-version pin (channel: stable alone floats)"
+                failed=1
+              fi
+            done
+          done
+          if [ "$failed" -eq 1 ]; then
+            exit 1
+          fi
+          echo "every flutter-action use pins flutter-version"
+
   conventional-commits:
     name: Commit messages
     runs-on: ubuntu-latest
@@ -75,6 +109,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned rather than left to float on `stable` alone -- see the
+          # "every flutter-action use must pin flutter-version" lint step:
+          # `dart format`'s output is not stable across Dart SDK versions,
+          # so an unpinned channel flaps files between two valid
+          # formattings depending on which CI run last touched them.
+          flutter-version: '3.44.9'
 
       - name: flutter pub get
         working-directory: app_flutter
@@ -161,6 +201,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned rather than left to float on `stable` alone -- see the
+          # "every flutter-action use must pin flutter-version" lint step:
+          # `dart format`'s output is not stable across Dart SDK versions,
+          # so an unpinned channel flaps files between two valid
+          # formattings depending on which CI run last touched them.
+          flutter-version: '3.44.9'
 
       - name: flutter pub get
         working-directory: app_flutter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Kept in lockstep with ci.yml's pin (see its "every
+          # flutter-action use must pin flutter-version" lint step) so a
+          # release build never diverges from what CI already verified.
+          flutter-version: '3.44.9'
 
       - name: Set up MSVC environment
         if: runner.os == 'Windows'

--- a/app_flutter/lib/data/ffi/gbm_bindings.dart
+++ b/app_flutter/lib/data/ffi/gbm_bindings.dart
@@ -568,6 +568,8 @@ typedef _RemoteFetchNative =
     Void Function(
       Pointer<Void> session,
       Pointer<Utf8> remoteName,
+      Pointer<Pointer<Utf8>> refs,
+      Int32 refCount,
       Int32 prune,
       Int32 tags,
     );
@@ -575,6 +577,8 @@ typedef RemoteFetchDart =
     void Function(
       Pointer<Void> session,
       Pointer<Utf8> remoteName,
+      Pointer<Pointer<Utf8>> refs,
+      int refCount,
       int prune,
       int tags,
     );

--- a/app_flutter/lib/data/ffi/gbm_bindings.dart
+++ b/app_flutter/lib/data/ffi/gbm_bindings.dart
@@ -720,6 +720,16 @@ typedef RemotePruneDart =
       int refCount,
     );
 
+typedef _RemoteAddNative =
+    Void Function(Pointer<Void> session, Pointer<Utf8> name, Pointer<Utf8> url);
+typedef RemoteAddDart =
+    void Function(Pointer<Void> session, Pointer<Utf8> name, Pointer<Utf8> url);
+
+typedef _RemoteRemoveNative =
+    Void Function(Pointer<Void> session, Pointer<Utf8> name);
+typedef RemoteRemoveDart =
+    void Function(Pointer<Void> session, Pointer<Utf8> name);
+
 typedef _RequestFileHistoryNative =
     Void Function(
       Pointer<Void> session,
@@ -1448,6 +1458,13 @@ class GbmBindings {
       remotePrune = library.lookupFunction<_RemotePruneNative, RemotePruneDart>(
         'gbm_remote_prune',
       ),
+      remoteAdd = library.lookupFunction<_RemoteAddNative, RemoteAddDart>(
+        'gbm_remote_add',
+      ),
+      remoteRemove = library
+          .lookupFunction<_RemoteRemoveNative, RemoteRemoveDart>(
+            'gbm_remote_remove',
+          ),
       requestCompareWithWorkingCopy = library
           .lookupFunction<
             _RequestCompareWithWorkingCopyNative,
@@ -1763,6 +1780,8 @@ class GbmBindings {
   final RequestCompareFileDiffDart requestCompareFileDiff;
   final RequestRemotePrunePreviewDart requestRemotePrunePreview;
   final RemotePruneDart remotePrune;
+  final RemoteAddDart remoteAdd;
+  final RemoteRemoveDart remoteRemove;
   final RequestCompareWithWorkingCopyDart requestCompareWithWorkingCopy;
   final RequestFileHistoryDart requestFileHistory;
   final RequestLineHistoryDart requestLineHistory;

--- a/app_flutter/lib/data/ffi/gbm_bindings.dart
+++ b/app_flutter/lib/data/ffi/gbm_bindings.dart
@@ -1132,6 +1132,13 @@ typedef HasCommitGraphDart = int Function(Pointer<Void> session);
 typedef _WriteCommitGraphNative = Void Function(Pointer<Void> session);
 typedef WriteCommitGraphDart = void Function(Pointer<Void> session);
 
+typedef _RepoInitNative = Int32 Function(Pointer<Utf8> path);
+typedef RepoInitDart = int Function(Pointer<Utf8> path);
+
+typedef _RepoCloneNative =
+    Int32 Function(Pointer<Utf8> url, Pointer<Utf8> destPath);
+typedef RepoCloneDart = int Function(Pointer<Utf8> url, Pointer<Utf8> destPath);
+
 typedef _DiscoveryOpenNative = Pointer<Void> Function(Pointer<Utf8> dbPath);
 typedef DiscoveryOpenDart = Pointer<Void> Function(Pointer<Utf8> dbPath);
 
@@ -1670,6 +1677,12 @@ class GbmBindings {
           .lookupFunction<_WriteCommitGraphNative, WriteCommitGraphDart>(
             'gbm_write_commit_graph',
           ),
+      repoInit = library.lookupFunction<_RepoInitNative, RepoInitDart>(
+        'gbm_repo_init',
+      ),
+      repoClone = library.lookupFunction<_RepoCloneNative, RepoCloneDart>(
+        'gbm_repo_clone',
+      ),
       discoveryOpen = library
           .lookupFunction<_DiscoveryOpenNative, DiscoveryOpenDart>(
             'gbm_discovery_open',
@@ -1839,6 +1852,8 @@ class GbmBindings {
   final ClearLocalIdentityDart clearLocalIdentity;
   final HasCommitGraphDart hasCommitGraph;
   final WriteCommitGraphDart writeCommitGraph;
+  final RepoInitDart repoInit;
+  final RepoCloneDart repoClone;
   final DiscoveryOpenDart discoveryOpen;
   final DiscoveryCloseDart discoveryClose;
   final DiscoveryAddBaseFolderDart discoveryAddBaseFolder;

--- a/app_flutter/lib/data/repositories/branch_repository.dart
+++ b/app_flutter/lib/data/repositories/branch_repository.dart
@@ -24,6 +24,7 @@ void checkoutBranch(
   String target, {
   bool createBranch = false,
   String newBranchName = '',
+  bool detach = false,
 }) {
   ref
       .read(repoSessionProvider(identity).notifier)
@@ -31,5 +32,6 @@ void checkoutBranch(
         target: target,
         createBranch: createBranch,
         newBranchName: newBranchName,
+        detach: detach,
       );
 }

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -1849,15 +1849,32 @@ class RepoSessionController extends StateNotifier<RepoSessionState> {
   /// gbm_remote_fetch()'s doc comment in gbm_capi.h. Async: fires
   /// GBM_EVENT_WORKING_COPY_OPERATION_FINISHED, and on success also
   /// refreshes history.
+  /// [refs] restricts the fetch to those specific refs under [remoteName]
+  /// (e.g. one branch, or every branch under a folder prefix) instead of
+  /// everything the remote's default refspec would bring in -- empty
+  /// fetches everything, the original behavior. See gbm_remote_fetch()'s
+  /// doc comment: a non-empty [refs] with an empty [remoteName] is
+  /// rejected (no well-defined "these refs from every remote").
   void fetchRemote({
     String remoteName = '',
+    List<String> refs = const <String>[],
     bool prune = false,
     bool tags = false,
   }) {
     if (_session == nullptr) return;
     final Pointer<Utf8> remotePtr = remoteName.toNativeUtf8();
     try {
-      _bindings.remoteFetch(_session, remotePtr, prune ? 1 : 0, tags ? 1 : 0);
+      _withNativeStringArray(
+        refs,
+        (array, count) => _bindings.remoteFetch(
+          _session,
+          remotePtr,
+          array,
+          count,
+          prune ? 1 : 0,
+          tags ? 1 : 0,
+        ),
+      );
     } finally {
       malloc.free(remotePtr);
     }

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -2127,6 +2127,33 @@ class RepoSessionController extends StateNotifier<RepoSessionState> {
     }
   }
 
+  /// `git remote add`. Async: fires GBM_EVENT_OPERATION_FINISHED, and on
+  /// success also refreshes the remote list (same event
+  /// gbm_remote_refresh() would fire).
+  void addRemote(String name, String url) {
+    if (_session == nullptr) return;
+    final Pointer<Utf8> namePtr = name.toNativeUtf8();
+    final Pointer<Utf8> urlPtr = url.toNativeUtf8();
+    try {
+      _bindings.remoteAdd(_session, namePtr, urlPtr);
+    } finally {
+      malloc.free(namePtr);
+      malloc.free(urlPtr);
+    }
+  }
+
+  /// `git remote remove`. Async: fires GBM_EVENT_OPERATION_FINISHED, and on
+  /// success also refreshes the remote list.
+  void removeRemote(String name) {
+    if (_session == nullptr) return;
+    final Pointer<Utf8> namePtr = name.toNativeUtf8();
+    try {
+      _bindings.remoteRemove(_session, namePtr);
+    } finally {
+      malloc.free(namePtr);
+    }
+  }
+
   /// `git log --follow` for one file. `startRevision` empty starts from
   /// HEAD. Async: fires GBM_EVENT_FILE_HISTORY_READY into
   /// [RepoSessionState.lastFileHistory].

--- a/app_flutter/lib/features/conflict_resolution/conflict_hunk_menu_items.dart
+++ b/app_flutter/lib/features/conflict_resolution/conflict_hunk_menu_items.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../widgets/gbm_menu.dart';
+
+/// `ctxItemsFor('conflictHunk')` from gbm_context_menus.dart's 05-I
+/// (Conflict hunk) -- 5 top-level items, danger last.
+///
+/// [onDiscardFromResult] is nullable: it maps onto the region's existing
+/// whole-region Reset (`_ResultPane`'s "Reset" button, `_resetRegion()`),
+/// which only makes sense once the region actually has something in the
+/// result -- the caller passes `null` when this region's result is still
+/// empty, the same way `_ResultPane` itself only renders its own Reset
+/// button `if (resolved)`.
+///
+/// [onOpenInExternalTool] has no backing capability -- nothing in this app
+/// launches an external diff/merge tool with the conflict's content
+/// pre-filled (`desktop_launcher.dart` only opens a terminal or a URL) --
+/// so it always renders `enabled: false` rather than being wired to
+/// something that would silently do the wrong thing, the same treatment
+/// 05-C's "Fetch this branch" and 05-J's "Fetch branches in folder" get
+/// for their own missing capabilities.
+List<GbmMenuItem> conflictHunkMenuItems({
+  required VoidCallback onTakeThisSide,
+  required VoidCallback onTakeThisLineOnly,
+  required VoidCallback onTakeBoth,
+  required VoidCallback? onDiscardFromResult,
+}) {
+  return <GbmMenuItem>[
+    GbmMenuItem(
+      label: 'Take this side',
+      icon: Icons.check_circle_outline,
+      onTap: onTakeThisSide,
+    ),
+    GbmMenuItem(
+      label: 'Take this line only',
+      icon: Icons.fact_check_outlined,
+      onTap: onTakeThisLineOnly,
+    ),
+    GbmMenuItem(
+      label: 'Take both — this side first',
+      icon: Icons.merge_type,
+      onTap: onTakeBoth,
+    ),
+    const GbmMenuItem(
+      label: 'Open in external merge tool',
+      icon: Icons.open_in_new,
+      enabled: false,
+      onTap: null,
+    ),
+    const GbmMenuItem.separator(),
+    GbmMenuItem(
+      label: 'Discard from result',
+      icon: Icons.delete_outline,
+      danger: true,
+      onTap: onDiscardFromResult,
+    ),
+  ];
+}

--- a/app_flutter/lib/features/conflict_resolution/conflict_hunk_menu_items.dart
+++ b/app_flutter/lib/features/conflict_resolution/conflict_hunk_menu_items.dart
@@ -52,6 +52,7 @@ List<GbmMenuItem> conflictHunkMenuItems({
       label: 'Discard from result',
       icon: Icons.delete_outline,
       danger: true,
+      enabled: onDiscardFromResult != null,
       onTap: onDiscardFromResult,
     ),
   ];

--- a/app_flutter/lib/features/conflict_resolution/conflict_resolve_window.dart
+++ b/app_flutter/lib/features/conflict_resolution/conflict_resolve_window.dart
@@ -15,7 +15,9 @@ import '../../routing/route_paths.dart';
 import '../../theme/gbm_theme.dart';
 import '../../theme/tokens.dart';
 import '../../widgets/gbm_button.dart';
+import '../../widgets/gbm_menu.dart';
 import '../../widgets/split_pane.dart';
+import 'conflict_hunk_menu_items.dart';
 import 'conflict_line_order.dart';
 import 'conflict_resolve_logic.dart';
 import 'original_operation_message_dialog.dart';
@@ -844,6 +846,11 @@ class _ConflictResolveWindowState extends ConsumerState<ConflictResolveWindow> {
           regionIndex: thisRegion,
           source: ConflictLineSource.ours,
           onApplyLines: _appendLines,
+          otherSource: ConflictLineSource.theirs,
+          otherSideLines: segment.theirs,
+          onReset: () => _resetRegion(thisRegion),
+          hasResult:
+              _lineOrder?.getOrderedLines(thisRegion).isNotEmpty ?? false,
         ),
       );
     }
@@ -904,6 +911,11 @@ class _ConflictResolveWindowState extends ConsumerState<ConflictResolveWindow> {
           regionIndex: thisRegion,
           source: ConflictLineSource.theirs,
           onApplyLines: _appendLines,
+          otherSource: ConflictLineSource.ours,
+          otherSideLines: segment.ours,
+          onReset: () => _resetRegion(thisRegion),
+          hasResult:
+              _lineOrder?.getOrderedLines(thisRegion).isNotEmpty ?? false,
         ),
       );
     }
@@ -1587,6 +1599,10 @@ class _SidePane extends StatefulWidget {
     required this.regionIndex,
     required this.source,
     required this.onApplyLines,
+    required this.otherSource,
+    required this.otherSideLines,
+    required this.onReset,
+    required this.hasResult,
   });
 
   final String label;
@@ -1598,12 +1614,57 @@ class _SidePane extends StatefulWidget {
   final Function(int regionIndex, ConflictLineSource source, List<String> lines)
   onApplyLines;
 
+  /// 05-I "Take both — this side first" needs the other side's lines to
+  /// append after this side's own -- this pane otherwise only knows about
+  /// [lines], its own side.
+  final ConflictLineSource otherSource;
+  final List<String> otherSideLines;
+
+  /// 05-I "Discard from result" -- the same whole-region reset
+  /// `_ResultPane`'s own "Reset" button calls, exposed here too so a
+  /// right-click on either side pane can reach it without navigating to
+  /// the result pane first.
+  final VoidCallback onReset;
+
+  /// Gates "Discard from result": true once this region has at least one
+  /// line in its result, mirroring `_ResultPane`'s own `if (resolved)`
+  /// guard on rendering its Reset button at all.
+  final bool hasResult;
+
   @override
   State<_SidePane> createState() => _SidePaneState();
 }
 
 class _SidePaneState extends State<_SidePane> {
   bool _hovered = false;
+
+  void _openHunkContextMenu(TapDownDetails details, String line) {
+    showGbmContextMenu(
+      context,
+      details.globalPosition,
+      conflictHunkMenuItems(
+        onTakeThisSide: () => widget.onApplyLines(
+          widget.regionIndex,
+          widget.source,
+          widget.lines,
+        ),
+        onTakeThisLineOnly: () => widget.onApplyLines(
+          widget.regionIndex,
+          widget.source,
+          <String>[line],
+        ),
+        onTakeBoth: () {
+          widget.onApplyLines(widget.regionIndex, widget.source, widget.lines);
+          widget.onApplyLines(
+            widget.regionIndex,
+            widget.otherSource,
+            widget.otherSideLines,
+          );
+        },
+        onDiscardFromResult: widget.hasResult ? widget.onReset : null,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1686,22 +1747,26 @@ class _SidePaneState extends State<_SidePane> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
                   for (final line in widget.lines)
-                    InkWell(
-                      onTap: () => widget.onApplyLines(
-                        widget.regionIndex,
-                        widget.source,
-                        [line],
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: GbmSpacing.space1,
+                    GestureDetector(
+                      onSecondaryTapDown: (TapDownDetails details) =>
+                          _openHunkContextMenu(details, line),
+                      child: InkWell(
+                        onTap: () => widget.onApplyLines(
+                          widget.regionIndex,
+                          widget.source,
+                          [line],
                         ),
-                        child: Text(
-                          line,
-                          style: TextStyle(
-                            fontFamily: GbmTypography.fontMono,
-                            fontSize: GbmTypography.textSm,
-                            color: colors.textPrimary,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: GbmSpacing.space1,
+                          ),
+                          child: Text(
+                            line,
+                            style: TextStyle(
+                              fontFamily: GbmTypography.fontMono,
+                              fontSize: GbmTypography.textSm,
+                              color: colors.textPrimary,
+                            ),
                           ),
                         ),
                       ),

--- a/app_flutter/lib/features/dialogs/manage_remotes/manage_remotes_dialog.dart
+++ b/app_flutter/lib/features/dialogs/manage_remotes/manage_remotes_dialog.dart
@@ -12,10 +12,9 @@ import '../../../widgets/gbm_dialog_shell.dart';
 
 /// The Dart analog of the remote-sync half of `PushPullDialog`/repository
 /// settings (src/app/dialogs). Routed as
-/// `/repo/:repoId/dialogs/manage-remotes`. Only lists and syncs against
-/// remotes that already exist (`git remote add`/`remove` are not yet part
-/// of the capi surface -- see src/core/git/ops/RemoteOps.h, which only
-/// covers list/fetch/pull/push).
+/// `/repo/:repoId/dialogs/manage-remotes`. Lists, syncs, adds, and removes
+/// remotes -- see src/core/git/ops/RemoteOps.h's makeAddRemoteOperation()/
+/// makeRemoveRemoteOperation().
 class ManageRemotesDialogContent extends ConsumerStatefulWidget {
   const ManageRemotesDialogContent({super.key, required this.identity});
 
@@ -38,6 +37,14 @@ class _ManageRemotesDialogContentState
     );
   }
 
+  Future<void> _addRemote(BuildContext context) async {
+    final ({String name, String url})? result = await _promptAddRemote(context);
+    if (result == null || !mounted) return;
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .addRemote(result.name, result.url);
+  }
+
   @override
   Widget build(BuildContext context) {
     final GbmColors colors = context.gbmColors;
@@ -49,6 +56,7 @@ class _ManageRemotesDialogContentState
       title: 'Remotes',
       width: 640,
       actions: <Widget>[
+        GbmButton(label: 'Add remote…', onPressed: () => _addRemote(context)),
         GbmButton(label: 'Close', onPressed: () => context.pop()),
       ],
       child: SizedBox(
@@ -143,8 +151,89 @@ class _RemoteRow extends ConsumerWidget {
               ),
             ),
           ),
+          TextButton(
+            onPressed: () => ref
+                .read(repoSessionProvider(identity).notifier)
+                .removeRemote(remote.name),
+            child: Text(
+              'Remove',
+              style: TextStyle(
+                fontSize: GbmTypography.textXs,
+                color: colors.danger,
+              ),
+            ),
+          ),
         ],
       ),
     );
   }
+}
+
+/// Prompts for both a name and a URL at once -- unlike every other
+/// branch/tag rename/create flow, adding a remote genuinely needs two
+/// values, so this doesn't fit promptText's single-field shape. Returns
+/// null if cancelled, or either field is left empty.
+Future<({String name, String url})?> _promptAddRemote(BuildContext context) {
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController urlController = TextEditingController();
+  return showDialog<({String name, String url})>(
+    context: context,
+    builder: (dialogContext) {
+      final GbmColors colors = dialogContext.gbmColors;
+      ({String name, String url})? resultFromControllers() {
+        final String name = nameController.text.trim();
+        final String url = urlController.text.trim();
+        return name.isEmpty || url.isEmpty ? null : (name: name, url: url);
+      }
+
+      // Only pops on a valid result -- leaving the dialog open (with
+      // whatever the user already typed still in place) is the signal
+      // that a required field is missing, rather than silently discarding
+      // the input by closing anyway.
+      void submitIfValid() {
+        final ({String name, String url})? result = resultFromControllers();
+        if (result != null) {
+          Navigator.of(dialogContext).pop(result);
+        }
+      }
+
+      return AlertDialog(
+        title: const Text('Add Remote'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            TextField(
+              controller: nameController,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Name',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: GbmSpacing.space2),
+            TextField(
+              controller: urlController,
+              decoration: const InputDecoration(
+                labelText: 'URL',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              onSubmitted: (_) => submitIfValid(),
+            ),
+          ],
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(
+              'Cancel',
+              style: TextStyle(color: colors.textSecondary),
+            ),
+          ),
+          TextButton(onPressed: submitIfValid, child: const Text('Add')),
+        ],
+      );
+    },
+  );
 }

--- a/app_flutter/lib/features/dialogs/manage_stashes/manage_stashes_dialog.dart
+++ b/app_flutter/lib/features/dialogs/manage_stashes/manage_stashes_dialog.dart
@@ -14,9 +14,19 @@ import '../../diff/diff_page.dart';
 /// The Dart analog of `ManageStashesDialog` (src/app/dialogs/
 /// ManageStashesDialog.cpp). Routed as `/repo/:repoId/dialogs/manage-stashes`.
 class ManageStashesDialogContent extends ConsumerStatefulWidget {
-  const ManageStashesDialogContent({super.key, required this.identity});
+  const ManageStashesDialogContent({
+    super.key,
+    required this.identity,
+    this.initialSelectedIndex,
+  });
 
   final RepoIdentity identity;
+
+  /// Pre-selects a stash entry (and requests its diff) on open -- set by
+  /// the sidebar stash context menu's "View diff" item
+  /// (route_paths.dart's `manageStashesDialogFor(selectIndex:)`) so the
+  /// dialog doesn't open on the default "Select a stash" empty state.
+  final int? initialSelectedIndex;
 
   @override
   ConsumerState<ManageStashesDialogContent> createState() =>
@@ -25,16 +35,19 @@ class ManageStashesDialogContent extends ConsumerStatefulWidget {
 
 class _ManageStashesDialogContentState
     extends ConsumerState<ManageStashesDialogContent> {
-  int? _selectedIndex;
+  late int? _selectedIndex = widget.initialSelectedIndex;
 
   @override
   void initState() {
     super.initState();
-    Future.microtask(
-      () => ref
-          .read(repoSessionProvider(widget.identity).notifier)
-          .refreshStashes(),
-    );
+    Future.microtask(() {
+      ref.read(repoSessionProvider(widget.identity).notifier).refreshStashes();
+      if (widget.initialSelectedIndex != null) {
+        ref
+            .read(repoSessionProvider(widget.identity).notifier)
+            .requestStashDiff(widget.initialSelectedIndex!);
+      }
+    });
   }
 
   @override

--- a/app_flutter/lib/features/repo_switcher/repo_switcher_popover.dart
+++ b/app_flutter/lib/features/repo_switcher/repo_switcher_popover.dart
@@ -10,19 +10,25 @@
 ///
 /// ahead/behind per row is not rendered: `RepoRecord` (src/core/cache/
 /// RepoIndexDb.h) stores only discovery metadata, and reading tracking
-/// counts for a repository would mean opening a session per row. Left out
-/// rather than faked, the same way `Clone repository…` below is rendered
-/// disabled instead of pretending to work.
+/// counts for a repository would mean opening a session per row -- left out
+/// rather than faked.
 library;
 
+import 'dart:convert';
+import 'dart:ffi' hide Size;
 import 'dart:math' as math;
 
+import 'package:ffi/ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../data/ffi/gbm_bindings.dart';
+import '../../data/ffi/json_codec.dart';
+import '../../data/models/git_error.dart';
 import '../../data/models/repo_record.dart';
 import '../../data/repositories/discovery_repository.dart';
+import '../../data/repositories/gbm_bindings_provider.dart';
 import '../../data/repositories/recents_repository.dart';
 import '../../data/services/desktop_launcher.dart';
 import '../../routing/app_router.dart';
@@ -195,6 +201,162 @@ Future<void> promptOpenRepository(
   if (path == null) return;
   onDismiss?.call();
   router.go(RoutePaths.workspaceFor(repoIdFor(path)));
+}
+
+/// Runs `git init` on a path the user provides (via `gbm_repo_init()`), then
+/// opens it exactly like [promptOpenRepository] does -- a fresh repository
+/// has no session of its own to open until it exists on disk. Backs File →
+/// New repository…
+///
+/// Needs [ref] (unlike [promptOpenRepository]) because init runs before any
+/// session exists: there is no `RepoSessionController` yet to dispatch
+/// through, so this reaches `gbm_repo_init()` directly via
+/// `gbmBindingsProvider`.
+Future<void> promptNewRepository(
+  BuildContext context,
+  WidgetRef ref, {
+  VoidCallback? onDismiss,
+}) async {
+  final GoRouter router = GoRouter.of(context);
+  final String? path = await promptText(
+    context,
+    title: 'New Repository',
+    label: 'Path for the new repository',
+  );
+  if (path == null) return;
+
+  final GbmBindings bindings = ref.read(gbmBindingsProvider);
+  final Pointer<Utf8> pathPtr = path.toNativeUtf8();
+  final int result;
+  try {
+    result = bindings.repoInit(pathPtr);
+  } finally {
+    malloc.free(pathPtr);
+  }
+  if (result != 0) {
+    if (context.mounted) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text(_decodeInitCloneErrorMessage(bindings))),
+      );
+    }
+    return;
+  }
+
+  onDismiss?.call();
+  router.go(RoutePaths.workspaceFor(repoIdFor(path)));
+}
+
+/// Runs `git clone <url> <destPath>` (via `gbm_repo_clone()`), then opens
+/// the result exactly like [promptOpenRepository] does. Backs both the
+/// switcher popover footer's `Clone repository…` and File → Clone
+/// repository….
+///
+/// Two fields (unlike New/Open's single path) need their own small dialog
+/// rather than [promptText] -- see `_promptClone` below, which follows
+/// `manage_remotes_dialog.dart`'s `_promptAddRemote()` pattern.
+Future<void> promptCloneRepository(
+  BuildContext context,
+  WidgetRef ref, {
+  VoidCallback? onDismiss,
+}) async {
+  final GoRouter router = GoRouter.of(context);
+  final ({String url, String destPath})? input = await _promptClone(context);
+  if (input == null) return;
+
+  final GbmBindings bindings = ref.read(gbmBindingsProvider);
+  final Pointer<Utf8> urlPtr = input.url.toNativeUtf8();
+  final Pointer<Utf8> destPtr = input.destPath.toNativeUtf8();
+  final int result;
+  try {
+    result = bindings.repoClone(urlPtr, destPtr);
+  } finally {
+    malloc.free(urlPtr);
+    malloc.free(destPtr);
+  }
+  if (result != 0) {
+    if (context.mounted) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text(_decodeInitCloneErrorMessage(bindings))),
+      );
+    }
+    return;
+  }
+
+  onDismiss?.call();
+  router.go(RoutePaths.workspaceFor(repoIdFor(input.destPath)));
+}
+
+String _decodeInitCloneErrorMessage(GbmBindings bindings) {
+  final String json = readLastResultJson(bindings);
+  if (json.isEmpty) return 'The operation failed.';
+  return GitError.fromJson(jsonDecode(json) as Map<String, dynamic>).message;
+}
+
+Future<({String url, String destPath})?> _promptClone(BuildContext context) {
+  final TextEditingController urlController = TextEditingController();
+  final TextEditingController destController = TextEditingController();
+  return showDialog<({String url, String destPath})>(
+    context: context,
+    builder: (dialogContext) {
+      final GbmColors colors = dialogContext.gbmColors;
+      ({String url, String destPath})? resultFromControllers() {
+        final String url = urlController.text.trim();
+        final String destPath = destController.text.trim();
+        return url.isEmpty || destPath.isEmpty
+            ? null
+            : (url: url, destPath: destPath);
+      }
+
+      // Same "only pop on a valid result" discipline as
+      // manage_remotes_dialog.dart's _promptAddRemote(): a required field
+      // left empty keeps the dialog open with what was already typed,
+      // rather than silently discarding it.
+      void submitIfValid() {
+        final ({String url, String destPath})? result = resultFromControllers();
+        if (result != null) {
+          Navigator.of(dialogContext).pop(result);
+        }
+      }
+
+      return AlertDialog(
+        title: const Text('Clone Repository'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            TextField(
+              controller: urlController,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Repository URL',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: GbmSpacing.space2),
+            TextField(
+              controller: destController,
+              decoration: const InputDecoration(
+                labelText: 'Destination path',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              onSubmitted: (_) => submitIfValid(),
+            ),
+          ],
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(
+              'Cancel',
+              style: TextStyle(color: colors.textSecondary),
+            ),
+          ),
+          TextButton(onPressed: submitIfValid, child: const Text('Clone')),
+        ],
+      );
+    },
+  );
 }
 
 /// The sidebar's top row: which repository this window is showing, and the
@@ -556,11 +718,8 @@ class _RepoSwitcherListState extends ConsumerState<RepoSwitcherList> {
         _FooterAction(
           label: 'Clone repository…',
           shortcut: _shortcutLabel('Shift+N'),
-          // No clone exists anywhere below this layer -- gbm_capi.h exposes
-          // no clone entry point and neither does src/core -- so this is
-          // rendered disabled rather than wired to something that would
-          // silently do nothing.
-          onTap: null,
+          onTap: () =>
+              promptCloneRepository(context, ref, onDismiss: widget.onDismiss),
         ),
       ],
     );

--- a/app_flutter/lib/features/sidebar/branch_tree_builder.dart
+++ b/app_flutter/lib/features/sidebar/branch_tree_builder.dart
@@ -245,3 +245,30 @@ int _compareTreeNodes(BranchTreeNode a, BranchTreeNode b) {
 
   return aName.compareTo(bName);
 }
+
+/// What 05-J's "Fetch branches in folder" needs to call
+/// `RepoSessionController.fetchRemote(remoteName:, refs:)`: the single
+/// remote every fetchable branch in [refs] tracks, and the branch names
+/// (as they exist on that remote, no prefix) to fetch. A local branch
+/// with no configured upstream contributes nothing (there is no remote
+/// ref for it to fetch). Returns null when there is nothing fetchable, or
+/// when the branches present track more than one distinct remote --
+/// `gbm_remote_fetch()` targets exactly one remote per call, and picking
+/// one over another silently would fetch less than the user asked for.
+(String remote, List<String> branches)? fetchableRefsInFolder(
+  List<RefInfo> refs,
+) {
+  final Map<String, List<String>> byRemote = <String, List<String>>{};
+  for (final RefInfo ref in refs) {
+    final String upstream = ref.kind == RefKind.remoteBranch
+        ? ref.fullName
+        : ref.upstream;
+    if (upstream.isEmpty) continue;
+    final (String remote, String branch) = remoteBranchParts(upstream);
+    if (remote.isEmpty || branch.isEmpty) continue;
+    (byRemote[remote] ??= <String>[]).add(branch);
+  }
+  if (byRemote.length != 1) return null;
+  final MapEntry<String, List<String>> only = byRemote.entries.single;
+  return (only.key, only.value);
+}

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../actions/gbm_action_availability.dart';
 import '../../actions/gbm_action_id.dart';
 import '../../data/models/ref_snapshot.dart';
+import '../../data/models/remote_info.dart';
 import '../../data/models/stash_entry.dart';
 import '../../data/repositories/branch_repository.dart';
 import '../../data/repositories/compare_tabs_repository.dart';
@@ -181,6 +182,32 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     ref
         .read(repoSessionProvider(widget.identity).notifier)
         .dropStash(stash.index);
+  }
+
+  void _checkoutTagDetached(RefInfo tag) {
+    checkoutBranch(ref, widget.identity, tag.shortName, detach: true);
+  }
+
+  void _pushTag(RefInfo tag, RemoteInfo remote) {
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .pushTag(remote.name, name: tag.shortName);
+  }
+
+  // Same `left: <ref string>` mechanism as _compareStash -- a tag name is
+  // already a valid ref on its own.
+  void _compareTag(RefInfo tag) {
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
+    final String tabId = ref
+        .read(compareTabsProvider(widget.identity).notifier)
+        .open(left: tag.shortName);
+    context.go(RoutePaths.compareFor(repoId, tabId));
+  }
+
+  void _deleteTag(RefInfo tag) {
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .deleteTag(tag.shortName);
   }
 
   void _openStashContextMenu(
@@ -557,11 +584,13 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
                               ),
                               child: BranchTreeItem(
                                 ref: tag,
-                                onCheckout: () => checkoutBranch(
-                                  ref,
-                                  widget.identity,
-                                  tag.shortName,
-                                ),
+                                onCheckout: () => _checkoutTagDetached(tag),
+                                onPushTag: session.remotes.length == 1
+                                    ? () =>
+                                          _pushTag(tag, session.remotes.single)
+                                    : null,
+                                onCompareRef: () => _compareTag(tag),
+                                onDeleteTag: () => _deleteTag(tag),
                                 // Sourced from isActionEnabled(), not
                                 // session.conflictActive directly -- single
                                 // source of truth for checkout availability.

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -276,11 +276,27 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
         .deleteBranch(names: names);
   }
 
+  // Only offered when every leaf ref in the folder resolves to the same
+  // remote (see fetchableRefsInFolder's doc comment) -- there's no "default
+  // remote" to fall back to for a folder mixing refs from more than one,
+  // unlike a repository-level fetch.
+  void _fetchFolder(BranchTreeFolder folder) {
+    final (String remote, List<String> branches)? fetchable =
+        fetchableRefsInFolder(_collectFolderLeafRefs(folder.children));
+    if (fetchable == null) return;
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .fetchRemote(remoteName: fetchable.$1, refs: fetchable.$2);
+  }
+
   void _openFolderContextMenu(
     BuildContext context,
     TapDownDetails details,
     BranchTreeFolder folder,
   ) {
+    final (String, List<String>)? fetchable = fetchableRefsInFolder(
+      _collectFolderLeafRefs(folder.children),
+    );
     showGbmContextMenu(
       context,
       details.globalPosition,
@@ -290,6 +306,7 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
         onCopyPrefix: () =>
             Clipboard.setData(ClipboardData(text: '${folder.folderName}/')),
         onDeleteMerged: () => _deleteMergedInFolder(folder),
+        onFetchFolder: fetchable == null ? null : () => _fetchFolder(folder),
       ),
     );
   }

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -18,6 +19,7 @@ import '../../widgets/gbm_menu.dart';
 import '../../widgets/prompt_text_dialog.dart';
 import '../repo_switcher/repo_switcher_popover.dart';
 import 'branch_tree_builder.dart';
+import 'widgets/branch_folder_menu_items.dart';
 import 'widgets/branch_tree_item.dart';
 import 'widgets/stash_menu_items.dart';
 
@@ -208,6 +210,88 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     ref
         .read(repoSessionProvider(widget.identity).notifier)
         .deleteTag(tag.shortName);
+  }
+
+  List<RefInfo> _collectFolderLeafRefs(List<BranchTreeNode> nodes) {
+    final List<RefInfo> refs = <RefInfo>[];
+    for (final BranchTreeNode node in nodes) {
+      if (node is BranchTreeLeaf) {
+        refs.add(node.ref);
+      } else if (node is BranchTreeFolder) {
+        refs.addAll(_collectFolderLeafRefs(node.children));
+      }
+    }
+    return refs;
+  }
+
+  Set<String> _collectFolderNames(List<BranchTreeNode> nodes) {
+    final Set<String> names = <String>{};
+    for (final BranchTreeNode node in nodes) {
+      if (node is BranchTreeFolder) {
+        names.add(node.folderName);
+        names.addAll(_collectFolderNames(node.children));
+      }
+    }
+    return names;
+  }
+
+  // "Expand all" opens this folder and every nested subfolder beneath it,
+  // not just this one level -- "Collapse all" only needs to close this
+  // one, since a closed ancestor already hides its descendants regardless
+  // of their own recorded expand state.
+  void _toggleFolderExpand(BranchTreeFolder folder) {
+    setState(() {
+      if (_expandedFolders.contains(folder.folderName)) {
+        _expandedFolders.remove(folder.folderName);
+      } else {
+        _expandedFolders
+          ..add(folder.folderName)
+          ..addAll(_collectFolderNames(folder.children));
+      }
+    });
+  }
+
+  // Reuses deleteBranch's existing safe-delete default (force: false,
+  // i.e. plain `git branch -d`) rather than a new "is this merged" capi
+  // capability: git itself refuses any branch here that isn't merged, and
+  // that refusal already surfaces through the existing delete-branch-
+  // recovery flow (checkoutChoices/deleteBranchChoices), the same path a
+  // single unmerged branch delete goes through today. Excludes HEAD and
+  // any branch checked out in a linked worktree, matching
+  // _isGoneAndBulkSelectable's exclusions for the same reason -- deleting
+  // either would fail loudly or move the current session's HEAD.
+  void _deleteMergedInFolder(BranchTreeFolder folder) {
+    final List<String> names = _collectFolderLeafRefs(folder.children)
+        .where(
+          (RefInfo ref) =>
+              ref.kind == RefKind.localBranch &&
+              !ref.isHead &&
+              ref.worktreePath.isEmpty,
+        )
+        .map((RefInfo ref) => ref.shortName)
+        .toList(growable: false);
+    if (names.isEmpty) return;
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .deleteBranch(names: names);
+  }
+
+  void _openFolderContextMenu(
+    BuildContext context,
+    TapDownDetails details,
+    BranchTreeFolder folder,
+  ) {
+    showGbmContextMenu(
+      context,
+      details.globalPosition,
+      branchFolderMenuItems(
+        isExpanded: _expandedFolders.contains(folder.folderName),
+        onToggleExpand: () => _toggleFolderExpand(folder),
+        onCopyPrefix: () =>
+            Clipboard.setData(ClipboardData(text: '${folder.folderName}/')),
+        onDeleteMerged: () => _deleteMergedInFolder(folder),
+      ),
+    );
   }
 
   void _openStashContextMenu(
@@ -711,6 +795,19 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     return const SizedBox.shrink();
   }
 
+  // Single-level toggle -- the chevron and clicking the folder name both
+  // use this, distinct from the context menu's "Expand all" (see
+  // _toggleFolderExpand's doc comment for why that one recurses).
+  void _toggleFolderExpandedSingleLevel(BranchTreeFolder folder) {
+    setState(() {
+      if (_expandedFolders.contains(folder.folderName)) {
+        _expandedFolders.remove(folder.folderName);
+      } else {
+        _expandedFolders.add(folder.folderName);
+      }
+    });
+  }
+
   Widget _buildFolderNode(BranchTreeFolder folder, BuildContext context) {
     final colors = context.gbmColors;
     final isExpanded = _expandedFolders.contains(folder.folderName);
@@ -718,37 +815,42 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
-        Container(
-          height: GbmSpacing.rowHeightCompact,
-          padding: const EdgeInsets.symmetric(horizontal: GbmSpacing.space2),
-          child: Row(
-            children: <Widget>[
-              IconButton(
-                icon: Icon(
-                  isExpanded ? Icons.expand_more : Icons.chevron_right,
-                  size: 18,
-                  color: colors.textSecondary,
-                ),
-                onPressed: () => setState(() {
-                  if (isExpanded) {
-                    _expandedFolders.remove(folder.folderName);
-                  } else {
-                    _expandedFolders.add(folder.folderName);
-                  }
-                }),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-              ),
-              Expanded(
-                child: Text(
-                  folder.folderName,
-                  style: TextStyle(
-                    fontSize: GbmTypography.textSm,
+        GestureDetector(
+          onSecondaryTapDown: (TapDownDetails details) =>
+              _openFolderContextMenu(context, details, folder),
+          child: Container(
+            height: GbmSpacing.rowHeightCompact,
+            padding: const EdgeInsets.symmetric(horizontal: GbmSpacing.space2),
+            child: Row(
+              children: <Widget>[
+                IconButton(
+                  icon: Icon(
+                    isExpanded ? Icons.expand_more : Icons.chevron_right,
+                    size: 18,
                     color: colors.textSecondary,
                   ),
+                  onPressed: () => _toggleFolderExpandedSingleLevel(folder),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(
+                    minWidth: 32,
+                    minHeight: 32,
+                  ),
                 ),
-              ),
-            ],
+                Expanded(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () => _toggleFolderExpandedSingleLevel(folder),
+                    child: Text(
+                      folder.folderName,
+                      style: TextStyle(
+                        fontSize: GbmTypography.textSm,
+                        color: colors.textSecondary,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
         if (isExpanded)

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -381,6 +381,19 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     );
   }
 
+  /// 05-C "Fetch this branch" -- a remote-only row's own ref is already an
+  /// unambiguous single remote + branch (unlike 05-J's folder-wide fetch,
+  /// which needs fetchableRefsInFolder()'s "single remote across every
+  /// leaf" check), so this always fetches exactly the one branch.
+  void _fetchRemoteRef(RefInfo remoteRef) {
+    final (String remoteName, String branch) = remoteBranchParts(
+      remoteRef.fullName,
+    );
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .fetchRemote(remoteName: remoteName, refs: <String>[branch]);
+  }
+
   /// 05-C "Delete on remote…" -- opens the existing dialog
   /// (`deleteRemoteBranchDialogFor`), previously unreachable from any UI.
   void _openDeleteRemoteBranchDialog(RefInfo remoteRef) {
@@ -801,6 +814,7 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
           onDeleteOnRemote: isRemoteOnly
               ? () => _openDeleteRemoteBranchDialog(node.ref)
               : null,
+          onFetchRef: isRemoteOnly ? () => _fetchRemoteRef(node.ref) : null,
           // Sourced from isActionEnabled(), not session.conflictActive
           // directly -- single source of truth for checkout availability.
           conflictActive: !isActionEnabled(GbmActionId.branchCheckout, session),

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -7,15 +7,18 @@ import '../../actions/gbm_action_id.dart';
 import '../../data/models/ref_snapshot.dart';
 import '../../data/models/stash_entry.dart';
 import '../../data/repositories/branch_repository.dart';
+import '../../data/repositories/compare_tabs_repository.dart';
 import '../../data/repositories/repo_identity.dart';
 import '../../data/repositories/repo_session_repository.dart';
 import '../../routing/route_paths.dart';
 import '../../theme/gbm_theme.dart';
 import '../../theme/tokens.dart';
+import '../../widgets/gbm_menu.dart';
 import '../../widgets/prompt_text_dialog.dart';
 import '../repo_switcher/repo_switcher_popover.dart';
 import 'branch_tree_builder.dart';
 import 'widgets/branch_tree_item.dart';
+import 'widgets/stash_menu_items.dart';
 
 /// Local branches for the open repository, with checkout-on-tap, plus
 /// create/rename/delete and the multi-select "gone" bulk-delete flow (see
@@ -127,6 +130,79 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     ref
         .read(repoSessionProvider(widget.identity).notifier)
         .deleteBranch(names: <String>[branch.shortName]);
+  }
+
+  void _applyStash(StashEntry stash) {
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .applyStash(stash.index);
+  }
+
+  void _popStash(StashEntry stash) {
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .applyStash(stash.index, pop: true);
+  }
+
+  Future<void> _createBranchFromStash(StashEntry stash) async {
+    final String? name = await promptText(
+      context,
+      title: 'New Branch from Stash',
+      label: 'Branch name',
+    );
+    if (name == null || !mounted) return;
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .branchFromStash(stash.index, name);
+  }
+
+  void _viewStashDiff(StashEntry stash) {
+    context.push(
+      RoutePaths.manageStashesDialogFor(
+        Uri.encodeComponent(widget.identity.workDir),
+        selectIndex: stash.index,
+      ),
+    );
+  }
+
+  // Uses the stash's own commit oid as the Compare tab's left ref -- a
+  // stash entry is a real commit (`git stash` creates one even though it
+  // never gets a branch), so this is the same `left: <ref string>`
+  // mechanism repositoryCompare already uses, not a new capability.
+  void _compareStash(StashEntry stash) {
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
+    final String tabId = ref
+        .read(compareTabsProvider(widget.identity).notifier)
+        .open(left: stash.oid);
+    context.go(RoutePaths.compareFor(repoId, tabId));
+  }
+
+  void _dropStash(StashEntry stash) {
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .dropStash(stash.index);
+  }
+
+  void _openStashContextMenu(
+    BuildContext context,
+    TapDownDetails details,
+    StashEntry stash,
+    bool conflictActive,
+  ) {
+    showGbmContextMenu(
+      context,
+      details.globalPosition,
+      stashMenuItems(
+        onApply: conflictActive ? null : () => _applyStash(stash),
+        onPop: conflictActive ? null : () => _popStash(stash),
+        onCreateBranch: conflictActive
+            ? null
+            : () => _createBranchFromStash(stash),
+        onViewDiff: () => _viewStashDiff(stash),
+        onCompare: () => _compareStash(stash),
+        onDrop: () => _dropStash(stash),
+      ),
+    );
   }
 
   void _deleteSelected() {
@@ -516,7 +592,21 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
                             ),
                           ),
                           ...filteredStashes.map((stash) {
-                            return _buildStashRow(stash, colors);
+                            return _buildStashRow(
+                              stash,
+                              colors,
+                              // Sourced from isActionEnabled(), not
+                              // session.conflictActive directly -- same
+                              // pattern as every other conflict-sensitive
+                              // gate in this file. branchStashChanges is
+                              // the closest existing id (stash apply/pop
+                              // mutate the working tree/index the same way
+                              // creating a stash would).
+                              !isActionEnabled(
+                                GbmActionId.branchStashChanges,
+                                session,
+                              ),
+                            );
                           }),
                         ],
                       ],
@@ -641,7 +731,11 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     );
   }
 
-  Widget _buildStashRow(StashEntry stash, GbmColors colors) {
+  Widget _buildStashRow(
+    StashEntry stash,
+    GbmColors colors,
+    bool conflictActive,
+  ) {
     final now = DateTime.now();
     final stashTime = DateTime.fromMillisecondsSinceEpoch(stash.timestamp);
     final diff = now.difference(stashTime);
@@ -657,36 +751,49 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
       timeStr = '${diff.inDays}d ago';
     }
 
-    return Container(
-      height: GbmSpacing.rowHeightCompact,
-      padding: const EdgeInsets.symmetric(horizontal: GbmSpacing.space2),
-      child: Row(
-        children: <Widget>[
-          const SizedBox(width: GbmSpacing.space2),
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  stash.message,
-                  style: TextStyle(
-                    fontSize: GbmTypography.textSm,
-                    color: colors.textPrimary,
+    return GestureDetector(
+      onSecondaryTapDown: (TapDownDetails details) =>
+          _openStashContextMenu(context, details, stash, conflictActive),
+      child: Container(
+        // No fixed height, unlike a branch row -- this row shows two lines
+        // (message + relative time) rather than one, and rowHeightCompact
+        // (26px) is too short for both at GbmTypography's textSm/textXs
+        // sizes, overflowing the Column below by several pixels. Vertical
+        // padding gives it breathing room instead of pinning a height that
+        // would need recalibrating by hand every time either text style
+        // changes.
+        padding: const EdgeInsets.symmetric(
+          horizontal: GbmSpacing.space2,
+          vertical: GbmSpacing.space1,
+        ),
+        child: Row(
+          children: <Widget>[
+            const SizedBox(width: GbmSpacing.space2),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    stash.message,
+                    style: TextStyle(
+                      fontSize: GbmTypography.textSm,
+                      color: colors.textPrimary,
+                    ),
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-                Text(
-                  timeStr,
-                  style: TextStyle(
-                    fontSize: GbmTypography.textXs,
-                    color: colors.textTertiary,
+                  Text(
+                    timeStr,
+                    style: TextStyle(
+                      fontSize: GbmTypography.textXs,
+                      color: colors.textTertiary,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/app_flutter/lib/features/sidebar/widgets/branch_folder_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_folder_menu_items.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/gbm_menu.dart';
+
+/// `ctxItemsFor('branchFolder')` from gbm_context_menus.dart's 05-J
+/// (Branch folder) -- 4 top-level items, danger last.
+///
+/// The spec's own item list gives the first item one combined label,
+/// "Expand all / Collapse all" -- a design-doc convention for a toggle
+/// whose real text is necessarily state-dependent at runtime. This splits
+/// it into its two concrete per-state strings, the same way 05-F/05-K's
+/// multi-select pluralization is documented as a deliberate divergence
+/// from a literal compound spec label rather than an unimplemented gap.
+///
+/// [onFetchFolder] has no backing capi capability -- `gbm_remote_fetch()`
+/// takes a remote name, not a ref prefix, the same limitation 05-C's
+/// "Fetch this branch" already documents for a single ref -- so it always
+/// renders `enabled: false` rather than being wired to something that
+/// would silently do the wrong thing (or omitted, which would look like a
+/// rendering bug rather than a real absence).
+List<GbmMenuItem> branchFolderMenuItems({
+  required bool isExpanded,
+  required VoidCallback onToggleExpand,
+  required VoidCallback onCopyPrefix,
+  required VoidCallback onDeleteMerged,
+}) {
+  return <GbmMenuItem>[
+    GbmMenuItem(
+      label: isExpanded ? 'Collapse all' : 'Expand all',
+      icon: isExpanded ? Icons.unfold_less : Icons.unfold_more,
+      onTap: onToggleExpand,
+    ),
+    const GbmMenuItem(
+      label: 'Fetch branches in folder',
+      icon: Icons.cloud_download_outlined,
+      enabled: false,
+      onTap: null,
+    ),
+    GbmMenuItem(
+      label: 'Copy folder prefix',
+      icon: Icons.copy,
+      onTap: onCopyPrefix,
+    ),
+    const GbmMenuItem.separator(),
+    GbmMenuItem(
+      label: 'Delete merged branches…',
+      icon: Icons.delete_outline,
+      danger: true,
+      onTap: onDeleteMerged,
+    ),
+  ];
+}

--- a/app_flutter/lib/features/sidebar/widgets/branch_folder_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_folder_menu_items.dart
@@ -12,17 +12,20 @@ import '../../../widgets/gbm_menu.dart';
 /// multi-select pluralization is documented as a deliberate divergence
 /// from a literal compound spec label rather than an unimplemented gap.
 ///
-/// [onFetchFolder] has no backing capi capability -- `gbm_remote_fetch()`
-/// takes a remote name, not a ref prefix, the same limitation 05-C's
-/// "Fetch this branch" already documents for a single ref -- so it always
-/// renders `enabled: false` rather than being wired to something that
-/// would silently do the wrong thing (or omitted, which would look like a
-/// rendering bug rather than a real absence).
+/// [onFetchFolder] is nullable: `gbm_remote_fetch()` now supports fetching
+/// specific refs (see FetchRequest.refs), but only from one remote per
+/// call, so the caller (SidebarPanel, via
+/// branch_tree_builder.dart's `fetchableRefsInFolder`) only wires this when
+/// every fetchable branch in the folder tracks the same single remote --
+/// `null` when there's nothing fetchable or the folder spans more than one
+/// remote, the same "no unambiguous target" treatment 05-D's "Push tag"
+/// gets for multiple remotes.
 List<GbmMenuItem> branchFolderMenuItems({
   required bool isExpanded,
   required VoidCallback onToggleExpand,
   required VoidCallback onCopyPrefix,
   required VoidCallback onDeleteMerged,
+  required VoidCallback? onFetchFolder,
 }) {
   return <GbmMenuItem>[
     GbmMenuItem(
@@ -30,11 +33,11 @@ List<GbmMenuItem> branchFolderMenuItems({
       icon: isExpanded ? Icons.unfold_less : Icons.unfold_more,
       onTap: onToggleExpand,
     ),
-    const GbmMenuItem(
+    GbmMenuItem(
       label: 'Fetch branches in folder',
       icon: Icons.cloud_download_outlined,
-      enabled: false,
-      onTap: null,
+      enabled: onFetchFolder != null,
+      onTap: onFetchFolder,
     ),
     GbmMenuItem(
       label: 'Copy folder prefix',

--- a/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
@@ -7,6 +7,7 @@ import '../../../theme/ref_chip_colors.dart';
 import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_menu.dart';
 import '../../../widgets/lucide_icon.dart';
+import 'tag_menu_items.dart';
 
 class BranchTreeItem extends StatelessWidget {
   const BranchTreeItem({
@@ -21,6 +22,9 @@ class BranchTreeItem extends StatelessWidget {
     this.onMerge,
     this.onPruneRef,
     this.onDeleteOnRemote,
+    this.onPushTag,
+    this.onCompareRef,
+    this.onDeleteTag,
     this.conflictActive = false,
   });
 
@@ -59,10 +63,20 @@ class BranchTreeItem extends StatelessWidget {
   final VoidCallback? onPruneRef;
   final VoidCallback? onDeleteOnRemote;
 
+  /// 05-D actions -- see [_buildMenuItems]'s branch on
+  /// `ref.kind == RefKind.tag`. [onPushTag] is nullable; see
+  /// tag_menu_items.dart's `onPush` doc comment for why (no single
+  /// unambiguous remote to push to).
+  final VoidCallback? onPushTag;
+  final VoidCallback? onCompareRef;
+  final VoidCallback? onDeleteTag;
+
   /// Whether [ref] is a "remote-only" leaf -- see
   /// `branch_tree_builder.dart`'s `mergeLocalAndRemoteBranches` doc comment
   /// -- rather than a real local branch.
   bool get _isRemoteOnly => ref.kind == RefKind.remoteBranch;
+
+  bool get _isTag => ref.kind == RefKind.tag;
 
   @override
   Widget build(BuildContext context) {
@@ -295,6 +309,18 @@ class BranchTreeItem extends StatelessWidget {
   /// so they are left off rather than wired to something that silently does
   /// the wrong thing.
   List<GbmMenuItem> _buildMenuItems() {
+    if (_isTag) {
+      return tagMenuItems(
+        tagName: ref.shortName,
+        onCheckoutDetached: conflictActive ? null : onCheckout,
+        onPush: onPushTag,
+        // Always wired by SidebarPanel for a tag row -- unlike onPushTag,
+        // neither has a "sometimes genuinely unavailable" case (see
+        // tag_menu_items.dart's doc comment).
+        onCompare: onCompareRef!,
+        onDelete: onDeleteTag!,
+      );
+    }
     if (_isRemoteOnly) {
       return _buildRemoteOnlyMenuItems();
     }

--- a/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
@@ -22,6 +22,7 @@ class BranchTreeItem extends StatelessWidget {
     this.onMerge,
     this.onPruneRef,
     this.onDeleteOnRemote,
+    this.onFetchRef,
     this.onPushTag,
     this.onCompareRef,
     this.onDeleteTag,
@@ -59,9 +60,12 @@ class BranchTreeItem extends StatelessWidget {
   /// remote-tracking ref either way); [onDeleteOnRemote] only for a
   /// remote-only row -- a gone row's "Delete on remote…" is permanently
   /// disabled (see [_buildGoneMenuItems]'s doc comment), so there is
-  /// nothing for a caller to wire there.
+  /// nothing for a caller to wire there. [onFetchRef] is the same: wired
+  /// only for a remote-only row -- a gone row's own upstream is already
+  /// vanished, so "Fetch this branch" is permanently disabled there too.
   final VoidCallback? onPruneRef;
   final VoidCallback? onDeleteOnRemote;
+  final VoidCallback? onFetchRef;
 
   /// 05-D actions -- see [_buildMenuItems]'s branch on
   /// `ref.kind == RefKind.tag`. [onPushTag] is nullable; see
@@ -223,17 +227,21 @@ class BranchTreeItem extends StatelessWidget {
   }
 
   /// 05-C (remote-only branch), scoped to what this app already has a real
-  /// destination for. Omits "Fetch this branch": `gbm_remote_fetch()` only
-  /// fetches an entire remote (no per-ref fetch in `gbm_capi.h`), and
-  /// approximating it with a whole-remote fetch would silently do more than
-  /// the label promises, so it's left off rather than wired to the wrong
-  /// thing -- same reasoning as `commit_row.dart`'s omitted menu items.
+  /// destination for. "Fetch this branch" is wired to [onFetchRef] --
+  /// `gbm_remote_fetch()` gained an optional per-ref list, so this fetches
+  /// just this one ref rather than approximating with a whole-remote fetch.
   List<GbmMenuItem> _buildRemoteOnlyMenuItems() {
     return <GbmMenuItem>[
       GbmMenuItem(
         label: 'Checkout as new local…',
         icon: Icons.call_split,
         onTap: conflictActive ? null : onCheckout,
+      ),
+      GbmMenuItem(
+        label: 'Fetch this branch',
+        icon: Icons.cloud_download_outlined,
+        enabled: onFetchRef != null,
+        onTap: onFetchRef,
       ),
       GbmMenuItem(
         label: 'Copy branch name',
@@ -270,12 +278,21 @@ class BranchTreeItem extends StatelessWidget {
   /// the vanished remote-tracking ref itself (`git branch --delete
   /// --remotes`), leaving the local branch untouched, per BRANCH_STATES's
   /// note: "真正移除 remote-tracking ref 要執行 Prune". "Fetch this branch"
-  /// is omitted for the same capi reason as [_buildRemoteOnlyMenuItems].
+  /// gets the same permanent-disabled treatment as "Checkout as new
+  /// local…" and "Delete on remote…" -- a gone row's own upstream is what
+  /// vanished, so there is nothing left to fetch until a Prune (or a fresh
+  /// push) clears or restores it, matching the spec's own "其餘停用".
   List<GbmMenuItem> _buildGoneMenuItems() {
     return <GbmMenuItem>[
       const GbmMenuItem(
         label: 'Checkout as new local…',
         icon: Icons.call_split,
+        enabled: false,
+        onTap: null,
+      ),
+      const GbmMenuItem(
+        label: 'Fetch this branch',
+        icon: Icons.cloud_download_outlined,
         enabled: false,
         onTap: null,
       ),

--- a/app_flutter/lib/features/sidebar/widgets/stash_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/stash_menu_items.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/gbm_menu.dart';
+
+/// `ctxItemsFor('stash')` from gbm_context_menus.dart's 05-H (Stash entry)
+/// -- 6 top-level items, danger last.
+///
+/// [onApply]/[onPop]/[onCreateBranch] are nullable: like TabRow's
+/// Merge/Cherry-pick/Reset (see its `conflictActive` doc comment), all
+/// three touch the working tree/index (apply and pop the same way a merge
+/// would, `git stash branch` additionally checks out a new branch), so the
+/// caller passes `null` for each while a conflict is active rather than
+/// this widget re-deriving `session.conflictActive` itself. [onViewDiff]/
+/// [onCompare]/[onDrop] stay enabled regardless -- none of the three
+/// touches the current HEAD, index, or working tree.
+List<GbmMenuItem> stashMenuItems({
+  required VoidCallback? onApply,
+  required VoidCallback? onPop,
+  required VoidCallback? onCreateBranch,
+  required VoidCallback onViewDiff,
+  required VoidCallback onCompare,
+  required VoidCallback onDrop,
+}) {
+  return <GbmMenuItem>[
+    GbmMenuItem(
+      label: 'Apply stash',
+      icon: Icons.unarchive_outlined,
+      onTap: onApply,
+    ),
+    GbmMenuItem(
+      label: 'Pop stash',
+      icon: Icons.move_to_inbox_outlined,
+      onTap: onPop,
+    ),
+    GbmMenuItem(
+      label: 'Create branch from stash…',
+      icon: Icons.call_split,
+      onTap: onCreateBranch,
+    ),
+    GbmMenuItem(
+      label: 'View diff',
+      icon: Icons.difference_outlined,
+      onTap: onViewDiff,
+    ),
+    GbmMenuItem(
+      label: 'Compare with…',
+      icon: Icons.compare_arrows,
+      onTap: onCompare,
+    ),
+    const GbmMenuItem.separator(),
+    GbmMenuItem(
+      label: 'Drop stash…',
+      icon: Icons.delete_outline,
+      danger: true,
+      onTap: onDrop,
+    ),
+  ];
+}

--- a/app_flutter/lib/features/sidebar/widgets/stash_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/stash_menu_items.dart
@@ -25,16 +25,19 @@ List<GbmMenuItem> stashMenuItems({
     GbmMenuItem(
       label: 'Apply stash',
       icon: Icons.unarchive_outlined,
+      enabled: onApply != null,
       onTap: onApply,
     ),
     GbmMenuItem(
       label: 'Pop stash',
       icon: Icons.move_to_inbox_outlined,
+      enabled: onPop != null,
       onTap: onPop,
     ),
     GbmMenuItem(
       label: 'Create branch from stash…',
       icon: Icons.call_split,
+      enabled: onCreateBranch != null,
       onTap: onCreateBranch,
     ),
     GbmMenuItem(

--- a/app_flutter/lib/features/sidebar/widgets/tag_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/tag_menu_items.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../widgets/gbm_menu.dart';
+
+/// `ctxItemsFor('tag')` from gbm_context_menus.dart's 05-D (Tag) -- 5
+/// top-level items, danger last.
+///
+/// [onCheckoutDetached] is nullable: like TabRow's Merge/Cherry-pick/Reset
+/// (see its `conflictActive` doc comment), checking out a tag moves HEAD,
+/// so the caller passes `null` while a conflict is active rather than this
+/// widget re-deriving `session.conflictActive` itself.
+///
+/// [onPush] is nullable for a different reason: unlike a repository-level
+/// push (`gbm_push`, where an empty remote name falls back to the branch's
+/// configured remote), `gbm_tag_push` runs
+/// `git push <remoteName> refs/tags/<name>` with whatever remote name it's
+/// given -- there is no "empty means default" support, and picking the
+/// right one among several needs a picker this menu doesn't have. The
+/// caller passes `null` when there isn't exactly one remote to push to
+/// unambiguously.
+List<GbmMenuItem> tagMenuItems({
+  required String tagName,
+  required VoidCallback? onCheckoutDetached,
+  required VoidCallback? onPush,
+  required VoidCallback onCompare,
+  required VoidCallback onDelete,
+}) {
+  return <GbmMenuItem>[
+    GbmMenuItem(
+      label: 'Checkout tag (detached)',
+      icon: Icons.call_split,
+      onTap: onCheckoutDetached,
+    ),
+    GbmMenuItem(
+      label: 'Push tag',
+      icon: Icons.cloud_upload_outlined,
+      onTap: onPush,
+    ),
+    GbmMenuItem(
+      label: 'Compare with…',
+      icon: Icons.compare_arrows,
+      onTap: onCompare,
+    ),
+    GbmMenuItem(
+      label: 'Copy tag name',
+      icon: Icons.copy,
+      onTap: () => Clipboard.setData(ClipboardData(text: tagName)),
+    ),
+    const GbmMenuItem.separator(),
+    GbmMenuItem(
+      label: 'Delete tag…',
+      icon: Icons.delete_outline,
+      danger: true,
+      onTap: onDelete,
+    ),
+  ];
+}

--- a/app_flutter/lib/features/sidebar/widgets/tag_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/tag_menu_items.dart
@@ -30,11 +30,13 @@ List<GbmMenuItem> tagMenuItems({
     GbmMenuItem(
       label: 'Checkout tag (detached)',
       icon: Icons.call_split,
+      enabled: onCheckoutDetached != null,
       onTap: onCheckoutDetached,
     ),
     GbmMenuItem(
       label: 'Push tag',
       icon: Icons.cloud_upload_outlined,
+      enabled: onPush != null,
       onTap: onPush,
     ),
     GbmMenuItem(

--- a/app_flutter/lib/features/workspace/widgets/workspace_tab.dart
+++ b/app_flutter/lib/features/workspace/widgets/workspace_tab.dart
@@ -75,3 +75,19 @@ int activeWorkspaceTabIndex(List<WorkspaceTab> tabs, String location) {
   );
   return index == -1 ? 0 : index;
 }
+
+/// The route `GbmActionId.viewNextTab` (View > Next tab, Ctrl/Cmd+Tab)
+/// navigates to: whichever [WorkspaceTab] follows the one matching
+/// [location] in [tabs], wrapping from the last tab back to the first.
+/// Built on [activeWorkspaceTabIndex], so a [location] matching no tab
+/// (e.g. a dialog pushed on top) advances from the same index-0 fallback
+/// that helper already defines, rather than a separate special case here.
+/// [tabs] is never empty in practice (the two fixed tabs always exist,
+/// see [defaultWorkspaceTabs]) -- a single-tab list is handled by wrapping
+/// to itself rather than asserting, since nothing about "next tab" implies
+/// there must be more than one.
+String nextWorkspaceTabRoute(List<WorkspaceTab> tabs, String location) {
+  final int current = activeWorkspaceTabIndex(tabs, location);
+  final int next = (current + 1) % tabs.length;
+  return tabs[next].route;
+}

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -471,16 +471,14 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
       // existing working directory -- and both go through the same path
       // prompt the switcher popover's footer uses, since this app has no
       // native folder-picker dependency (see pubspec.yaml). Opening one
-      // records it in the manually-opened list (spec page 11 item 6).
-      //
-      // New and Clone are disabled rather than routed somewhere plausible:
-      // neither `git init` nor clone exists anywhere below this layer (no
-      // entry point in gbm_capi.h, nothing in src/core), so there is
-      // nothing for them to call. They used to navigate to the repository
-      // list, which never created or cloned anything either.
-      GbmActionId.fileNewRepository: null,
+      // records it in the manually-opened list (spec page 11 item 6). New
+      // and Clone share the same footer entry points too -- see
+      // promptNewRepository()/promptCloneRepository() in
+      // repo_switcher_popover.dart.
+      GbmActionId.fileNewRepository: () => promptNewRepository(context, ref),
       GbmActionId.fileOpenRepository: () => promptOpenRepository(context),
-      GbmActionId.fileCloneRepository: null,
+      GbmActionId.fileCloneRepository: () =>
+          promptCloneRepository(context, ref),
       GbmActionId.fileSwitchRepository: () {
         // Same reveal-then-act pattern as editFilterBranches below: the
         // popover anchors to the sidebar's repository button, which is not

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -38,6 +38,7 @@ import 'widgets/platform_menu_bar_host.dart';
 import 'widgets/tab_row.dart';
 import 'widgets/top_bar.dart';
 import 'widgets/workspace_action_shortcuts.dart';
+import 'widgets/workspace_tab.dart';
 
 /// The repository shell: menu bar + top bar + tab switcher + sidebar, with
 /// `child` (History or Working Copy, see routing/app_router.dart's
@@ -543,7 +544,25 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
       GbmActionId.viewHistory: () => context.go(RoutePaths.historyFor(repoId)),
       GbmActionId.viewWorkingCopy: () =>
           context.go(RoutePaths.workingCopyFor(repoId)),
-      GbmActionId.viewNextTab: null,
+      // Cycles History -> Working Copy -> each open Compare tab (in the
+      // order TabRow renders them) -> back to History. Built on the same
+      // `tabs`/`location` shape TabRow itself derives its active tab from
+      // (see tab_row.dart's build()), so the two never disagree about tab
+      // order.
+      GbmActionId.viewNextTab: () {
+        final List<WorkspaceTab> tabs = <WorkspaceTab>[
+          ...defaultWorkspaceTabs(
+            repoId,
+            pendingChangeCount: session.workingCopyStatus.entries.length,
+          ),
+          for (final CompareTabSpec spec in ref.read(
+            compareTabsProvider(identity),
+          ))
+            compareWorkspaceTab(spec, repoId),
+        ];
+        final String location = GoRouterState.of(context).uri.toString();
+        context.go(nextWorkspaceTabRoute(tabs, location));
+      },
       GbmActionId.viewFileListAsTree: () async {
         final currentMode = ref.read(fileListViewModeProvider);
         final newMode = currentMode == FileListViewMode.list

--- a/app_flutter/lib/routing/app_router.dart
+++ b/app_flutter/lib/routing/app_router.dart
@@ -202,7 +202,12 @@ final Provider<GoRouter> appRouterProvider = Provider<GoRouter>((ref) {
           final RepoIdentity identity = repoIdentityFromRouteParam(
             state.pathParameters['repoId']!,
           );
-          return ManageStashesDialogContent(identity: identity);
+          return ManageStashesDialogContent(
+            identity: identity,
+            initialSelectedIndex: int.tryParse(
+              state.uri.queryParameters['index'] ?? '',
+            ),
+          );
         },
       ),
       dialogRoute(

--- a/app_flutter/lib/routing/route_paths.dart
+++ b/app_flutter/lib/routing/route_paths.dart
@@ -101,8 +101,21 @@ abstract final class RoutePaths {
       '/repo/$repoId/dialogs/cherry-pick';
   static String stashChangesDialogFor(String repoId) =>
       '/repo/$repoId/dialogs/stash-changes';
-  static String manageStashesDialogFor(String repoId) =>
-      '/repo/$repoId/dialogs/manage-stashes';
+
+  /// [selectIndex] pre-selects a stash entry (and its diff) on open --
+  /// used by the sidebar's stash context menu's "View diff" item so
+  /// clicking it doesn't land on ManageStashesDialogContent's default
+  /// "Select a stash" empty state.
+  static String manageStashesDialogFor(String repoId, {int? selectIndex}) {
+    if (selectIndex == null) {
+      return '/repo/$repoId/dialogs/manage-stashes';
+    }
+    return Uri(
+      path: '/repo/$repoId/dialogs/manage-stashes',
+      queryParameters: <String, String>{'index': '$selectIndex'},
+    ).toString();
+  }
+
   static String manageWorktreesDialogFor(String repoId) =>
       '/repo/$repoId/dialogs/manage-worktrees';
   static String manageRemotesDialogFor(String repoId) =>

--- a/app_flutter/test/data/services/desktop_launcher_test.dart
+++ b/app_flutter/test/data/services/desktop_launcher_test.dart
@@ -132,9 +132,11 @@ void main() {
       );
 
       await launcher.openTerminal('/home/x/my repo; rm -rf /');
-      expect(starter.args.single, <String>[
-        '--working-directory=/home/x/my repo; rm -rf /',
-      ], reason: 'arguments are passed as a list, never through a shell');
+      expect(
+        starter.args.single,
+        <String>['--working-directory=/home/x/my repo; rm -rf /'],
+        reason: 'arguments are passed as a list, never through a shell',
+      );
     });
   });
 
@@ -175,12 +177,11 @@ void main() {
       );
 
       await launcher.openUrl('https://example.com');
-      expect(starter.args.single, <String>[
-        '/c',
-        'start',
-        '',
-        'https://example.com',
-      ], reason: 'without the title argument, start consumes the URL as one');
+      expect(
+        starter.args.single,
+        <String>['/c', 'start', '', 'https://example.com'],
+        reason: 'without the title argument, start consumes the URL as one',
+      );
     });
   });
 }

--- a/app_flutter/test/features/conflict_resolution/conflict_hunk_context_menu_test.dart
+++ b/app_flutter/test/features/conflict_resolution/conflict_hunk_context_menu_test.dart
@@ -1,0 +1,361 @@
+// Verifies the 05-I (Conflict hunk) context menu -- a right-click on a
+// line inside either side pane of ConflictResolveWindow -- reaches the
+// real per-region ConflictLineOrderState the same way the existing
+// click/drag interactions do. conflict_hunk_menu_items_test.dart already
+// covers the item list itself in isolation; this covers the dispatch
+// path that tier structurally cannot, the same gap closed for
+// 05-C/05-H/05-D/05-J. Mirrors conflict_resolve_window_test.dart's
+// `_pumpWindow` harness (that file's own private helpers aren't
+// importable from here).
+import 'dart:ui' as ui;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/parsed_conflict_file.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart'
+    show RepoSessionState, WorkingTreeContentReply, repoSessionProvider;
+import 'package:gbm_flutter/features/conflict_resolution/conflict_resolve_window.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+ConflictSegment _regionSegment({
+  required List<String> ours,
+  required List<String> theirs,
+}) => ConflictSegment(
+  kind: ConflictSegmentKind.region,
+  lines: const <String>[],
+  ours: ours,
+  theirs: theirs,
+  base: const <String>[],
+  hasBase: false,
+);
+
+const WorkingCopyEntry _conflictEntry = WorkingCopyEntry(
+  path: 'conflict.txt',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+RepoSessionState _sessionWith(WorkingCopyEntry entry) => RepoSessionState(
+  isOpen: true,
+  workingCopyStatus: WorkingCopyStatus(entries: [entry]),
+  lastWorkingTreeContent: WorkingTreeContentReply(
+    path: entry.path,
+    editable: true,
+    content: '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n',
+  ),
+);
+
+Future<void> _selectConflictFile(WidgetTester tester) async {
+  await tester.tap(find.text('conflict.txt'));
+  await tester.pumpAndSettle();
+}
+
+/// Once a region is resolved, its assembled text also appears in the
+/// bottom "Result (editable)" TextField, and the source line stays
+/// visible in its own side pane too -- so a bare `find.text(line)` can
+/// become ambiguous after a region resolves. Scopes to the "Ours"/
+/// "Theirs" side pane's own Container (same ancestor pattern
+/// conflict_resolve_window_test.dart's own tests use), which is the one
+/// place the source line always renders exactly once regardless of
+/// resolution state.
+Finder _sourceLine(String paneLabel, String line) => find.descendant(
+  of: find.ancestor(of: find.text(paneLabel), matching: find.byType(Container)),
+  matching: find.text(line),
+);
+
+Future<void> _rightClick(WidgetTester tester, Finder finder) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(finder));
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pumpWindow(
+  WidgetTester tester,
+  RepoIdentity identity,
+  RepoSessionState sessionState,
+  ParsedConflictFile parsedFile,
+) async {
+  // Same sizing as conflict_resolve_window_test.dart's _pumpWindow -- the
+  // three-column layout overflows flutter_test's default surface
+  // otherwise.
+  tester.view.physicalSize = const ui.Size(1400, 900);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  final GoRouter router = GoRouter(
+    initialLocation: RoutePaths.conflictsFor(
+      Uri.encodeComponent(identity.workDir),
+    ),
+    routes: <RouteBase>[
+      GoRoute(
+        path: RoutePaths.conflicts,
+        builder: (context, state) =>
+            ConflictResolveWindow(identity: identity, isMacOS: false),
+      ),
+    ],
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoSessionProvider(identity).overrideWith(
+        (ref) => FakeRepoSessionController(
+          identity,
+          sessionState,
+          parsedFile: parsedFile,
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  final RepoIdentity identity = RepoIdentity(
+    workDir: '/test/repo',
+    gitDir: '/test/repo/.git',
+  );
+
+  group('conflict hunk context menu (05-I)', () {
+    testWidgets('right-clicking a line in a side pane opens its 05-I menu', (
+      tester,
+    ) async {
+      final parsed = ParsedConflictFile(
+        segments: <ConflictSegment>[
+          _regionSegment(
+            ours: <String>['ours-line'],
+            theirs: <String>['theirs-line'],
+          ),
+        ],
+        regionCount: 1,
+        wellFormed: true,
+      );
+      await _pumpWindow(tester, identity, _sessionWith(_conflictEntry), parsed);
+      await _selectConflictFile(tester);
+
+      await _rightClick(tester, find.text('ours-line'));
+
+      expect(find.text('Take this side'), findsOneWidget);
+      expect(find.text('Take this line only'), findsOneWidget);
+      expect(find.text('Take both — this side first'), findsOneWidget);
+      expect(find.text('Open in external merge tool'), findsOneWidget);
+      expect(find.text('Discard from result'), findsOneWidget);
+    });
+
+    testWidgets('Take this side appends every line of that side, not just '
+        'the clicked one', (tester) async {
+      final parsed = ParsedConflictFile(
+        segments: <ConflictSegment>[
+          _regionSegment(
+            ours: <String>['ours-a', 'ours-b'],
+            theirs: <String>['theirs-a'],
+          ),
+        ],
+        regionCount: 1,
+        wellFormed: true,
+      );
+      await _pumpWindow(tester, identity, _sessionWith(_conflictEntry), parsed);
+      await _selectConflictFile(tester);
+
+      await _rightClick(tester, find.text('ours-a'));
+      await tester.tap(find.text('Take this side'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('①'), findsOneWidget);
+      expect(find.text('②'), findsOneWidget);
+    });
+
+    testWidgets('Take this line only appends just the clicked line', (
+      tester,
+    ) async {
+      final parsed = ParsedConflictFile(
+        segments: <ConflictSegment>[
+          _regionSegment(
+            ours: <String>['ours-a', 'ours-b'],
+            theirs: <String>['theirs-a'],
+          ),
+        ],
+        regionCount: 1,
+        wellFormed: true,
+      );
+      await _pumpWindow(tester, identity, _sessionWith(_conflictEntry), parsed);
+      await _selectConflictFile(tester);
+
+      await _rightClick(tester, find.text('ours-b'));
+      await tester.tap(find.text('Take this line only'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('①'), findsOneWidget);
+      expect(find.text('②'), findsNothing);
+    });
+
+    testWidgets(
+      'Take both — this side first appends this side\'s lines, then the '
+      'other side\'s',
+      (tester) async {
+        final parsed = ParsedConflictFile(
+          segments: <ConflictSegment>[
+            _regionSegment(
+              ours: <String>['ours-a'],
+              theirs: <String>['theirs-a'],
+            ),
+          ],
+          regionCount: 1,
+          wellFormed: true,
+        );
+        await _pumpWindow(
+          tester,
+          identity,
+          _sessionWith(_conflictEntry),
+          parsed,
+        );
+        await _selectConflictFile(tester);
+
+        await _rightClick(tester, find.text('ours-a'));
+        await tester.tap(find.text('Take both — this side first'));
+        await tester.pumpAndSettle();
+
+        // Both lines now appear twice each: once in their own source side
+        // pane, once in the result -- ① is this side's (ours), ② is the
+        // other side's (theirs), confirming both landed and in order.
+        expect(find.text('①'), findsOneWidget);
+        expect(find.text('②'), findsOneWidget);
+        expect(find.text('Resolved'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Discard from result is disabled while the region has nothing in '
+      'its result yet',
+      (tester) async {
+        final parsed = ParsedConflictFile(
+          segments: <ConflictSegment>[
+            _regionSegment(
+              ours: <String>['ours-a'],
+              theirs: <String>['theirs-a'],
+            ),
+          ],
+          regionCount: 1,
+          wellFormed: true,
+        );
+        await _pumpWindow(
+          tester,
+          identity,
+          _sessionWith(_conflictEntry),
+          parsed,
+        );
+        await _selectConflictFile(tester);
+
+        expect(find.text('Unresolved'), findsOneWidget);
+
+        await _rightClick(tester, find.text('ours-a'));
+        await tester.tap(find.text('Discard from result'));
+        await tester.pumpAndSettle();
+
+        // No crash and no change -- disabled items simply no-op on tap.
+        expect(find.text('Unresolved'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Discard from result resets the region back to unresolved once it '
+      'has something to discard',
+      (tester) async {
+        final parsed = ParsedConflictFile(
+          segments: <ConflictSegment>[
+            _regionSegment(
+              ours: <String>['ours-a'],
+              theirs: <String>['theirs-a'],
+            ),
+          ],
+          regionCount: 1,
+          wellFormed: true,
+        );
+        await _pumpWindow(
+          tester,
+          identity,
+          _sessionWith(_conflictEntry),
+          parsed,
+        );
+        await _selectConflictFile(tester);
+
+        await _rightClick(tester, find.text('ours-a'));
+        await tester.tap(find.text('Take this side'));
+        await tester.pumpAndSettle();
+        expect(find.text('Resolved'), findsOneWidget);
+
+        await _rightClick(tester, _sourceLine('Ours', 'ours-a'));
+        await tester.tap(find.text('Discard from result'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Unresolved'), findsOneWidget);
+        expect(find.text('Resolved'), findsNothing);
+      },
+    );
+
+    testWidgets('Open in external merge tool is disabled -- no external tool '
+        'integration exists', (tester) async {
+      final parsed = ParsedConflictFile(
+        segments: <ConflictSegment>[
+          _regionSegment(
+            ours: <String>['ours-a'],
+            theirs: <String>['theirs-a'],
+          ),
+        ],
+        regionCount: 1,
+        wellFormed: true,
+      );
+      await _pumpWindow(tester, identity, _sessionWith(_conflictEntry), parsed);
+      await _selectConflictFile(tester);
+
+      await _rightClick(tester, find.text('ours-a'));
+      await tester.tap(find.text('Open in external merge tool'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unresolved'), findsOneWidget);
+    });
+  });
+}

--- a/app_flutter/test/features/conflict_resolution/conflict_hunk_menu_items_test.dart
+++ b/app_flutter/test/features/conflict_resolution/conflict_hunk_menu_items_test.dart
@@ -1,0 +1,109 @@
+// Pure-Dart unit tests for conflictHunkMenuItems() -- no widget pump
+// needed. Verifies the item list matches gbm_context_menus.dart's 05-I
+// (Conflict hunk) spec exactly, that "Open in external merge tool" always
+// renders disabled (no backing capability), and that "Discard from
+// result" goes through the nullable-callback gate for a region with
+// nothing in its result yet.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/context_menus/gbm_context_menus.dart';
+import 'package:gbm_flutter/features/conflict_resolution/conflict_hunk_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+void main() {
+  group('conflictHunkMenuItems', () {
+    test('labels and order match gbmContextMenuGroups 05-I exactly', () {
+      final List<GbmMenuItem> items = conflictHunkMenuItems(
+        onTakeThisSide: () {},
+        onTakeThisLineOnly: () {},
+        onTakeBoth: () {},
+        onDiscardFromResult: () {},
+      );
+
+      final List<String> actualLabels = items
+          .where((GbmMenuItem item) => !item.separator)
+          .map((GbmMenuItem item) => item.label)
+          .toList();
+      final List<String> specLabels =
+          gbmContextMenuGroups[GbmContextMenuTarget.conflictHunk]!.items
+              .map((GbmContextMenuItemSpec spec) => spec.label)
+              .toList();
+
+      expect(actualLabels, specLabels);
+    });
+
+    test('Discard from result is last, is danger, preceded by a separator', () {
+      final List<GbmMenuItem> items = conflictHunkMenuItems(
+        onTakeThisSide: () {},
+        onTakeThisLineOnly: () {},
+        onTakeBoth: () {},
+        onDiscardFromResult: () {},
+      );
+
+      expect(items.last.label, 'Discard from result');
+      expect(items.last.danger, isTrue);
+      expect(items[items.length - 2].separator, isTrue);
+    });
+
+    test('Open in external merge tool always renders disabled', () {
+      final List<GbmMenuItem> items = conflictHunkMenuItems(
+        onTakeThisSide: () {},
+        onTakeThisLineOnly: () {},
+        onTakeBoth: () {},
+        onDiscardFromResult: () {},
+      );
+      final GbmMenuItem item = items.firstWhere(
+        (GbmMenuItem i) => i.label == 'Open in external merge tool',
+      );
+      expect(item.enabled, isFalse);
+      expect(item.onTap, isNull);
+    });
+
+    test('onDiscardFromResult: null renders Discard from result disabled, '
+        'other items unaffected', () {
+      final List<GbmMenuItem> items = conflictHunkMenuItems(
+        onTakeThisSide: () {},
+        onTakeThisLineOnly: () {},
+        onTakeBoth: () {},
+        onDiscardFromResult: null,
+      );
+
+      final Map<String, GbmMenuItem> byLabel = <String, GbmMenuItem>{
+        for (final GbmMenuItem item in items)
+          if (!item.separator) item.label: item,
+      };
+
+      expect(byLabel['Discard from result']!.onTap, isNull);
+      expect(byLabel['Take this side']!.onTap, isNotNull);
+      expect(byLabel['Take this line only']!.onTap, isNotNull);
+      expect(byLabel['Take both — this side first']!.onTap, isNotNull);
+    });
+
+    test('each callback reaches its matching item, not a neighbor', () {
+      bool tookSide = false;
+      bool tookLine = false;
+      bool discarded = false;
+
+      final List<GbmMenuItem> items = conflictHunkMenuItems(
+        onTakeThisSide: () => tookSide = true,
+        onTakeThisLineOnly: () => tookLine = true,
+        onTakeBoth: () {},
+        onDiscardFromResult: () => discarded = true,
+      );
+
+      items.firstWhere((GbmMenuItem i) => i.label == 'Take this side').onTap!();
+      expect(tookSide, isTrue);
+      expect(tookLine, isFalse);
+      expect(discarded, isFalse);
+
+      items
+          .firstWhere((GbmMenuItem i) => i.label == 'Take this line only')
+          .onTap!();
+      expect(tookLine, isTrue);
+
+      items
+          .firstWhere((GbmMenuItem i) => i.label == 'Discard from result')
+          .onTap!();
+      expect(discarded, isTrue);
+    });
+  });
+}

--- a/app_flutter/test/features/conflict_resolution/conflict_hunk_menu_items_test.dart
+++ b/app_flutter/test/features/conflict_resolution/conflict_hunk_menu_items_test.dart
@@ -73,6 +73,7 @@ void main() {
       };
 
       expect(byLabel['Discard from result']!.onTap, isNull);
+      expect(byLabel['Discard from result']!.enabled, isFalse);
       expect(byLabel['Take this side']!.onTap, isNotNull);
       expect(byLabel['Take this line only']!.onTap, isNotNull);
       expect(byLabel['Take both — this side first']!.onTap, isNotNull);

--- a/app_flutter/test/features/dialogs/manage_remotes/manage_remotes_dialog_test.dart
+++ b/app_flutter/test/features/dialogs/manage_remotes/manage_remotes_dialog_test.dart
@@ -1,0 +1,136 @@
+// Verifies ManageRemotesDialogContent's Add/Remove wiring reaches the
+// real repoSessionProvider seam -- Phase 3 of the project-gaps plan:
+// `git remote add`/`remove` now exist end-to-end (core -> capi -> FFI ->
+// this dialog), closing the gap CLAUDE.md's "Known gaps" section used to
+// document ("no entry point exists").
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/remote_info.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/manage_remotes/manage_remotes_dialog.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+
+import '../../../support/fake_repo_session.dart';
+
+final RepoIdentity _testIdentity = RepoIdentity.forWorkDir('/test/repo');
+
+const RemoteInfo _origin = RemoteInfo(
+  name: 'origin',
+  fetchUrl: 'https://example.com/repo.git',
+  pushUrl: 'https://example.com/repo.git',
+);
+
+Future<FakeRepoSessionController> _pump(
+  WidgetTester tester, {
+  RepoSessionState initialState = const RepoSessionState(),
+}) async {
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _testIdentity,
+    initialState,
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      repoSessionProvider(_testIdentity).overrideWith((ref) => fake),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        home: ManageRemotesDialogContent(identity: _testIdentity),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  return fake;
+}
+
+void main() {
+  group('ManageRemotesDialogContent', () {
+    testWidgets('Add remote… with both fields filled reaches addRemote', (
+      tester,
+    ) async {
+      final FakeRepoSessionController fake = await _pump(tester);
+
+      await tester.tap(find.text('Add remote…'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Name'),
+        'upstream',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'URL'),
+        'git@example.com:upstream/repo.git',
+      );
+      await tester.tap(find.text('Add'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand cmd = fake.commandLog.singleWhere(
+        (c) => c.name == 'addRemote',
+      );
+      expect(cmd.args['name'], 'upstream');
+      expect(cmd.args['url'], 'git@example.com:upstream/repo.git');
+    });
+
+    testWidgets('Cancel does not reach addRemote', (tester) async {
+      final FakeRepoSessionController fake = await _pump(tester);
+
+      await tester.tap(find.text('Add remote…'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Name'),
+        'upstream',
+      );
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(fake.commandLog.any((c) => c.name == 'addRemote'), isFalse);
+    });
+
+    testWidgets('Add with an empty URL does not reach addRemote (both fields '
+        'required)', (tester) async {
+      final FakeRepoSessionController fake = await _pump(tester);
+
+      await tester.tap(find.text('Add remote…'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Name'),
+        'upstream',
+      );
+      // URL left empty.
+      await tester.tap(find.text('Add'));
+      await tester.pumpAndSettle();
+
+      expect(fake.commandLog.any((c) => c.name == 'addRemote'), isFalse);
+      // The dialog stays open on invalid input rather than silently
+      // closing -- the Add button is still there to retry.
+      expect(find.text('Add'), findsOneWidget);
+    });
+
+    testWidgets('Remove reaches removeRemote with that remote\'s name', (
+      tester,
+    ) async {
+      final FakeRepoSessionController fake = await _pump(
+        tester,
+        initialState: const RepoSessionState(remotes: <RemoteInfo>[_origin]),
+      );
+
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand cmd = fake.commandLog.singleWhere(
+        (c) => c.name == 'removeRemote',
+      );
+      expect(cmd.args['name'], 'origin');
+    });
+  });
+}

--- a/app_flutter/test/features/repo_switcher/repo_switcher_init_clone_test.dart
+++ b/app_flutter/test/features/repo_switcher/repo_switcher_init_clone_test.dart
@@ -1,0 +1,272 @@
+// Covers promptNewRepository()/promptCloneRepository() in
+// repo_switcher_popover.dart: File → New repository…/Clone repository… and
+// the switcher popover footer's Clone repository… all funnel through these
+// two functions. Both reach gbm_repo_init()/gbm_repo_clone() directly via
+// gbmBindingsProvider (there is no session yet for a RepoSessionController
+// to dispatch through), so this drives a configurable fake GbmBindings
+// rather than a FakeRepoSessionController.
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/ffi/gbm_bindings.dart';
+import 'package:gbm_flutter/data/repositories/gbm_bindings_provider.dart';
+import 'package:gbm_flutter/features/repo_switcher/repo_switcher_popover.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+
+class _FakeInitCloneBindings implements GbmBindings {
+  int initResult = 0;
+  int cloneResult = 0;
+  String errorJson = '';
+  String? lastInitPath;
+  String? lastCloneUrl;
+  String? lastCloneDest;
+
+  @override
+  RepoInitDart get repoInit => (Pointer<Utf8> path) {
+    lastInitPath = path.toDartString();
+    return initResult;
+  };
+
+  @override
+  RepoCloneDart get repoClone => (Pointer<Utf8> url, Pointer<Utf8> destPath) {
+    lastCloneUrl = url.toDartString();
+    lastCloneDest = destPath.toDartString();
+    return cloneResult;
+  };
+
+  @override
+  LastResultJsonLenDart get lastResultJsonLen =>
+      () => utf8ByteLength(errorJson);
+
+  @override
+  LastResultJsonCopyDart get lastResultJsonCopy =>
+      (Pointer<Uint8> out, int outLen) {
+        final List<int> bytes = errorJson.codeUnits;
+        for (int i = 0; i < outLen && i < bytes.length; i++) {
+          out[i] = bytes[i];
+        }
+      };
+
+  @override
+  Never noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('Not implemented for testing');
+  }
+}
+
+int utf8ByteLength(String s) => s.codeUnits.length;
+
+Future<GoRouter> _pump(
+  WidgetTester tester,
+  Widget child,
+  _FakeInitCloneBindings bindings,
+) async {
+  final GoRouter router = GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(body: child),
+      ),
+      GoRoute(
+        path: RoutePaths.history,
+        builder: (context, state) => Scaffold(
+          body: Text('workspace: ${state.pathParameters['repoId']}'),
+        ),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[gbmBindingsProvider.overrideWithValue(bindings)],
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return router;
+}
+
+class _NewRepoButton extends ConsumerWidget {
+  const _NewRepoButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ElevatedButton(
+      onPressed: () => promptNewRepository(context, ref),
+      child: const Text('New'),
+    );
+  }
+}
+
+class _CloneRepoButton extends ConsumerWidget {
+  const _CloneRepoButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ElevatedButton(
+      onPressed: () => promptCloneRepository(context, ref),
+      child: const Text('Open Clone Prompt'),
+    );
+  }
+}
+
+void main() {
+  group('promptNewRepository', () {
+    testWidgets('runs gbm_repo_init and switches to the new repository', (
+      tester,
+    ) async {
+      final _FakeInitCloneBindings bindings = _FakeInitCloneBindings();
+      final GoRouter router = await _pump(
+        tester,
+        const _NewRepoButton(),
+        bindings,
+      );
+
+      await tester.tap(find.text('New'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '/repos/new-project');
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(bindings.lastInitPath, '/repos/new-project');
+      expect(
+        router.routerDelegate.currentConfiguration.uri.toString(),
+        RoutePaths.workspaceFor(Uri.encodeComponent('/repos/new-project')),
+      );
+    });
+
+    testWidgets('cancelling the prompt calls gbm_repo_init with nothing', (
+      tester,
+    ) async {
+      final _FakeInitCloneBindings bindings = _FakeInitCloneBindings();
+      await _pump(tester, const _NewRepoButton(), bindings);
+
+      await tester.tap(find.text('New'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(bindings.lastInitPath, isNull);
+    });
+
+    testWidgets('shows the GitError message and stays put when init fails', (
+      tester,
+    ) async {
+      final _FakeInitCloneBindings bindings = _FakeInitCloneBindings()
+        ..initResult = -3
+        ..errorJson =
+            '{"code":2,"codeName":"InvalidArgument",'
+            '"message":"A repository path is required","detail":"",'
+            '"argv":[],"exitCode":0}';
+      final GoRouter router = await _pump(
+        tester,
+        const _NewRepoButton(),
+        bindings,
+      );
+
+      await tester.tap(find.text('New'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '/repos/blocked');
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('A repository path is required'), findsOneWidget);
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/');
+    });
+  });
+
+  group('promptCloneRepository', () {
+    testWidgets(
+      'runs gbm_repo_clone with both fields and switches to the clone',
+      (tester) async {
+        final _FakeInitCloneBindings bindings = _FakeInitCloneBindings();
+        final GoRouter router = await _pump(
+          tester,
+          const _CloneRepoButton(),
+          bindings,
+        );
+
+        await tester.tap(find.text('Open Clone Prompt'));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Repository URL'),
+          'git@github.com:example/repo.git',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Destination path'),
+          '/repos/cloned',
+        );
+        await tester.tap(find.text('Clone'));
+        await tester.pumpAndSettle();
+
+        expect(bindings.lastCloneUrl, 'git@github.com:example/repo.git');
+        expect(bindings.lastCloneDest, '/repos/cloned');
+        expect(
+          router.routerDelegate.currentConfiguration.uri.toString(),
+          RoutePaths.workspaceFor(Uri.encodeComponent('/repos/cloned')),
+        );
+      },
+    );
+
+    testWidgets('does not submit while the destination path is still empty', (
+      tester,
+    ) async {
+      final _FakeInitCloneBindings bindings = _FakeInitCloneBindings();
+      await _pump(tester, const _CloneRepoButton(), bindings);
+
+      await tester.tap(find.text('Open Clone Prompt'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Repository URL'),
+        'git@github.com:example/repo.git',
+      );
+      await tester.tap(find.text('Clone'));
+      await tester.pumpAndSettle();
+
+      expect(bindings.lastCloneUrl, isNull);
+      // The dialog is still open with what was typed still in place.
+      expect(find.text('git@github.com:example/repo.git'), findsOneWidget);
+    });
+
+    testWidgets('shows the GitError message and stays put when clone fails', (
+      tester,
+    ) async {
+      final _FakeInitCloneBindings bindings = _FakeInitCloneBindings()
+        ..cloneResult = -1
+        ..errorJson =
+            '{"code":1,"codeName":"NotFound",'
+            '"message":"repository not found","detail":"",'
+            '"argv":[],"exitCode":128}';
+      final GoRouter router = await _pump(
+        tester,
+        const _CloneRepoButton(),
+        bindings,
+      );
+
+      await tester.tap(find.text('Open Clone Prompt'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Repository URL'),
+        'git@github.com:example/missing.git',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Destination path'),
+        '/repos/cloned',
+      );
+      await tester.tap(find.text('Clone'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('repository not found'), findsOneWidget);
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/');
+    });
+  });
+}

--- a/app_flutter/test/features/sidebar/branch_context_menu_test.dart
+++ b/app_flutter/test/features/sidebar/branch_context_menu_test.dart
@@ -62,6 +62,23 @@ RefInfo _goneBranch({String name = 'feature/gone'}) {
   );
 }
 
+RefInfo _tag({String name = 'v1.0.0'}) {
+  return RefInfo(
+    fullName: 'refs/tags/$name',
+    shortName: name,
+    kind: RefKind.tag,
+    target: 'a' * 40,
+    upstream: '',
+    ahead: 0,
+    behind: 0,
+    hasTrackingInfo: false,
+    isGone: false,
+    isHead: false,
+    isSymbolic: false,
+    worktreePath: '',
+  );
+}
+
 Future<void> _rightClick(WidgetTester tester, Finder finder) async {
   final TestGesture gesture = await tester.createGesture(
     kind: PointerDeviceKind.mouse,
@@ -375,5 +392,152 @@ void main() {
         );
       },
     );
+  });
+
+  group('tag row (05-D)', () {
+    testWidgets('shows the 05-D tag menu, not the 05-B local-branch menu', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _tag(),
+          onCheckout: () {},
+          onPushTag: () {},
+          onCompareRef: () {},
+          onDeleteTag: () {},
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+
+      expect(find.text('Checkout tag (detached)'), findsOneWidget);
+      expect(find.text('Push tag'), findsOneWidget);
+      expect(find.text('Compare with…'), findsOneWidget);
+      expect(find.text('Copy tag name'), findsOneWidget);
+      expect(find.text('Delete tag…'), findsOneWidget);
+      expect(find.text('Rename branch'), findsNothing);
+      expect(find.text('Delete branch'), findsNothing);
+      expect(find.text('Merge into current branch'), findsNothing);
+    });
+
+    testWidgets('Delete tag… is styled danger', (tester) async {
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _tag(),
+          onCheckout: () {},
+          onCompareRef: () {},
+          onDeleteTag: () {},
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      final Text label = tester.widget<Text>(find.text('Delete tag…'));
+      expect(
+        label.style?.color,
+        tokensFor(GbmThemeVariant.darkTechnical).danger,
+      );
+    });
+
+    testWidgets('tapping Checkout tag (detached) invokes onCheckout', (
+      tester,
+    ) async {
+      bool checkedOut = false;
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _tag(),
+          onCheckout: () => checkedOut = true,
+          onCompareRef: () {},
+          onDeleteTag: () {},
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      await tester.tap(find.text('Checkout tag (detached)'));
+      await tester.pumpAndSettle();
+      expect(checkedOut, isTrue);
+    });
+
+    testWidgets(
+      'Checkout tag (detached) is disabled (no onTap) while conflictActive, '
+      'Push tag stays unaffected',
+      (tester) async {
+        await _pump(
+          tester,
+          BranchTreeItem(
+            ref: _tag(),
+            onCheckout: () {},
+            onPushTag: () {},
+            onCompareRef: () {},
+            onDeleteTag: () {},
+            conflictActive: true,
+          ),
+        );
+        await _rightClick(tester, find.byType(BranchTreeItem));
+
+        // Disabled -- absence of a thrown callback on tap is the
+        // assertion, same pattern as the 05-C conflictActive case above.
+        await tester.tap(find.text('Checkout tag (detached)'));
+        await tester.pumpAndSettle();
+        expect(find.text('Checkout tag (detached)'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Push tag still reaches onPushTag while conflictActive -- unlike '
+      'Checkout, it never touches HEAD or the working tree',
+      (tester) async {
+        bool pushed = false;
+        await _pump(
+          tester,
+          BranchTreeItem(
+            ref: _tag(),
+            onCheckout: () {},
+            onPushTag: () => pushed = true,
+            onCompareRef: () {},
+            onDeleteTag: () {},
+            conflictActive: true,
+          ),
+        );
+        await _rightClick(tester, find.byType(BranchTreeItem));
+        await tester.tap(find.text('Push tag'));
+        await tester.pumpAndSettle();
+        expect(pushed, isTrue);
+      },
+    );
+
+    testWidgets('Push tag is disabled (no onTap) when onPushTag is null', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _tag(),
+          onCheckout: () {},
+          onCompareRef: () {},
+          onDeleteTag: () {},
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      await tester.tap(find.text('Push tag'));
+      await tester.pumpAndSettle();
+      expect(find.text('Push tag'), findsNothing);
+    });
+
+    testWidgets('tapping Delete tag… invokes onDeleteTag', (tester) async {
+      bool deleted = false;
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _tag(),
+          onCheckout: () {},
+          onCompareRef: () {},
+          onDeleteTag: () => deleted = true,
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      await tester.tap(find.text('Delete tag…'));
+      await tester.pumpAndSettle();
+      expect(deleted, isTrue);
+    });
   });
 }

--- a/app_flutter/test/features/sidebar/branch_context_menu_test.dart
+++ b/app_flutter/test/features/sidebar/branch_context_menu_test.dart
@@ -177,6 +177,7 @@ void main() {
         await _rightClick(tester, find.byType(BranchTreeItem));
 
         expect(find.text('Checkout as new local…'), findsOneWidget);
+        expect(find.text('Fetch this branch'), findsOneWidget);
         expect(find.text('Copy branch name'), findsOneWidget);
         expect(find.text('Prune this ref'), findsOneWidget);
         expect(find.text('Delete on remote…'), findsOneWidget);
@@ -184,6 +185,38 @@ void main() {
         expect(find.text('Delete branch'), findsNothing);
         expect(find.text('Merge into current branch'), findsNothing);
         expect(find.text('New branch from here'), findsNothing);
+      },
+    );
+
+    testWidgets('tapping Fetch this branch invokes onFetchRef', (tester) async {
+      bool fetched = false;
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _remoteOnlyBranch(),
+          onCheckout: () {},
+          onFetchRef: () => fetched = true,
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      await tester.tap(find.text('Fetch this branch'));
+      await tester.pumpAndSettle();
+      expect(fetched, isTrue);
+    });
+
+    testWidgets(
+      'Fetch this branch is disabled (no onTap) when onFetchRef is null',
+      (tester) async {
+        await _pump(
+          tester,
+          BranchTreeItem(ref: _remoteOnlyBranch(), onCheckout: () {}),
+        );
+        await _rightClick(tester, find.byType(BranchTreeItem));
+        await tester.tap(find.text('Fetch this branch'));
+        await tester.pumpAndSettle();
+        // No crash and no callback exists to fire -- same pattern as the
+        // other disabled-item assertions in this file.
+        expect(find.text('Fetch this branch'), findsNothing);
       },
     );
 
@@ -307,6 +340,7 @@ void main() {
       await _rightClick(tester, find.byType(BranchTreeItem));
 
       expect(find.text('Checkout as new local…'), findsOneWidget);
+      expect(find.text('Fetch this branch'), findsOneWidget);
       expect(find.text('Copy branch name'), findsOneWidget);
       expect(find.text('Prune this ref'), findsOneWidget);
       expect(find.text('Delete on remote…'), findsOneWidget);
@@ -315,6 +349,25 @@ void main() {
       expect(find.text('Merge into current branch'), findsNothing);
       expect(find.text('New branch from here'), findsNothing);
     });
+
+    testWidgets(
+      'tapping Fetch this branch does nothing (disabled -- own upstream is '
+      'what vanished)',
+      (tester) async {
+        await _pump(
+          tester,
+          BranchTreeItem(
+            ref: _goneBranch(),
+            onCheckout: () {},
+            onPruneRef: () {},
+          ),
+        );
+        await _rightClick(tester, find.byType(BranchTreeItem));
+        await tester.tap(find.text('Fetch this branch'));
+        await tester.pumpAndSettle();
+        expect(find.text('Fetch this branch'), findsNothing);
+      },
+    );
 
     testWidgets(
       'tapping Checkout as new local… does nothing (disabled -- already local)',

--- a/app_flutter/test/features/sidebar/branch_tree_builder_test.dart
+++ b/app_flutter/test/features/sidebar/branch_tree_builder_test.dart
@@ -370,4 +370,110 @@ void main() {
       expect(folder.children.length, 2);
     });
   });
+
+  group('fetchableRefsInFolder', () {
+    RefInfo localWithUpstream({
+      required String shortName,
+      required String upstream,
+    }) => RefInfo(
+      fullName: 'refs/heads/$shortName',
+      shortName: shortName,
+      kind: RefKind.localBranch,
+      target: 'local-$shortName',
+      upstream: upstream,
+      ahead: 0,
+      behind: 0,
+      hasTrackingInfo: true,
+      isGone: false,
+      isHead: false,
+      isSymbolic: false,
+      worktreePath: '',
+    );
+
+    RefInfo localWithNoUpstream(String shortName) => RefInfo(
+      fullName: 'refs/heads/$shortName',
+      shortName: shortName,
+      kind: RefKind.localBranch,
+      target: 'local-$shortName',
+      upstream: '',
+      ahead: 0,
+      behind: 0,
+      hasTrackingInfo: false,
+      isGone: false,
+      isHead: false,
+      isSymbolic: false,
+      worktreePath: '',
+    );
+
+    RefInfo remoteOnly({required String remote, required String branch}) =>
+        RefInfo(
+          fullName: 'refs/remotes/$remote/$branch',
+          shortName: '$remote/$branch',
+          kind: RefKind.remoteBranch,
+          target: 'remote-$branch',
+          upstream: '',
+          ahead: 0,
+          behind: 0,
+          hasTrackingInfo: false,
+          isGone: false,
+          isHead: false,
+          isSymbolic: false,
+          worktreePath: '',
+        );
+
+    test('collects branch names from local branches tracking one remote', () {
+      final result = fetchableRefsInFolder([
+        localWithUpstream(
+          shortName: 'feature/a',
+          upstream: 'refs/remotes/origin/feature/a',
+        ),
+        localWithUpstream(
+          shortName: 'feature/b',
+          upstream: 'refs/remotes/origin/feature/b',
+        ),
+      ]);
+
+      expect(result, isNotNull);
+      expect(result!.$1, 'origin');
+      expect(result.$2, <String>['feature/a', 'feature/b']);
+    });
+
+    test('also collects from remote-only leaves via their own fullName', () {
+      final result = fetchableRefsInFolder([
+        remoteOnly(remote: 'origin', branch: 'feature/c'),
+      ]);
+
+      expect(result, isNotNull);
+      expect(result!.$1, 'origin');
+      expect(result.$2, <String>['feature/c']);
+    });
+
+    test('a local branch with no upstream contributes nothing', () {
+      final result = fetchableRefsInFolder([localWithNoUpstream('feature/d')]);
+
+      expect(result, isNull);
+    });
+
+    test(
+      'returns null when the folder\'s branches track more than one remote',
+      () {
+        final result = fetchableRefsInFolder([
+          localWithUpstream(
+            shortName: 'feature/a',
+            upstream: 'refs/remotes/origin/feature/a',
+          ),
+          localWithUpstream(
+            shortName: 'feature/b',
+            upstream: 'refs/remotes/upstream/feature/b',
+          ),
+        ]);
+
+        expect(result, isNull);
+      },
+    );
+
+    test('returns null for an empty ref list', () {
+      expect(fetchableRefsInFolder(const []), isNull);
+    });
+  });
 }

--- a/app_flutter/test/features/sidebar/sidebar_panel_branch_folder_test.dart
+++ b/app_flutter/test/features/sidebar/sidebar_panel_branch_folder_test.dart
@@ -1,0 +1,236 @@
+// Verifies SidebarPanel's 05-J (Branch folder) context menu wiring, and
+// the row-tap-to-toggle it gained alongside the menu, reach the real
+// repoSessionProvider/GoRouter seam -- see CLAUDE.md's Testing tiers.
+// branch_folder_menu_items_test.dart already covers the item list itself
+// in isolation; this covers the SidebarPanel-level dispatch that tier
+// structurally cannot, the same gap closed for 05-C/05-H/05-D.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/repositories/branch_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/sidebar/sidebar_panel.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _testIdentity = RepoIdentity.forWorkDir('/test/repo');
+final String _repoIdParam = Uri.encodeComponent(_testIdentity.workDir);
+
+RefInfo _localBranch(
+  String name, {
+  bool isHead = false,
+  String worktreePath = '',
+}) {
+  return RefInfo(
+    fullName: 'refs/heads/$name',
+    shortName: name,
+    kind: RefKind.localBranch,
+    target: 'a' * 40,
+    upstream: '',
+    ahead: 0,
+    behind: 0,
+    hasTrackingInfo: false,
+    isGone: false,
+    isHead: isHead,
+    isSymbolic: isHead,
+    worktreePath: worktreePath,
+  );
+}
+
+final RefSnapshot _testRefs = RefSnapshot(
+  head: HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: 'a' * 40,
+  ),
+  refs: <RefInfo>[
+    _localBranch('main', isHead: true),
+    _localBranch('release/v1'),
+    _localBranch('release/v2'),
+    _localBranch('feature/auth'),
+    _localBranch('feature/nested/deep'),
+  ],
+  refCountGuardTripped: false,
+  totalRefCount: 5,
+);
+
+class _Harness {
+  _Harness({required this.fake});
+  final FakeRepoSessionController fake;
+}
+
+Future<_Harness> _pump(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _testIdentity,
+    const RepoSessionState(),
+  );
+
+  final GoRouter router = GoRouter(
+    initialLocation: '/repo/$_repoIdParam/history',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/repo/:repoId/history',
+        builder: (context, state) => Scaffold(
+          body: SidebarPanel(identity: _testIdentity, filterFocusNode: null),
+        ),
+      ),
+    ],
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoRefsProvider(_testIdentity).overrideWithValue(_testRefs),
+      repoSessionProvider(_testIdentity).overrideWith((ref) => fake),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  return _Harness(fake: fake);
+}
+
+Future<void> _rightClick(WidgetTester tester, Finder finder) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(finder));
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SidebarPanel branch folder context menu (05-J)', () {
+    testWidgets('right-clicking a folder row opens its 05-J menu', (
+      tester,
+    ) async {
+      await _pump(tester);
+
+      await _rightClick(tester, find.text('release'));
+
+      expect(find.text('Expand all'), findsOneWidget);
+      expect(find.text('Fetch branches in folder'), findsOneWidget);
+      expect(find.text('Copy folder prefix'), findsOneWidget);
+      expect(find.text('Delete merged branches…'), findsOneWidget);
+    });
+
+    testWidgets('clicking the folder name toggles it open, revealing its '
+        'children', (tester) async {
+      await _pump(tester);
+
+      // BranchTreeItem renders a leaf's full shortName, not a
+      // folder-stripped segment (see branch_tree_item.dart's `ref.shortName`
+      // usage) -- so "release/v1" is the actual rendered text, not "v1".
+      expect(find.text('release/v1'), findsNothing);
+
+      await tester.tap(find.text('release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('release/v1'), findsOneWidget);
+      expect(find.text('release/v2'), findsOneWidget);
+    });
+
+    testWidgets(
+      'Expand all opens the folder and reveals a nested subfolder\'s own '
+      'children too, not just the top level',
+      (tester) async {
+        await _pump(tester);
+
+        expect(find.text('feature/nested/deep'), findsNothing);
+
+        await _rightClick(tester, find.text('feature'));
+        await tester.tap(find.text('Expand all'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('feature/auth'), findsOneWidget);
+        // "nested" is itself a subfolder under "feature" -- Expand all
+        // should open it too, revealing "deep" without a second click.
+        expect(find.text('feature/nested/deep'), findsOneWidget);
+      },
+    );
+
+    testWidgets('Copy folder prefix copies "<folderName>/" to the clipboard', (
+      tester,
+    ) async {
+      final List<Object?> clipboardCalls = <Object?>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardCalls.add(call.arguments);
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      await _pump(tester);
+      await _rightClick(tester, find.text('release'));
+      await tester.tap(find.text('Copy folder prefix'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, hasLength(1));
+      expect((clipboardCalls.single as Map)['text'], 'release/');
+    });
+
+    testWidgets(
+      'Delete merged branches… reaches deleteBranch with every branch in '
+      'the folder',
+      (tester) async {
+        final _Harness h = await _pump(tester);
+
+        await _rightClick(tester, find.text('release'));
+        await tester.tap(find.text('Delete merged branches…'));
+        await tester.pumpAndSettle();
+
+        final FakeCommand cmd = h.fake.commandLog.singleWhere(
+          (c) => c.name == 'deleteBranch',
+        );
+        expect(cmd.args['names'], <String>['release/v1', 'release/v2']);
+      },
+    );
+
+    testWidgets(
+      'Fetch branches in folder is disabled -- no per-ref fetch capability',
+      (tester) async {
+        final _Harness h = await _pump(tester);
+
+        await _rightClick(tester, find.text('release'));
+        await tester.tap(find.text('Fetch branches in folder'));
+        await tester.pumpAndSettle();
+
+        expect(h.fake.commandLog.any((c) => c.name == 'fetchRemote'), isFalse);
+      },
+    );
+  });
+}

--- a/app_flutter/test/features/sidebar/sidebar_panel_branch_folder_test.dart
+++ b/app_flutter/test/features/sidebar/sidebar_panel_branch_folder_test.dart
@@ -29,16 +29,17 @@ RefInfo _localBranch(
   String name, {
   bool isHead = false,
   String worktreePath = '',
+  String upstream = '',
 }) {
   return RefInfo(
     fullName: 'refs/heads/$name',
     shortName: name,
     kind: RefKind.localBranch,
     target: 'a' * 40,
-    upstream: '',
+    upstream: upstream,
     ahead: 0,
     behind: 0,
-    hasTrackingInfo: false,
+    hasTrackingInfo: upstream.isNotEmpty,
     isGone: false,
     isHead: isHead,
     isSymbolic: isHead,
@@ -64,12 +65,33 @@ final RefSnapshot _testRefs = RefSnapshot(
   totalRefCount: 5,
 );
 
+// Same shape, but every "release/*" branch tracks an "origin" upstream --
+// used by the enabled-fetch tests below, since fetchableRefsInFolder()
+// requires every leaf's upstream to resolve to the same single remote.
+final RefSnapshot _testRefsWithUpstream = RefSnapshot(
+  head: HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: 'a' * 40,
+  ),
+  refs: <RefInfo>[
+    _localBranch('main', isHead: true),
+    _localBranch('release/v1', upstream: 'refs/remotes/origin/release/v1'),
+    _localBranch('release/v2', upstream: 'refs/remotes/origin/release/v2'),
+    _localBranch('feature/auth'),
+    _localBranch('feature/nested/deep'),
+  ],
+  refCountGuardTripped: false,
+  totalRefCount: 5,
+);
+
 class _Harness {
   _Harness({required this.fake});
   final FakeRepoSessionController fake;
 }
 
-Future<_Harness> _pump(WidgetTester tester) async {
+Future<_Harness> _pump(WidgetTester tester, {RefSnapshot? refs}) async {
   SharedPreferences.setMockInitialValues(<String, Object>{});
   final SharedPreferences prefs = await SharedPreferences.getInstance();
 
@@ -93,7 +115,7 @@ Future<_Harness> _pump(WidgetTester tester) async {
   final ProviderContainer container = ProviderContainer(
     overrides: <Override>[
       sharedPreferencesProvider.overrideWithValue(prefs),
-      repoRefsProvider(_testIdentity).overrideWithValue(_testRefs),
+      repoRefsProvider(_testIdentity).overrideWithValue(refs ?? _testRefs),
       repoSessionProvider(_testIdentity).overrideWith((ref) => fake),
     ],
   );
@@ -221,7 +243,8 @@ void main() {
     );
 
     testWidgets(
-      'Fetch branches in folder is disabled -- no per-ref fetch capability',
+      'Fetch branches in folder is disabled when the folder\'s branches '
+      'have no upstream -- no single unambiguous remote to fetch from',
       (tester) async {
         final _Harness h = await _pump(tester);
 
@@ -230,6 +253,24 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(h.fake.commandLog.any((c) => c.name == 'fetchRemote'), isFalse);
+      },
+    );
+
+    testWidgets(
+      'Fetch branches in folder reaches fetchRemote with the folder\'s '
+      'single remote and its branch names, when every leaf tracks it',
+      (tester) async {
+        final _Harness h = await _pump(tester, refs: _testRefsWithUpstream);
+
+        await _rightClick(tester, find.text('release'));
+        await tester.tap(find.text('Fetch branches in folder'));
+        await tester.pumpAndSettle();
+
+        final FakeCommand cmd = h.fake.commandLog.singleWhere(
+          (c) => c.name == 'fetchRemote',
+        );
+        expect(cmd.args['remoteName'], 'origin');
+        expect(cmd.args['refs'], <String>['release/v1', 'release/v2']);
       },
     );
   });

--- a/app_flutter/test/features/sidebar/sidebar_panel_remote_branch_test.dart
+++ b/app_flutter/test/features/sidebar/sidebar_panel_remote_branch_test.dart
@@ -276,6 +276,23 @@ void main() {
       expect(prune.args['refs'], <String>['refs/remotes/origin/release']);
     });
 
+    testWidgets(
+      'Fetch this branch calls fetchRemote with the remote name and branch',
+      (tester) async {
+        final _Harness harness = await _pump(tester);
+
+        await _openRemoteRowMenu(tester);
+        await tester.tap(find.text('Fetch this branch'));
+        await tester.pumpAndSettle();
+
+        final FakeCommand fetch = harness.fake.commandLog.singleWhere(
+          (c) => c.name == 'fetchRemote',
+        );
+        expect(fetch.args['remoteName'], 'origin');
+        expect(fetch.args['refs'], <String>['release']);
+      },
+    );
+
     testWidgets('Delete on remote… navigates to deleteRemoteBranchDialogFor', (
       tester,
     ) async {
@@ -372,8 +389,8 @@ void main() {
     );
 
     testWidgets(
-      'Checkout as new local… and Delete on remote… stay disabled -- no '
-      'command reaches the session when tapped',
+      'Checkout as new local…, Fetch this branch, and Delete on remote… '
+      'stay disabled -- no command reaches the session when tapped',
       (tester) async {
         final _Harness harness = await _pump(tester);
 
@@ -392,11 +409,20 @@ void main() {
 
         await tester.tap(moreButton);
         await tester.pumpAndSettle();
+        await tester.tap(find.text('Fetch this branch'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(moreButton);
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Delete on remote…'));
         await tester.pumpAndSettle();
 
         expect(
           harness.fake.commandLog.any((c) => c.name == 'checkout'),
+          isFalse,
+        );
+        expect(
+          harness.fake.commandLog.any((c) => c.name == 'fetchRemote'),
           isFalse,
         );
         // Delete on remote… doesn't dispatch a session command at all --

--- a/app_flutter/test/features/sidebar/sidebar_panel_stash_test.dart
+++ b/app_flutter/test/features/sidebar/sidebar_panel_stash_test.dart
@@ -1,0 +1,336 @@
+// Verifies SidebarPanel's 05-H (Stash entry) context menu wiring reaches
+// the real repoSessionProvider/GoRouter seam -- see CLAUDE.md's Testing
+// tiers: stash_menu_items_test.dart already covers the item list itself
+// (labels/order/danger-last/nullable gating) in isolation; this covers the
+// dispatch path stash_menu_items_test.dart structurally cannot, the same
+// gap sidebar_panel_remote_branch_test.dart closed for the 05-C menu.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/models/repo_state.dart';
+import 'package:gbm_flutter/data/models/stash_entry.dart';
+import 'package:gbm_flutter/data/repositories/branch_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/manage_stashes/manage_stashes_dialog.dart';
+import 'package:gbm_flutter/features/sidebar/sidebar_panel.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _testIdentity = RepoIdentity.forWorkDir('/test/repo');
+final String _repoIdParam = Uri.encodeComponent(_testIdentity.workDir);
+
+// SidebarPanel renders "No branches" instead of the tree+stash section
+// whenever the merged branch list is empty (see its `branches.isEmpty`
+// guard) -- a real local branch has to be seeded here even though these
+// tests only care about the stash section below it.
+final RefInfo _localMain = RefInfo(
+  fullName: 'refs/heads/main',
+  shortName: 'main',
+  kind: RefKind.localBranch,
+  target: 'a' * 40,
+  upstream: '',
+  ahead: 0,
+  behind: 0,
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: true,
+  isSymbolic: true,
+  worktreePath: '',
+);
+
+final RefSnapshot _testRefs = RefSnapshot(
+  head: HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: 'a' * 40,
+  ),
+  refs: <RefInfo>[_localMain],
+  refCountGuardTripped: false,
+  totalRefCount: 1,
+);
+
+final StashEntry _stash0 = StashEntry(
+  index: 0,
+  message: 'WIP on main: quick fix',
+  oid: 'b' * 40,
+  timestamp: 1700000000,
+);
+
+const RepoState _mergeState = RepoState(
+  flags: RepoStateFlags.merge,
+  isClean: false,
+  isSequencerOperation: true,
+  rebaseStep: 0,
+  rebaseTotal: 0,
+  rebaseOntoLabel: '',
+  indexLocked: false,
+  indexLockAgeSeconds: null,
+  describe: '',
+);
+
+class _Harness {
+  _Harness({required this.fake});
+  final FakeRepoSessionController fake;
+}
+
+Future<_Harness> _pump(
+  WidgetTester tester, {
+  RepoSessionState initialState = const RepoSessionState(),
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _testIdentity,
+    initialState,
+  );
+
+  final GoRouter router = GoRouter(
+    initialLocation: '/repo/$_repoIdParam/history',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/repo/:repoId/history',
+        builder: (context, state) => Scaffold(
+          body: SidebarPanel(identity: _testIdentity, filterFocusNode: null),
+        ),
+      ),
+      GoRoute(
+        path: RoutePaths.compare,
+        builder: (context, state) =>
+            const Scaffold(body: SizedBox(key: Key('compare-stub'))),
+      ),
+      GoRoute(
+        path: RoutePaths.manageStashesDialog,
+        // The real dialog, not a stub -- its initState is exactly what
+        // "View diff" needs covered (see route_paths.dart's
+        // manageStashesDialogFor(selectIndex:) doc comment): it reads
+        // ?index= and fires requestStashDiff for it.
+        builder: (context, state) => Scaffold(
+          body: ManageStashesDialogContent(
+            identity: _testIdentity,
+            initialSelectedIndex: int.tryParse(
+              state.uri.queryParameters['index'] ?? '',
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoRefsProvider(_testIdentity).overrideWithValue(_testRefs),
+      repoSessionProvider(_testIdentity).overrideWith((ref) => fake),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  return _Harness(fake: fake);
+}
+
+Future<void> _rightClick(WidgetTester tester, Finder finder) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(finder));
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SidebarPanel stash context menu (05-H)', () {
+    testWidgets('right-clicking a stash row opens its 05-H menu', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        initialState: RepoSessionState(stashes: <StashEntry>[_stash0]),
+      );
+
+      await _rightClick(tester, find.text('WIP on main: quick fix'));
+
+      expect(find.text('Apply stash'), findsOneWidget);
+      expect(find.text('Pop stash'), findsOneWidget);
+      expect(find.text('Create branch from stash…'), findsOneWidget);
+      expect(find.text('View diff'), findsOneWidget);
+      expect(find.text('Compare with…'), findsOneWidget);
+      expect(find.text('Drop stash…'), findsOneWidget);
+    });
+
+    testWidgets('Apply stash reaches applyStash(pop: false)', (tester) async {
+      final _Harness h = await _pump(
+        tester,
+        initialState: RepoSessionState(stashes: <StashEntry>[_stash0]),
+      );
+
+      await _rightClick(tester, find.text('WIP on main: quick fix'));
+      await tester.tap(find.text('Apply stash'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand cmd = h.fake.commandLog.singleWhere(
+        (c) => c.name == 'applyStash',
+      );
+      expect(cmd.args['index'], 0);
+      expect(cmd.args['pop'], isFalse);
+    });
+
+    testWidgets('Pop stash reaches applyStash(pop: true)', (tester) async {
+      final _Harness h = await _pump(
+        tester,
+        initialState: RepoSessionState(stashes: <StashEntry>[_stash0]),
+      );
+
+      await _rightClick(tester, find.text('WIP on main: quick fix'));
+      await tester.tap(find.text('Pop stash'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand cmd = h.fake.commandLog.singleWhere(
+        (c) => c.name == 'applyStash',
+      );
+      expect(cmd.args['pop'], isTrue);
+    });
+
+    testWidgets('Drop stash… reaches dropStash', (tester) async {
+      final _Harness h = await _pump(
+        tester,
+        initialState: RepoSessionState(stashes: <StashEntry>[_stash0]),
+      );
+
+      await _rightClick(tester, find.text('WIP on main: quick fix'));
+      await tester.tap(find.text('Drop stash…'));
+      await tester.pumpAndSettle();
+
+      expect(
+        h.fake.commandLog.any(
+          (c) => c.name == 'dropStash' && c.args['index'] == 0,
+        ),
+        isTrue,
+      );
+    });
+
+    testWidgets(
+      'View diff navigates to Manage Stashes with the stash pre-selected '
+      'and its initState fires requestStashDiff',
+      (tester) async {
+        final _Harness h = await _pump(
+          tester,
+          initialState: RepoSessionState(stashes: <StashEntry>[_stash0]),
+        );
+
+        await _rightClick(tester, find.text('WIP on main: quick fix'));
+        await tester.tap(find.text('View diff'));
+        // Not pumpAndSettle: the dialog's diff pane shows an indefinitely
+        // spinning CircularProgressIndicator until a real lastStashDiff
+        // arrives (FakeRepoSessionController.requestStashDiff only
+        // records the call, per its class doc comment -- it never
+        // publishes a new state), which pumpAndSettle would wait on
+        // forever. A few frames are enough for the navigation and
+        // initState's microtask to land.
+        await tester.pump();
+        await tester.pump();
+
+        // `push`, not `go` -- SidebarPanel stays mounted underneath, and
+        // the dialog is now mounted too, so its own element resolves the
+        // post-navigation location.
+        expect(
+          GoRouterState.of(
+            tester.element(find.byType(ManageStashesDialogContent)),
+          ).uri.toString(),
+          contains('manage-stashes'),
+        );
+        expect(
+          h.fake.commandLog.any(
+            (c) => c.name == 'requestStashDiff' && c.args['index'] == 0,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets(
+      'Compare with… opens a Compare tab whose left ref is the stash oid',
+      (tester) async {
+        await _pump(
+          tester,
+          initialState: RepoSessionState(stashes: <StashEntry>[_stash0]),
+        );
+
+        await _rightClick(tester, find.text('WIP on main: quick fix'));
+        await tester.tap(find.text('Compare with…'));
+        await tester.pumpAndSettle();
+
+        // `go`, not `push` -- SidebarPanel (and the History route it lives
+        // under) is replaced, so the compare-stub route's own element is
+        // what's left mounted to read the post-navigation location from.
+        expect(
+          GoRouterState.of(
+            tester.element(find.byKey(const Key('compare-stub'))),
+          ).uri.toString(),
+          contains('/compare/'),
+        );
+      },
+    );
+
+    testWidgets(
+      'Apply/Pop/Create branch from stash… are disabled while a conflict '
+      'is active, then re-enabled once it clears (conflictActive '
+      'round-trip, per CLAUDE.md\'s Rule)',
+      (tester) async {
+        final _Harness h = await _pump(
+          tester,
+          initialState: RepoSessionState(
+            stashes: <StashEntry>[_stash0],
+            repoState: _mergeState,
+          ),
+        );
+
+        await _rightClick(tester, find.text('WIP on main: quick fix'));
+        await tester.tap(find.text('Apply stash'));
+        await tester.pumpAndSettle();
+        expect(
+          h.fake.commandLog.any((c) => c.name == 'applyStash'),
+          isFalse,
+          reason: 'mid-conflict, Apply stash should be disabled and no-op',
+        );
+
+        // repoState defaults to null (clean) on a fresh RepoSessionState
+        // with no override.
+        h.fake.emit(RepoSessionState(stashes: <StashEntry>[_stash0]));
+        await tester.pumpAndSettle();
+
+        await _rightClick(tester, find.text('WIP on main: quick fix'));
+        await tester.tap(find.text('Apply stash'));
+        await tester.pumpAndSettle();
+        expect(
+          h.fake.commandLog.any((c) => c.name == 'applyStash'),
+          isTrue,
+          reason: 'once clean, Apply stash should reach the controller',
+        );
+      },
+    );
+  });
+}

--- a/app_flutter/test/features/sidebar/sidebar_panel_tag_test.dart
+++ b/app_flutter/test/features/sidebar/sidebar_panel_tag_test.dart
@@ -1,0 +1,290 @@
+// Verifies SidebarPanel's 05-D (Tag) context menu wiring reaches the real
+// repoSessionProvider/GoRouter seam -- see CLAUDE.md's Testing tiers:
+// tag_menu_items_test.dart and branch_context_menu_test.dart's "tag row
+// (05-D)" group already cover the item list and BranchTreeItem's own
+// dispatch in isolation; this covers the SidebarPanel-level wiring those
+// two tiers structurally cannot, the same gap
+// sidebar_panel_remote_branch_test.dart closed for the 05-C menu and
+// sidebar_panel_stash_test.dart closed for 05-H.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/models/remote_info.dart';
+import 'package:gbm_flutter/data/models/repo_state.dart';
+import 'package:gbm_flutter/data/repositories/branch_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/sidebar/sidebar_panel.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _testIdentity = RepoIdentity.forWorkDir('/test/repo');
+final String _repoIdParam = Uri.encodeComponent(_testIdentity.workDir);
+
+final RefInfo _localMain = RefInfo(
+  fullName: 'refs/heads/main',
+  shortName: 'main',
+  kind: RefKind.localBranch,
+  target: 'a' * 40,
+  upstream: '',
+  ahead: 0,
+  behind: 0,
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: true,
+  isSymbolic: true,
+  worktreePath: '',
+);
+
+final RefInfo _tagV1 = RefInfo(
+  fullName: 'refs/tags/v1.0.0',
+  shortName: 'v1.0.0',
+  kind: RefKind.tag,
+  target: 'b' * 40,
+  upstream: '',
+  ahead: 0,
+  behind: 0,
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: false,
+  isSymbolic: false,
+  worktreePath: '',
+);
+
+final RefSnapshot _testRefs = RefSnapshot(
+  head: HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: 'a' * 40,
+  ),
+  refs: <RefInfo>[_localMain, _tagV1],
+  refCountGuardTripped: false,
+  totalRefCount: 2,
+);
+
+const RemoteInfo _origin = RemoteInfo(
+  name: 'origin',
+  fetchUrl: 'https://example.com/repo.git',
+  pushUrl: 'https://example.com/repo.git',
+);
+
+const RepoState _mergeState = RepoState(
+  flags: RepoStateFlags.merge,
+  isClean: false,
+  isSequencerOperation: true,
+  rebaseStep: 0,
+  rebaseTotal: 0,
+  rebaseOntoLabel: '',
+  indexLocked: false,
+  indexLockAgeSeconds: null,
+  describe: '',
+);
+
+class _Harness {
+  _Harness({required this.fake});
+  final FakeRepoSessionController fake;
+}
+
+Future<_Harness> _pump(
+  WidgetTester tester, {
+  RepoSessionState initialState = const RepoSessionState(),
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _testIdentity,
+    initialState,
+  );
+
+  final GoRouter router = GoRouter(
+    initialLocation: '/repo/$_repoIdParam/history',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/repo/:repoId/history',
+        builder: (context, state) => Scaffold(
+          body: SidebarPanel(identity: _testIdentity, filterFocusNode: null),
+        ),
+      ),
+      GoRoute(
+        path: RoutePaths.compare,
+        builder: (context, state) =>
+            const Scaffold(body: SizedBox(key: Key('compare-stub'))),
+      ),
+    ],
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoRefsProvider(_testIdentity).overrideWithValue(_testRefs),
+      repoSessionProvider(_testIdentity).overrideWith((ref) => fake),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  return _Harness(fake: fake);
+}
+
+Future<void> _rightClick(WidgetTester tester, Finder finder) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(finder));
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SidebarPanel tag context menu (05-D)', () {
+    testWidgets('right-clicking a tag row opens its 05-D menu', (tester) async {
+      await _pump(tester);
+
+      await _rightClick(tester, find.text('v1.0.0'));
+
+      expect(find.text('Checkout tag (detached)'), findsOneWidget);
+      expect(find.text('Push tag'), findsOneWidget);
+      expect(find.text('Compare with…'), findsOneWidget);
+      expect(find.text('Copy tag name'), findsOneWidget);
+      expect(find.text('Delete tag…'), findsOneWidget);
+    });
+
+    testWidgets(
+      'Checkout tag (detached) reaches checkout(target: tagName, detach: '
+      'true)',
+      (tester) async {
+        final _Harness h = await _pump(tester);
+
+        await _rightClick(tester, find.text('v1.0.0'));
+        await tester.tap(find.text('Checkout tag (detached)'));
+        await tester.pumpAndSettle();
+
+        final FakeCommand cmd = h.fake.commandLog.singleWhere(
+          (c) => c.name == 'checkout',
+        );
+        expect(cmd.args['target'], 'v1.0.0');
+      },
+    );
+
+    testWidgets(
+      'Push tag reaches pushTag with the single configured remote, when '
+      'exactly one remote exists',
+      (tester) async {
+        final _Harness h = await _pump(
+          tester,
+          initialState: const RepoSessionState(remotes: <RemoteInfo>[_origin]),
+        );
+
+        await _rightClick(tester, find.text('v1.0.0'));
+        await tester.tap(find.text('Push tag'));
+        await tester.pumpAndSettle();
+
+        final FakeCommand cmd = h.fake.commandLog.singleWhere(
+          (c) => c.name == 'pushTag',
+        );
+        expect(cmd.args['remoteName'], 'origin');
+        expect(cmd.args['name'], 'v1.0.0');
+      },
+    );
+
+    testWidgets(
+      'Push tag is disabled when there is no single unambiguous remote '
+      '(zero remotes here)',
+      (tester) async {
+        final _Harness h = await _pump(tester);
+
+        await _rightClick(tester, find.text('v1.0.0'));
+        await tester.tap(find.text('Push tag'));
+        await tester.pumpAndSettle();
+
+        expect(h.fake.commandLog.any((c) => c.name == 'pushTag'), isFalse);
+      },
+    );
+
+    testWidgets('Delete tag… reaches deleteTag', (tester) async {
+      final _Harness h = await _pump(tester);
+
+      await _rightClick(tester, find.text('v1.0.0'));
+      await tester.tap(find.text('Delete tag…'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand cmd = h.fake.commandLog.singleWhere(
+        (c) => c.name == 'deleteTag',
+      );
+      expect(cmd.args['name'], 'v1.0.0');
+    });
+
+    testWidgets(
+      'Compare with… opens a Compare tab whose left ref is the tag name',
+      (tester) async {
+        await _pump(tester);
+
+        await _rightClick(tester, find.text('v1.0.0'));
+        await tester.tap(find.text('Compare with…'));
+        await tester.pumpAndSettle();
+
+        expect(
+          GoRouterState.of(
+            tester.element(find.byKey(const Key('compare-stub'))),
+          ).uri.toString(),
+          contains('/compare/'),
+        );
+      },
+    );
+
+    testWidgets(
+      'Checkout tag (detached) is disabled while a conflict is active, '
+      'then re-enabled once it clears (conflictActive round-trip, per '
+      'CLAUDE.md\'s Rule)',
+      (tester) async {
+        final _Harness h = await _pump(
+          tester,
+          initialState: const RepoSessionState(repoState: _mergeState),
+        );
+
+        await _rightClick(tester, find.text('v1.0.0'));
+        await tester.tap(find.text('Checkout tag (detached)'));
+        await tester.pumpAndSettle();
+        expect(
+          h.fake.commandLog.any((c) => c.name == 'checkout'),
+          isFalse,
+          reason: 'mid-conflict, checkout should be disabled and no-op',
+        );
+
+        h.fake.emit(const RepoSessionState());
+        await tester.pumpAndSettle();
+
+        await _rightClick(tester, find.text('v1.0.0'));
+        await tester.tap(find.text('Checkout tag (detached)'));
+        await tester.pumpAndSettle();
+        expect(
+          h.fake.commandLog.any((c) => c.name == 'checkout'),
+          isTrue,
+          reason: 'once clean, checkout should reach the controller',
+        );
+      },
+    );
+  });
+}

--- a/app_flutter/test/features/sidebar/widgets/branch_folder_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/branch_folder_menu_items_test.dart
@@ -1,0 +1,115 @@
+// Pure-Dart unit tests for branchFolderMenuItems() -- no widget pump
+// needed. Verifies the item list matches gbm_context_menus.dart's 05-J
+// (Branch folder) spec, with the documented divergence for the toggle
+// item's state-dependent label (see the function's own doc comment), and
+// that "Fetch branches in folder" always renders disabled (no capi
+// backing).
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/context_menus/gbm_context_menus.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/branch_folder_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+void main() {
+  group('branchFolderMenuItems', () {
+    final List<String> specLabels =
+        gbmContextMenuGroups[GbmContextMenuTarget.branchFolder]!.items
+            .map((GbmContextMenuItemSpec spec) => spec.label)
+            .toList();
+
+    test('item count and order match gbmContextMenuGroups 05-J, aside from '
+        'the documented toggle-label split', () {
+      final List<GbmMenuItem> items = branchFolderMenuItems(
+        isExpanded: false,
+        onToggleExpand: () {},
+        onCopyPrefix: () {},
+        onDeleteMerged: () {},
+      );
+      final List<String> actualLabels = items
+          .where((GbmMenuItem item) => !item.separator)
+          .map((GbmMenuItem item) => item.label)
+          .toList();
+
+      expect(actualLabels, hasLength(specLabels.length));
+      // Item 0 is the documented split -- checked separately below.
+      expect(actualLabels.sublist(1), specLabels.sublist(1));
+    });
+
+    test('collapsed (isExpanded: false) shows "Expand all"', () {
+      final List<GbmMenuItem> items = branchFolderMenuItems(
+        isExpanded: false,
+        onToggleExpand: () {},
+        onCopyPrefix: () {},
+        onDeleteMerged: () {},
+      );
+      expect(items.first.label, 'Expand all');
+    });
+
+    test('expanded (isExpanded: true) shows "Collapse all"', () {
+      final List<GbmMenuItem> items = branchFolderMenuItems(
+        isExpanded: true,
+        onToggleExpand: () {},
+        onCopyPrefix: () {},
+        onDeleteMerged: () {},
+      );
+      expect(items.first.label, 'Collapse all');
+    });
+
+    test(
+      'Delete merged branches… is last, is danger, preceded by a separator',
+      () {
+        final List<GbmMenuItem> items = branchFolderMenuItems(
+          isExpanded: false,
+          onToggleExpand: () {},
+          onCopyPrefix: () {},
+          onDeleteMerged: () {},
+        );
+
+        expect(items.last.label, 'Delete merged branches…');
+        expect(items.last.danger, isTrue);
+        expect(items[items.length - 2].separator, isTrue);
+      },
+    );
+
+    test('Fetch branches in folder always renders disabled', () {
+      final List<GbmMenuItem> items = branchFolderMenuItems(
+        isExpanded: false,
+        onToggleExpand: () {},
+        onCopyPrefix: () {},
+        onDeleteMerged: () {},
+      );
+      final GbmMenuItem fetchItem = items.firstWhere(
+        (GbmMenuItem i) => i.label == 'Fetch branches in folder',
+      );
+      expect(fetchItem.enabled, isFalse);
+      expect(fetchItem.onTap, isNull);
+    });
+
+    test('each callback reaches its matching item, not a neighbor', () {
+      bool toggled = false;
+      bool copied = false;
+      bool deleted = false;
+
+      final List<GbmMenuItem> items = branchFolderMenuItems(
+        isExpanded: false,
+        onToggleExpand: () => toggled = true,
+        onCopyPrefix: () => copied = true,
+        onDeleteMerged: () => deleted = true,
+      );
+
+      items.firstWhere((GbmMenuItem i) => i.label == 'Expand all').onTap!();
+      expect(toggled, isTrue);
+      expect(copied, isFalse);
+      expect(deleted, isFalse);
+
+      items
+          .firstWhere((GbmMenuItem i) => i.label == 'Copy folder prefix')
+          .onTap!();
+      expect(copied, isTrue);
+
+      items
+          .firstWhere((GbmMenuItem i) => i.label == 'Delete merged branches…')
+          .onTap!();
+      expect(deleted, isTrue);
+    });
+  });
+}

--- a/app_flutter/test/features/sidebar/widgets/branch_folder_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/branch_folder_menu_items_test.dart
@@ -2,8 +2,8 @@
 // needed. Verifies the item list matches gbm_context_menus.dart's 05-J
 // (Branch folder) spec, with the documented divergence for the toggle
 // item's state-dependent label (see the function's own doc comment), and
-// that "Fetch branches in folder" always renders disabled (no capi
-// backing).
+// that "Fetch branches in folder" goes through the nullable-callback gate
+// for the "no single unambiguous remote" case.
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/features/context_menus/gbm_context_menus.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/branch_folder_menu_items.dart';
@@ -23,6 +23,7 @@ void main() {
         onToggleExpand: () {},
         onCopyPrefix: () {},
         onDeleteMerged: () {},
+        onFetchFolder: () {},
       );
       final List<String> actualLabels = items
           .where((GbmMenuItem item) => !item.separator)
@@ -40,6 +41,7 @@ void main() {
         onToggleExpand: () {},
         onCopyPrefix: () {},
         onDeleteMerged: () {},
+        onFetchFolder: () {},
       );
       expect(items.first.label, 'Expand all');
     });
@@ -50,6 +52,7 @@ void main() {
         onToggleExpand: () {},
         onCopyPrefix: () {},
         onDeleteMerged: () {},
+        onFetchFolder: () {},
       );
       expect(items.first.label, 'Collapse all');
     });
@@ -62,6 +65,7 @@ void main() {
           onToggleExpand: () {},
           onCopyPrefix: () {},
           onDeleteMerged: () {},
+          onFetchFolder: () {},
         );
 
         expect(items.last.label, 'Delete merged branches…');
@@ -70,18 +74,37 @@ void main() {
       },
     );
 
-    test('Fetch branches in folder always renders disabled', () {
+    test('onFetchFolder: null renders Fetch branches in folder disabled, '
+        'matching the "no single unambiguous remote" case', () {
       final List<GbmMenuItem> items = branchFolderMenuItems(
         isExpanded: false,
         onToggleExpand: () {},
         onCopyPrefix: () {},
         onDeleteMerged: () {},
+        onFetchFolder: null,
       );
       final GbmMenuItem fetchItem = items.firstWhere(
         (GbmMenuItem i) => i.label == 'Fetch branches in folder',
       );
       expect(fetchItem.enabled, isFalse);
       expect(fetchItem.onTap, isNull);
+    });
+
+    test('onFetchFolder: a real callback renders it enabled and reachable', () {
+      bool fetched = false;
+      final List<GbmMenuItem> items = branchFolderMenuItems(
+        isExpanded: false,
+        onToggleExpand: () {},
+        onCopyPrefix: () {},
+        onDeleteMerged: () {},
+        onFetchFolder: () => fetched = true,
+      );
+      final GbmMenuItem fetchItem = items.firstWhere(
+        (GbmMenuItem i) => i.label == 'Fetch branches in folder',
+      );
+      expect(fetchItem.enabled, isTrue);
+      fetchItem.onTap!();
+      expect(fetched, isTrue);
     });
 
     test('each callback reaches its matching item, not a neighbor', () {
@@ -94,6 +117,7 @@ void main() {
         onToggleExpand: () => toggled = true,
         onCopyPrefix: () => copied = true,
         onDeleteMerged: () => deleted = true,
+        onFetchFolder: () {},
       );
 
       items.firstWhere((GbmMenuItem i) => i.label == 'Expand all').onTap!();

--- a/app_flutter/test/features/sidebar/widgets/stash_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/stash_menu_items_test.dart
@@ -1,0 +1,103 @@
+// Pure-Dart unit tests for stashMenuItems() -- no widget pump needed.
+// Verifies the item list matches gbm_context_menus.dart's 05-H (Stash
+// entry) spec exactly (labels, order, danger-last) and that the
+// conflict-sensitive items (Apply/Pop/Create branch from stash…) go
+// through the nullable-callback gate the same way TabRow's Merge/
+// Cherry-pick/Reset do, while View diff/Compare with…/Drop stash… stay
+// callable regardless.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/context_menus/gbm_context_menus.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/stash_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+void main() {
+  group('stashMenuItems', () {
+    test('labels and order match gbmContextMenuGroups 05-H exactly', () {
+      final List<GbmMenuItem> items = stashMenuItems(
+        onApply: () {},
+        onPop: () {},
+        onCreateBranch: () {},
+        onViewDiff: () {},
+        onCompare: () {},
+        onDrop: () {},
+      );
+
+      final List<String> actualLabels = items
+          .where((GbmMenuItem item) => !item.separator)
+          .map((GbmMenuItem item) => item.label)
+          .toList();
+      final List<String> specLabels =
+          gbmContextMenuGroups[GbmContextMenuTarget.stashEntry]!.items
+              .map((GbmContextMenuItemSpec spec) => spec.label)
+              .toList();
+
+      expect(actualLabels, specLabels);
+    });
+
+    test('Drop stash… is last, is danger, and is preceded by a separator', () {
+      final List<GbmMenuItem> items = stashMenuItems(
+        onApply: () {},
+        onPop: () {},
+        onCreateBranch: () {},
+        onViewDiff: () {},
+        onCompare: () {},
+        onDrop: () {},
+      );
+
+      expect(items.last.label, 'Drop stash…');
+      expect(items.last.danger, isTrue);
+      expect(items[items.length - 2].separator, isTrue);
+    });
+
+    test('passing null for Apply/Pop/Create branch from stash… renders them '
+        'disabled, matching a conflict-active gate', () {
+      final List<GbmMenuItem> items = stashMenuItems(
+        onApply: null,
+        onPop: null,
+        onCreateBranch: null,
+        onViewDiff: () {},
+        onCompare: () {},
+        onDrop: () {},
+      );
+
+      final Map<String, GbmMenuItem> byLabel = <String, GbmMenuItem>{
+        for (final GbmMenuItem item in items)
+          if (!item.separator) item.label: item,
+      };
+
+      expect(byLabel['Apply stash']!.onTap, isNull);
+      expect(byLabel['Pop stash']!.onTap, isNull);
+      expect(byLabel['Create branch from stash…']!.onTap, isNull);
+      // Unaffected by the same gate.
+      expect(byLabel['View diff']!.onTap, isNotNull);
+      expect(byLabel['Compare with…']!.onTap, isNotNull);
+      expect(byLabel['Drop stash…']!.onTap, isNotNull);
+    });
+
+    test('each callback reaches its matching item, not a neighbor', () {
+      bool appliedCalled = false;
+      bool poppedCalled = false;
+      bool droppedCalled = false;
+
+      final List<GbmMenuItem> items = stashMenuItems(
+        onApply: () => appliedCalled = true,
+        onPop: () => poppedCalled = true,
+        onCreateBranch: () {},
+        onViewDiff: () {},
+        onCompare: () {},
+        onDrop: () => droppedCalled = true,
+      );
+
+      items.firstWhere((GbmMenuItem i) => i.label == 'Apply stash').onTap!();
+      expect(appliedCalled, isTrue);
+      expect(poppedCalled, isFalse);
+      expect(droppedCalled, isFalse);
+
+      items.firstWhere((GbmMenuItem i) => i.label == 'Pop stash').onTap!();
+      expect(poppedCalled, isTrue);
+
+      items.firstWhere((GbmMenuItem i) => i.label == 'Drop stash…').onTap!();
+      expect(droppedCalled, isTrue);
+    });
+  });
+}

--- a/app_flutter/test/features/sidebar/widgets/stash_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/stash_menu_items_test.dart
@@ -66,8 +66,11 @@ void main() {
       };
 
       expect(byLabel['Apply stash']!.onTap, isNull);
+      expect(byLabel['Apply stash']!.enabled, isFalse);
       expect(byLabel['Pop stash']!.onTap, isNull);
+      expect(byLabel['Pop stash']!.enabled, isFalse);
       expect(byLabel['Create branch from stash…']!.onTap, isNull);
+      expect(byLabel['Create branch from stash…']!.enabled, isFalse);
       // Unaffected by the same gate.
       expect(byLabel['View diff']!.onTap, isNotNull);
       expect(byLabel['Compare with…']!.onTap, isNotNull);

--- a/app_flutter/test/features/sidebar/widgets/tag_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/tag_menu_items_test.dart
@@ -1,0 +1,140 @@
+// Pure-Dart unit tests for tagMenuItems() -- no widget pump needed.
+// Verifies the item list matches gbm_context_menus.dart's 05-D (Tag) spec
+// exactly and that "Push tag" goes through the nullable-callback gate for
+// the no-single-remote case (see the function's own doc comment for why
+// there's no "default remote" to fall back to, unlike a repository-level
+// push).
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/context_menus/gbm_context_menus.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/tag_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+void main() {
+  group('tagMenuItems', () {
+    test('labels and order match gbmContextMenuGroups 05-D exactly', () {
+      final List<GbmMenuItem> items = tagMenuItems(
+        tagName: 'v1.0.0',
+        onCheckoutDetached: () {},
+        onPush: () {},
+        onCompare: () {},
+        onDelete: () {},
+      );
+
+      final List<String> actualLabels = items
+          .where((GbmMenuItem item) => !item.separator)
+          .map((GbmMenuItem item) => item.label)
+          .toList();
+      final List<String> specLabels =
+          gbmContextMenuGroups[GbmContextMenuTarget.tag]!.items
+              .map((GbmContextMenuItemSpec spec) => spec.label)
+              .toList();
+
+      expect(actualLabels, specLabels);
+    });
+
+    test('Delete tag… is last, is danger, and is preceded by a separator', () {
+      final List<GbmMenuItem> items = tagMenuItems(
+        tagName: 'v1.0.0',
+        onCheckoutDetached: () {},
+        onPush: () {},
+        onCompare: () {},
+        onDelete: () {},
+      );
+
+      expect(items.last.label, 'Delete tag…');
+      expect(items.last.danger, isTrue);
+      expect(items[items.length - 2].separator, isTrue);
+    });
+
+    test('onPush: null renders Push tag disabled, other items unaffected', () {
+      final List<GbmMenuItem> items = tagMenuItems(
+        tagName: 'v1.0.0',
+        onCheckoutDetached: () {},
+        onPush: null,
+        onCompare: () {},
+        onDelete: () {},
+      );
+
+      final Map<String, GbmMenuItem> byLabel = <String, GbmMenuItem>{
+        for (final GbmMenuItem item in items)
+          if (!item.separator) item.label: item,
+      };
+
+      expect(byLabel['Push tag']!.onTap, isNull);
+      expect(byLabel['Checkout tag (detached)']!.onTap, isNotNull);
+      expect(byLabel['Compare with…']!.onTap, isNotNull);
+      expect(byLabel['Copy tag name']!.onTap, isNotNull);
+      expect(byLabel['Delete tag…']!.onTap, isNotNull);
+    });
+
+    test('onCheckoutDetached: null renders Checkout tag (detached) disabled, '
+        'matching a conflict-active gate', () {
+      final List<GbmMenuItem> items = tagMenuItems(
+        tagName: 'v1.0.0',
+        onCheckoutDetached: null,
+        onPush: () {},
+        onCompare: () {},
+        onDelete: () {},
+      );
+
+      final Map<String, GbmMenuItem> byLabel = <String, GbmMenuItem>{
+        for (final GbmMenuItem item in items)
+          if (!item.separator) item.label: item,
+      };
+
+      expect(byLabel['Checkout tag (detached)']!.onTap, isNull);
+      expect(byLabel['Push tag']!.onTap, isNotNull);
+    });
+
+    test('Copy tag name copies the tag\'s own name to the clipboard', () async {
+      final List<Object?> clipboardCalls = <Object?>[];
+      TestWidgetsFlutterBinding.ensureInitialized().defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.setData') {
+              clipboardCalls.add(call.arguments);
+            }
+            return null;
+          });
+      addTearDown(
+        () => TestWidgetsFlutterBinding.ensureInitialized()
+            .defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+
+      final List<GbmMenuItem> items = tagMenuItems(
+        tagName: 'release-2.0',
+        onCheckoutDetached: () {},
+        onPush: () {},
+        onCompare: () {},
+        onDelete: () {},
+      );
+      items.firstWhere((GbmMenuItem i) => i.label == 'Copy tag name').onTap!();
+
+      expect(clipboardCalls, hasLength(1));
+      expect((clipboardCalls.single as Map)['text'], 'release-2.0');
+    });
+
+    test('each callback reaches its matching item, not a neighbor', () {
+      bool checkedOut = false;
+      bool deleted = false;
+
+      final List<GbmMenuItem> items = tagMenuItems(
+        tagName: 'v1.0.0',
+        onCheckoutDetached: () => checkedOut = true,
+        onPush: () {},
+        onCompare: () {},
+        onDelete: () => deleted = true,
+      );
+
+      items
+          .firstWhere((GbmMenuItem i) => i.label == 'Checkout tag (detached)')
+          .onTap!();
+      expect(checkedOut, isTrue);
+      expect(deleted, isFalse);
+
+      items.firstWhere((GbmMenuItem i) => i.label == 'Delete tag…').onTap!();
+      expect(deleted, isTrue);
+    });
+  });
+}

--- a/app_flutter/test/features/sidebar/widgets/tag_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/tag_menu_items_test.dart
@@ -62,6 +62,7 @@ void main() {
       };
 
       expect(byLabel['Push tag']!.onTap, isNull);
+      expect(byLabel['Push tag']!.enabled, isFalse);
       expect(byLabel['Checkout tag (detached)']!.onTap, isNotNull);
       expect(byLabel['Compare with…']!.onTap, isNotNull);
       expect(byLabel['Copy tag name']!.onTap, isNotNull);
@@ -84,6 +85,7 @@ void main() {
       };
 
       expect(byLabel['Checkout tag (detached)']!.onTap, isNull);
+      expect(byLabel['Checkout tag (detached)']!.enabled, isFalse);
       expect(byLabel['Push tag']!.onTap, isNotNull);
     });
 

--- a/app_flutter/test/features/workspace/widgets/workspace_tab_test.dart
+++ b/app_flutter/test/features/workspace/widgets/workspace_tab_test.dart
@@ -1,10 +1,13 @@
-// Pure-Dart unit tests for workspace_tab.dart's data model and the two
-// helper functions tab_row.dart is switched onto in this commit --
-// defaultWorkspaceTabs() (the fixed History/Working Copy pair) and
-// activeWorkspaceTabIndex() (the location -> active-tab lookup that
-// replaces tab_row.dart's old `location.endsWith('/working-copy')` check).
-// No widget pump needed: everything here is plain data/functions.
+// Pure-Dart unit tests for workspace_tab.dart's data model and its three
+// helper functions -- defaultWorkspaceTabs() (the fixed History/Working
+// Copy pair), activeWorkspaceTabIndex() (the location -> active-tab
+// lookup), and nextWorkspaceTabRoute() (View > Next tab / Ctrl+Tab's
+// wrap-around route lookup, backing workspace_screen.dart's
+// GbmActionId.viewNextTab handler). No widget pump needed: everything here
+// is plain data/functions.
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/repositories/compare_tabs_repository.dart';
+import 'package:gbm_flutter/features/workspace/widgets/tab_row.dart';
 import 'package:gbm_flutter/features/workspace/widgets/workspace_tab.dart';
 import 'package:gbm_flutter/routing/route_paths.dart';
 
@@ -96,6 +99,81 @@ void main() {
     test('falls back to index 0 (History) when location matches no tab route, '
         'mirroring the old !onWorkingCopy default', () {
       expect(activeWorkspaceTabIndex(tabs, '/repo/$_repoId/dialogs/merge'), 0);
+    });
+  });
+
+  group('nextWorkspaceTabRoute', () {
+    test('from History, returns Working Copy\'s route', () {
+      final List<WorkspaceTab> tabs = defaultWorkspaceTabs(
+        _repoId,
+        pendingChangeCount: 0,
+      );
+
+      expect(
+        nextWorkspaceTabRoute(tabs, RoutePaths.historyFor(_repoId)),
+        RoutePaths.workingCopyFor(_repoId),
+      );
+    });
+
+    test('from the last tab, wraps back around to the first tab\'s route', () {
+      final List<WorkspaceTab> tabs = defaultWorkspaceTabs(
+        _repoId,
+        pendingChangeCount: 0,
+      );
+
+      expect(
+        nextWorkspaceTabRoute(tabs, RoutePaths.workingCopyFor(_repoId)),
+        RoutePaths.historyFor(_repoId),
+      );
+    });
+
+    test('cycles through an open Compare tab between Working Copy and the '
+        'wrap back to History', () {
+      final CompareTabSpec compareSpec = const CompareTabSpec(
+        id: 'tab1',
+        left: 'HEAD',
+      );
+      final List<WorkspaceTab> tabs = <WorkspaceTab>[
+        ...defaultWorkspaceTabs(_repoId, pendingChangeCount: 0),
+        compareWorkspaceTab(compareSpec, _repoId),
+      ];
+
+      expect(
+        nextWorkspaceTabRoute(tabs, RoutePaths.workingCopyFor(_repoId)),
+        RoutePaths.compareFor(_repoId, 'tab1'),
+      );
+      expect(
+        nextWorkspaceTabRoute(tabs, RoutePaths.compareFor(_repoId, 'tab1')),
+        RoutePaths.historyFor(_repoId),
+      );
+    });
+
+    test('when location matches no tab route, falls back to index 0 first '
+        '(mirroring activeWorkspaceTabIndex) and advances to Working Copy', () {
+      final List<WorkspaceTab> tabs = defaultWorkspaceTabs(
+        _repoId,
+        pendingChangeCount: 0,
+      );
+
+      expect(
+        nextWorkspaceTabRoute(tabs, '/repo/$_repoId/dialogs/merge'),
+        RoutePaths.workingCopyFor(_repoId),
+      );
+    });
+
+    test('with only one tab, returns that same tab\'s route', () {
+      final List<WorkspaceTab> tabs = <WorkspaceTab>[
+        WorkspaceTab(
+          kind: WorkspaceTabKind.history,
+          label: 'History',
+          route: RoutePaths.historyFor(_repoId),
+        ),
+      ];
+
+      expect(
+        nextWorkspaceTabRoute(tabs, RoutePaths.historyFor(_repoId)),
+        RoutePaths.historyFor(_repoId),
+      );
     });
   });
 }

--- a/app_flutter/test/integration/workspace_next_tab_intent_test.dart
+++ b/app_flutter/test/integration/workspace_next_tab_intent_test.dart
@@ -1,0 +1,134 @@
+// Regression coverage for GbmActionId.viewNextTab: workspace_screen.dart's
+// _buildActionHandlers() hardcoded this id to `null` even though
+// gbm_shortcuts.dart binds Ctrl/Cmd+Tab to it and gbm_menu_model.dart draws
+// "Next tab" under View -- so both the keyboard shortcut and the menu item
+// rendered as live UI that silently did nothing on click/press, the same
+// failure shape CLAUDE.md documents for the historical
+// repositoryFetch/Pull/Push/viewToggleSidebar bug.
+//
+// This drives the real WorkspaceScreen behind pumpWorkspace (not a hand-fed
+// handler map) so it exercises the actual GoRouter location the same way a
+// user's keypress would, including wrapping through a Compare tab opened
+// via the real compareTabsProvider.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/features/workspace/workspace_screen.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:go_router/go_router.dart';
+
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/repo',
+  gitDir: '/test/repo/.git',
+);
+
+final List<RouteBase> _compareRoute = <RouteBase>[
+  GoRoute(
+    path: RoutePaths.compare,
+    builder: (context, state) =>
+        const Scaffold(body: SizedBox(key: Key('compare-stub'))),
+  ),
+];
+
+String _location(WidgetTester tester) => GoRouterState.of(
+  tester.element(find.byType(WorkspaceScreen)),
+).uri.toString();
+
+// pumpWorkspace always passes isMacOS: false unless overridden, so the
+// bound shortcut is Ctrl+Tab (see gbm_shortcuts.dart's _makeShortcut).
+Future<void> _pressCtrlTab(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.tab);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.tab);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openCompareTab(WidgetTester tester) async {
+  await tester.tap(find.text('Repository'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Compare…'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('View > Next tab / Ctrl+Tab intent dispatch', () {
+    testWidgets('Ctrl+Tab from History navigates to Working Copy', (
+      tester,
+    ) async {
+      await pumpWorkspace(tester, identity: _identity);
+      expect(
+        _location(tester),
+        RoutePaths.historyFor(Uri.encodeComponent(_identity.workDir)),
+      );
+
+      await _pressCtrlTab(tester);
+
+      expect(
+        _location(tester),
+        RoutePaths.workingCopyFor(Uri.encodeComponent(_identity.workDir)),
+        reason:
+            'Ctrl+Tab should advance to the next tab the same way View > '
+            'Next tab does -- it currently no-ops because '
+            'actionHandlers[viewNextTab] is hardcoded null.',
+      );
+    });
+
+    testWidgets('Ctrl+Tab from the last tab wraps back around to History', (
+      tester,
+    ) async {
+      await pumpWorkspace(tester, identity: _identity);
+
+      await _pressCtrlTab(tester);
+      expect(
+        _location(tester),
+        RoutePaths.workingCopyFor(Uri.encodeComponent(_identity.workDir)),
+      );
+
+      await _pressCtrlTab(tester);
+
+      expect(
+        _location(tester),
+        RoutePaths.historyFor(Uri.encodeComponent(_identity.workDir)),
+      );
+    });
+
+    testWidgets(
+      'Ctrl+Tab cycles through an open Compare tab between Working Copy '
+      'and the wrap back to History',
+      (tester) async {
+        await pumpWorkspace(
+          tester,
+          identity: _identity,
+          extraRoutes: _compareRoute,
+        );
+
+        await _openCompareTab(tester);
+        expect(_location(tester), contains('/compare/'));
+        final String compareLocation = _location(tester);
+
+        await _pressCtrlTab(tester);
+
+        expect(
+          _location(tester),
+          RoutePaths.historyFor(Uri.encodeComponent(_identity.workDir)),
+          reason:
+              'the newly-opened Compare tab is last in tab order, so '
+              'the next tab after it wraps back to History.',
+        );
+
+        await _pressCtrlTab(tester);
+        expect(
+          _location(tester),
+          RoutePaths.workingCopyFor(Uri.encodeComponent(_identity.workDir)),
+        );
+
+        await _pressCtrlTab(tester);
+        expect(_location(tester), compareLocation);
+      },
+    );
+  });
+}

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -223,11 +223,15 @@ class FakeRepoSessionController extends RepoSessionController {
   @override
   void fetchRemote({
     String remoteName = '',
+    List<String> refs = const <String>[],
     bool prune = false,
     bool tags = false,
   }) {
     commandLog.add(
-      FakeCommand('fetchRemote', <String, Object?>{'remoteName': remoteName}),
+      FakeCommand('fetchRemote', <String, Object?>{
+        'remoteName': remoteName,
+        'refs': refs,
+      }),
     );
   }
 

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -313,6 +313,20 @@ class FakeRepoSessionController extends RepoSessionController {
   }
 
   @override
+  void addRemote(String name, String url) {
+    commandLog.add(
+      FakeCommand('addRemote', <String, Object?>{'name': name, 'url': url}),
+    );
+  }
+
+  @override
+  void removeRemote(String name) {
+    commandLog.add(
+      FakeCommand('removeRemote', <String, Object?>{'name': name}),
+    );
+  }
+
+  @override
   void renameBranch({
     required String from,
     required String to,

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -269,6 +269,21 @@ class FakeRepoSessionController extends RepoSessionController {
   }
 
   @override
+  void deleteBranch({
+    required List<String> names,
+    bool force = false,
+    bool isRemote = false,
+    String remoteName = '',
+  }) {
+    commandLog.add(
+      FakeCommand('deleteBranch', <String, Object?>{
+        'names': names,
+        'force': force,
+      }),
+    );
+  }
+
+  @override
   void checkout({
     required String target,
     bool detach = false,

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -309,6 +309,74 @@ class FakeRepoSessionController extends RepoSessionController {
   }
 
   @override
+  void applyStash(int index, {bool pop = false}) {
+    commandLog.add(
+      FakeCommand('applyStash', <String, Object?>{'index': index, 'pop': pop}),
+    );
+  }
+
+  @override
+  void dropStash(int index) {
+    commandLog.add(FakeCommand('dropStash', <String, Object?>{'index': index}));
+  }
+
+  @override
+  void branchFromStash(int index, String branchName) {
+    commandLog.add(
+      FakeCommand('branchFromStash', <String, Object?>{
+        'index': index,
+        'branchName': branchName,
+      }),
+    );
+  }
+
+  @override
+  void requestStashDiff(int index) {
+    commandLog.add(
+      FakeCommand('requestStashDiff', <String, Object?>{'index': index}),
+    );
+  }
+
+  @override
+  void createTag(
+    String name, {
+    String target = '',
+    String message = '',
+    bool force = false,
+  }) {
+    commandLog.add(
+      FakeCommand('createTag', <String, Object?>{
+        'name': name,
+        'target': target,
+      }),
+    );
+  }
+
+  @override
+  void deleteTag(
+    String name, {
+    bool alsoRemote = false,
+    String remoteName = '',
+  }) {
+    commandLog.add(
+      FakeCommand('deleteTag', <String, Object?>{
+        'name': name,
+        'alsoRemote': alsoRemote,
+      }),
+    );
+  }
+
+  @override
+  void pushTag(String remoteName, {String name = ''}) {
+    commandLog.add(
+      FakeCommand('pushTag', <String, Object?>{
+        'remoteName': remoteName,
+        'name': name,
+      }),
+    );
+  }
+
+  @override
   void provideCredential(String secret) {
     commandLog.add(const FakeCommand('provideCredential'));
   }

--- a/src/capi/CMakeLists.txt
+++ b/src/capi/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(gbm_capi SHARED
     Handle.cpp
     History.cpp
     Identity.cpp
+    InitClone.cpp
     JsonCodec.cpp
     Lfs.cpp
     Merge.cpp

--- a/src/capi/InitClone.cpp
+++ b/src/capi/InitClone.cpp
@@ -1,0 +1,61 @@
+#include "capi/JsonCodec.h"
+#include "capi/Session.h"
+#include "capi/StagingBuffer.h"
+#include "capi/gbm_capi.h"
+#include "core/base/CancellationToken.h"
+#include "core/git/ops/InitCloneOps.h"
+
+using namespace gbm;
+using namespace gbm::capi;
+
+namespace {
+
+/// -(1 + code-ordinal), matching gbm_capi.h's GbmErrorCode mapping -- same
+/// helper as Discovery.cpp's, duplicated rather than shared since these
+/// session-less capi files have no common base to hang it from.
+int32_t errorCodeOrdinal(const GitError& error) {
+    return -(1 + static_cast<int32_t>(error.code));
+}
+
+}  // namespace
+
+GBM_API int32_t gbm_repo_init(const char* path) {
+    const GitResult<GitInstallation> installation = sharedGitInstallation();
+    if (!installation) {
+        setStagingBuffer(toJson(installation.error()));
+        return errorCodeOrdinal(installation.error());
+    }
+    std::unique_ptr<IProcessRunner> runner = makeProcessRunner(installation.value().executable);
+
+    InitRepoRequest request;
+    request.path = path != nullptr ? path : "";
+
+    const CancellationSource cancel;  // Synchronous, like gbm_discovery_scan_all.
+    const GitResult<void> result = runInitRepo(*runner, request, cancel.token());
+    if (!result) {
+        setStagingBuffer(toJson(result.error()));
+        return errorCodeOrdinal(result.error());
+    }
+    return 0;
+}
+
+GBM_API int32_t gbm_repo_clone(const char* url, const char* destPath) {
+    const GitResult<GitInstallation> installation = sharedGitInstallation();
+    if (!installation) {
+        setStagingBuffer(toJson(installation.error()));
+        return errorCodeOrdinal(installation.error());
+    }
+    std::unique_ptr<IProcessRunner> runner = makeProcessRunner(installation.value().executable);
+
+    CloneRepoRequest request;
+    request.url = url != nullptr ? url : "";
+    request.destPath = destPath != nullptr ? destPath : "";
+
+    const CancellationSource cancel;  // Synchronous, like gbm_discovery_scan_all.
+    const GitResult<void> result = runCloneRepo(*runner, request, cancel.token());
+    if (!result) {
+        setStagingBuffer(toJson(result.error()));
+        return errorCodeOrdinal(result.error());
+    }
+    return 0;
+}

--- a/src/capi/Remotes.cpp
+++ b/src/capi/Remotes.cpp
@@ -43,10 +43,13 @@ GBM_API int32_t gbm_remotes_json(GbmSessionHandle session) {
 
 GBM_API void gbm_remote_fetch(GbmSessionHandle session,
                               const char* remoteName,
+                              const char* const* refs,
+                              int32_t refCount,
                               int32_t prune,
                               int32_t tags) {
     FetchRequest request;
     request.remoteName = remoteName != nullptr ? remoteName : "";
+    request.refs = toStringVector(refs, refCount);
     request.prune = prune != 0;
     request.tags = tags != 0;
     toSession(session)->fetchRemote(std::move(request));

--- a/src/capi/Remotes.cpp
+++ b/src/capi/Remotes.cpp
@@ -94,6 +94,19 @@ GBM_API void gbm_remote_prune(GbmSessionHandle session,
     toSession(session)->pruneRemote(std::move(request));
 }
 
+GBM_API void gbm_remote_add(GbmSessionHandle session, const char* name, const char* url) {
+    AddRemoteRequest request;
+    request.name = name != nullptr ? name : "";
+    request.url = url != nullptr ? url : "";
+    toSession(session)->addRemote(std::move(request));
+}
+
+GBM_API void gbm_remote_remove(GbmSessionHandle session, const char* name) {
+    RemoveRemoteRequest request;
+    request.name = name != nullptr ? name : "";
+    toSession(session)->removeRemote(std::move(request));
+}
+
 GBM_API void gbm_provide_credential(GbmSessionHandle session, const char* secret) {
     toSession(session)->provideCredential(secret != nullptr ? secret : "");
 }

--- a/src/capi/Session.cpp
+++ b/src/capi/Session.cpp
@@ -734,6 +734,20 @@ void Session::pruneRemote(PruneRemoteRequest request) {
     submitOperation(makePruneRemoteOperation(std::move(request)), /*refreshHistoryOnSuccess=*/true);
 }
 
+void Session::addRemote(AddRemoteRequest request) {
+    // Not submitWorkingCopyOperation, same reasoning as pruneRemote():
+    // this only touches repo config, never the working tree or index.
+    submitOperation(makeAddRemoteOperation(std::move(request)),
+                    /*refreshHistoryOnSuccess=*/false,
+                    [this]() { refreshRemotes(); });
+}
+
+void Session::removeRemote(RemoveRemoteRequest request) {
+    submitOperation(makeRemoveRemoteOperation(std::move(request)),
+                    /*refreshHistoryOnSuccess=*/false,
+                    [this]() { refreshRemotes(); });
+}
+
 void Session::provideCredential(std::string secret) {
     askpass_.answer(secret);
 }

--- a/src/capi/Session.h
+++ b/src/capi/Session.h
@@ -255,6 +255,10 @@ public:
     /// Async: see gbm_remote_prune()'s doc comment.
     void pruneRemote(PruneRemoteRequest request);
 
+    /// Async: see gbm_remote_add()/gbm_remote_remove()'s doc comments.
+    void addRemote(AddRemoteRequest request);
+    void removeRemote(RemoveRemoteRequest request);
+
     /// Async: see gbm_provide_credential()/gbm_cancel_credential()'s doc
     /// comments. A no-op if no prompt is currently outstanding.
     void provideCredential(std::string secret);

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -1174,6 +1174,28 @@ GBM_API int32_t gbm_has_commit_graph(GbmSessionHandle session);
 /// are unchanged -- see the doc comment on the mirrored Qt method).
 GBM_API void gbm_write_commit_graph(GbmSessionHandle session);
 
+// --- Repository creation (init / clone) -------------------------------------
+// Session-less, like Discovery below: these create the repository directory
+// itself, so they run before any GbmSessionHandle exists. On success, the
+// caller opens a normal session on the resulting working directory via
+// gbm_session_open() -- neither function opens or returns a session itself.
+
+/// Runs `git init <path>` synchronously (blocks the calling thread -- init
+/// is local and fast, so this is safe to call directly, unlike clone below).
+/// `path` is created if it doesn't already exist. Returns 0 on success, or a
+/// negative GbmErrorCode with the staging buffer populated with a GitError
+/// JSON.
+GBM_API int32_t gbm_repo_init(const char* path);
+
+/// Runs `git clone <url> <destPath>` synchronously (blocks the calling
+/// thread -- callers should run this off the UI isolate, e.g. via Dart's
+/// Isolate.run, the same caveat gbm_discovery_scan_all() carries, now
+/// extended to a network operation with no upper bound on how long it may
+/// run). Per-object transfer progress is not reported -- see
+/// InitCloneOps.h's doc comment. Returns 0 on success, or a negative
+/// GbmErrorCode with the staging buffer populated with a GitError JSON.
+GBM_API int32_t gbm_repo_clone(const char* url, const char* destPath);
+
 // --- Discovery -------------------------------------------------------------
 // A separate handle class from GbmSessionHandle: discovery scans base
 // folders and is not tied to any one open repository -- see

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -707,12 +707,21 @@ GBM_API void gbm_remote_refresh(GbmSessionHandle session);
 /// gbm_remote_refresh() has not yet published one.
 GBM_API int32_t gbm_remotes_json(GbmSessionHandle session);
 
-/// `git fetch`. `remoteName` empty fetches every remote (`--all`). Async:
-/// fires GBM_EVENT_WORKING_COPY_OPERATION_FINISHED, and on success also
-/// triggers the same refresh gbm_history_refresh() would (a fetch can bring
-/// in new commits on remote-tracking refs).
+/// `git fetch`. `remoteName` empty fetches every remote (`--all`). `refs`
+/// (with `refCount` entries) restricts the fetch to those specific refs
+/// under `remoteName` (e.g. one branch, or every branch under a folder
+/// prefix) instead of everything the remote's default refspec would bring
+/// in -- `refCount` 0 fetches everything, the original behavior. A non-zero
+/// `refCount` with an empty `remoteName` is rejected (see
+/// GBM_EVENT_OPERATION_FINISHED's outcome): there is no well-defined "these
+/// refs from every remote". Async: fires
+/// GBM_EVENT_WORKING_COPY_OPERATION_FINISHED, and on success also triggers
+/// the same refresh gbm_history_refresh() would (a fetch can bring in new
+/// commits on remote-tracking refs).
 GBM_API void gbm_remote_fetch(GbmSessionHandle session,
                               const char* remoteName,
+                              const char* const* refs,
+                              int32_t refCount,
                               int32_t prune,
                               int32_t tags);
 

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -761,6 +761,17 @@ GBM_API void gbm_remote_prune(GbmSessionHandle session,
                               const char* const* refs,
                               int32_t refCount);
 
+/// `git remote add <name> <url>`. Async: fires GBM_EVENT_OPERATION_FINISHED
+/// (same channel as gbm_remote_prune() -- adding a remote touches only repo
+/// config, not the working tree or index), and on success also triggers the
+/// same refresh gbm_remote_refresh() would.
+GBM_API void gbm_remote_add(GbmSessionHandle session, const char* name, const char* url);
+
+/// `git remote remove <name>`. Async: fires GBM_EVENT_OPERATION_FINISHED,
+/// and on success also triggers the same refresh gbm_remote_refresh()
+/// would.
+GBM_API void gbm_remote_remove(GbmSessionHandle session, const char* name);
+
 // --- Credential prompts (askpass) -------------------------------------
 // Answers or dismisses whichever prompt GBM_EVENT_CREDENTIAL_REQUESTED most
 // recently announced. A no-op if none is currently outstanding.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(gbm_core STATIC
     git/ops/CompareOps.cpp
     git/ops/ConfigOps.cpp
     git/ops/ConflictOps.cpp
+    git/ops/InitCloneOps.cpp
     git/ops/LfsOps.cpp
     git/ops/MaintenanceOps.cpp
     git/ops/MergeOps.cpp

--- a/src/core/git/ops/InitCloneOps.cpp
+++ b/src/core/git/ops/InitCloneOps.cpp
@@ -1,0 +1,49 @@
+#include "core/git/ops/InitCloneOps.h"
+
+#include "core/git/AskpassHelper.h"
+
+#include <utility>
+
+namespace gbm {
+
+GitResult<void> runInitRepo(IProcessRunner& runner,
+                            const InitRepoRequest& request,
+                            CancellationToken token) {
+    if (request.path.empty()) {
+        return fail(GitError::Code::InvalidArgument, "A repository path is required");
+    }
+
+    GitCommand command;
+    command.args = {"init", "--quiet", request.path.string()};
+    command.timeout = std::chrono::seconds(30);
+
+    auto result = runner.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+    return {};
+}
+
+GitResult<void> runCloneRepo(IProcessRunner& runner,
+                             const CloneRepoRequest& request,
+                             CancellationToken token) {
+    if (request.url.empty()) {
+        return fail(GitError::Code::InvalidArgument, "A repository URL is required");
+    }
+    if (request.destPath.empty()) {
+        return fail(GitError::Code::InvalidArgument, "A destination path is required");
+    }
+
+    GitCommand command;
+    command.args = {"clone", "--quiet", request.url, request.destPath.string()};
+    command.timeout = std::chrono::milliseconds(0);
+    askpass::wire(command, request.askpassDir);
+
+    auto result = runner.run(command, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+    return {};
+}
+
+}  // namespace gbm

--- a/src/core/git/ops/InitCloneOps.h
+++ b/src/core/git/ops/InitCloneOps.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "core/base/CancellationToken.h"
+#include "core/base/Error.h"
+#include "core/git/IProcessRunner.h"
+
+#include <filesystem>
+#include <string>
+
+namespace gbm {
+
+struct InitRepoRequest {
+    std::filesystem::path path;
+};
+
+struct CloneRepoRequest {
+    std::string url;
+    std::filesystem::path destPath;
+    /// Set by the app layer to a directory made with askpass::makeRequestDir();
+    /// empty means "no credential prompt is possible", and an auth failure is
+    /// reported immediately instead. Same convention as FetchRequest.
+    std::filesystem::path askpassDir;
+};
+
+/// `git init <path>`. These run before any RepoPaths/Session exists -- see
+/// RemoteOps.h's Operation subclasses for the ordinary case, which all
+/// require an already-open repository -- so this is a plain function taking
+/// IProcessRunner directly rather than an Operation. `path` is created if it
+/// doesn't already exist (git init does this itself, including missing
+/// parents); reinitializing an existing repository is not treated as an
+/// error, matching git's own behavior.
+GitResult<void> runInitRepo(IProcessRunner& runner,
+                            const InitRepoRequest& request,
+                            CancellationToken token);
+
+/// `git clone <url> <destPath>`. Zero timeout, like every network operation
+/// in this app (see RemoteOps.h's FetchOperation): a slow clone is not a
+/// hang, and cancellation is how the user actually stops it. Per-object
+/// transfer progress is not parsed from stderr -- same scope cut this app
+/// already makes for fetch/pull/push -- so this reports only success or
+/// failure, not a running byte/object count.
+GitResult<void> runCloneRepo(IProcessRunner& runner,
+                             const CloneRepoRequest& request,
+                             CancellationToken token);
+
+}  // namespace gbm

--- a/src/core/git/ops/RemoteOps.cpp
+++ b/src/core/git/ops/RemoteOps.cpp
@@ -218,6 +218,74 @@ private:
     PruneRemoteRequest request_;
 };
 
+class AddRemoteOperation final : public Operation {
+public:
+    explicit AddRemoteOperation(AddRemoteRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Add remote " + request_.name; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.name.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "Remote name is required");
+            return outcome;
+        }
+        if (request_.url.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "Remote URL is required");
+            return outcome;
+        }
+
+        GitCommand command(paths.commandDir(), {"remote", "add", request_.name, request_.url});
+        command.timeout = std::chrono::seconds(30);
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    AddRemoteRequest request_;
+};
+
+class RemoveRemoteOperation final : public Operation {
+public:
+    explicit RemoveRemoteOperation(RemoveRemoteRequest request) : request_(std::move(request)) {}
+
+    std::string describe() const override { return "Remove remote " + request_.name; }
+
+    OperationOutcome run(IProcessRunner& runner,
+                         const RepoPaths& paths,
+                         CancellationToken token) override {
+        OperationOutcome outcome;
+        if (request_.name.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument, "Remote name is required");
+            return outcome;
+        }
+
+        GitCommand command(paths.commandDir(), {"remote", "remove", request_.name});
+        command.timeout = std::chrono::seconds(30);
+        auto result = runner.run(command, token);
+        if (!result) {
+            outcome.error = std::move(result).error();
+            outcome.summary = outcome.error->message;
+            return outcome;
+        }
+        outcome.succeeded = true;
+        outcome.summary = describe();
+        return outcome;
+    }
+
+private:
+    RemoveRemoteRequest request_;
+};
+
 }  // namespace
 
 RemoteStore::RemoteStore(IProcessRunner& runner, RepoPaths paths)
@@ -319,6 +387,14 @@ std::unique_ptr<Operation> makePushOperation(PushRequest request) {
 
 std::unique_ptr<Operation> makePruneRemoteOperation(PruneRemoteRequest request) {
     return std::make_unique<PruneRemoteOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeAddRemoteOperation(AddRemoteRequest request) {
+    return std::make_unique<AddRemoteOperation>(std::move(request));
+}
+
+std::unique_ptr<Operation> makeRemoveRemoteOperation(RemoveRemoteRequest request) {
+    return std::make_unique<RemoveRemoteOperation>(std::move(request));
 }
 
 }  // namespace gbm

--- a/src/core/git/ops/RemoteOps.cpp
+++ b/src/core/git/ops/RemoteOps.cpp
@@ -21,6 +21,12 @@ public:
                          const RepoPaths& paths,
                          CancellationToken token) override {
         OperationOutcome outcome;
+        if (!request_.refs.empty() && request_.remoteName.empty()) {
+            outcome.error = GitError(GitError::Code::InvalidArgument,
+                                     "Fetching specific refs requires a remote name");
+            return outcome;
+        }
+
         std::vector<std::string> args{"fetch"};
         if (request_.prune) {
             args.emplace_back("--prune");
@@ -32,6 +38,9 @@ public:
             args.emplace_back("--all");
         } else {
             args.push_back(request_.remoteName);
+            for (const std::string& ref : request_.refs) {
+                args.push_back(ref);
+            }
         }
 
         GitCommand command(paths.commandDir(), std::move(args));

--- a/src/core/git/ops/RemoteOps.h
+++ b/src/core/git/ops/RemoteOps.h
@@ -49,6 +49,12 @@ private:
 
 struct FetchRequest {
     std::string remoteName;  ///< Empty fetches every remote (`--all`).
+    /// Specific refs to fetch from `remoteName` (e.g. one branch, or every
+    /// branch under a folder prefix) rather than every branch the remote's
+    /// default refspec would bring in. Empty fetches everything, the
+    /// existing behavior. Requires a non-empty `remoteName` -- there is no
+    /// well-defined "these refs from every remote".
+    std::vector<std::string> refs;
     bool prune = false;
     bool tags = false;
     /// Set by the app layer to a directory made with askpass::makeRequestDir();

--- a/src/core/git/ops/RemoteOps.h
+++ b/src/core/git/ops/RemoteOps.h
@@ -89,6 +89,15 @@ struct PruneRemoteRequest {
     std::vector<std::string> refs;  ///< Exact set to delete -- see RemotePrunePreviewEntry.
 };
 
+struct AddRemoteRequest {
+    std::string name;
+    std::string url;
+};
+
+struct RemoveRemoteRequest {
+    std::string name;
+};
+
 /// `git fetch`. Zero timeout, like every network operation here: a slow link
 /// is not a hang, and cancellation is how the user actually stops it.
 std::unique_ptr<Operation> makeFetchOperation(FetchRequest request);
@@ -108,5 +117,14 @@ std::unique_ptr<Operation> makePushOperation(PushRequest request);
 /// command has no "delete only these" mode, so a dialog that lets the user
 /// deselect entries first can't be built on top of it.
 std::unique_ptr<Operation> makePruneRemoteOperation(PruneRemoteRequest request);
+
+/// `git remote add <name> <url>`. Rejects an empty name or URL before
+/// spawning git -- both produce a git error anyway, but the message this
+/// way names which field was missing rather than surfacing git's own
+/// usage text.
+std::unique_ptr<Operation> makeAddRemoteOperation(AddRemoteRequest request);
+
+/// `git remote remove <name>`.
+std::unique_ptr<Operation> makeRemoveRemoteOperation(RemoveRemoteRequest request);
 
 }  // namespace gbm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(gbm_core_tests
     unit/GitExecutableTest.cpp
     unit/GitIntegrationTest.cpp
     unit/GraphBuilderTest.cpp
+    unit/InitCloneOpsTest.cpp
     unit/MaintenanceOpsTest.cpp
     unit/OriginalOperationMessageTest.cpp
     unit/PreparedCommitMessageTest.cpp
@@ -124,6 +125,7 @@ if(GBM_BUILD_CAPI)
         capi/DiscoveryApiTest.cpp
         capi/FileHistoryApiTest.cpp
         capi/IdentityApiTest.cpp
+        capi/InitCloneApiTest.cpp
         capi/JsonCodecTest.cpp
         capi/LfsApiTest.cpp
         capi/MergeApiTest.cpp

--- a/tests/capi/InitCloneApiTest.cpp
+++ b/tests/capi/InitCloneApiTest.cpp
@@ -1,0 +1,138 @@
+// Integration tests for the session-less repository-creation slice of the
+// extern "C" surface (gbm_capi.h): gbm_repo_init and gbm_repo_clone. Clone
+// is tested against a local bare repository reached over the plain
+// filesystem transport, which needs no credentials -- git never invokes
+// askpass for it, so this stays fully offline, same as RemoteApiTest.cpp.
+#include "capi/gbm_capi.h"
+#include "core/git/GitExecutable.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace gbm::capi {
+namespace {
+
+std::string lastResultJson() {
+    std::string json(static_cast<std::size_t>(gbm_last_result_json_len()), '\0');
+    gbm_last_result_json_copy(reinterpret_cast<uint8_t*>(json.data()),
+                              static_cast<int32_t>(json.size()));
+    return json;
+}
+
+class InitCloneApiTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        auto detected = GitExecutable::detect();
+        if (!detected) {
+            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        }
+    }
+
+    void SetUp() override {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        base_ = std::filesystem::temp_directory_path() /
+                ("gbm-capi-initclone-" + std::string(info->name()));
+        std::filesystem::remove_all(base_);
+        std::filesystem::create_directories(base_);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(base_, ec);
+    }
+
+    /// A bare repo with one commit on main, reachable as a plain filesystem
+    /// path -- git treats that as a transport with no network/credentials
+    /// involved, same fixture style as RemoteApiTest.cpp.
+    std::filesystem::path makeBareOrigin() {
+        const std::filesystem::path origin = base_ / "origin.git";
+        const std::filesystem::path scratch = base_ / "origin-scratch";
+        std::filesystem::create_directories(scratch);
+
+        auto run = [](const std::string& cmd) { ASSERT_EQ(std::system(cmd.c_str()), 0); };
+        run("git init --quiet --bare --initial-branch=main \"" + origin.string() + "\"");
+        run("git -C \"" + scratch.string() + "\" init --quiet --initial-branch=main");
+        run("git -C \"" + scratch.string() + "\" config user.email test@example.com");
+        run("git -C \"" + scratch.string() + "\" config user.name Test");
+        {
+            std::ofstream file(scratch / "README.md");
+            file << "hello\n";
+        }
+        run("git -C \"" + scratch.string() + "\" add README.md");
+        run("git -C \"" + scratch.string() + "\" commit --quiet -m initial");
+        run("git -C \"" + scratch.string() + "\" push --quiet \"" + origin.string() + "\" main");
+        return origin;
+    }
+
+    std::filesystem::path base_;
+};
+
+TEST_F(InitCloneApiTest, InitCreatesAUsableRepository) {
+    const std::filesystem::path repo = base_ / "new-project";
+
+    ASSERT_EQ(gbm_repo_init(repo.string().c_str()), 0);
+
+    EXPECT_TRUE(std::filesystem::is_directory(repo / ".git"));
+}
+
+TEST_F(InitCloneApiTest, InitCreatesMissingParentDirectories) {
+    const std::filesystem::path repo = base_ / "nested" / "deep" / "new-project";
+
+    ASSERT_EQ(gbm_repo_init(repo.string().c_str()), 0);
+
+    EXPECT_TRUE(std::filesystem::is_directory(repo / ".git"));
+}
+
+TEST_F(InitCloneApiTest, InitFailsCleanlyWithAnEmptyPath) {
+    const int32_t result = gbm_repo_init("");
+
+    EXPECT_LT(result, 0);
+    EXPECT_NE(lastResultJson().find("InvalidArgument"), std::string::npos);
+}
+
+TEST_F(InitCloneApiTest, CloneCreatesAWorkingCopyWithTheOriginsHistory) {
+    const std::filesystem::path origin = makeBareOrigin();
+    const std::filesystem::path dest = base_ / "cloned";
+
+    ASSERT_EQ(gbm_repo_clone(origin.string().c_str(), dest.string().c_str()), 0);
+
+    EXPECT_TRUE(std::filesystem::is_directory(dest / ".git"));
+    EXPECT_TRUE(std::filesystem::is_regular_file(dest / "README.md"));
+}
+
+TEST_F(InitCloneApiTest, CloneFailsCleanlyWhenTheSourceDoesNotExist) {
+    const std::filesystem::path missing = base_ / "does-not-exist.git";
+    const std::filesystem::path dest = base_ / "cloned";
+
+    const int32_t result = gbm_repo_clone(missing.string().c_str(), dest.string().c_str());
+
+    EXPECT_LT(result, 0);
+    EXPECT_FALSE(std::filesystem::exists(dest));
+}
+
+TEST_F(InitCloneApiTest, CloneFailsCleanlyWithAnEmptyUrl) {
+    const std::filesystem::path dest = base_ / "cloned";
+
+    const int32_t result = gbm_repo_clone("", dest.string().c_str());
+
+    EXPECT_LT(result, 0);
+    EXPECT_NE(lastResultJson().find("InvalidArgument"), std::string::npos);
+    EXPECT_FALSE(std::filesystem::exists(dest));
+}
+
+TEST_F(InitCloneApiTest, ANewlyClonedRepositoryOpensANormalSession) {
+    const std::filesystem::path origin = makeBareOrigin();
+    const std::filesystem::path dest = base_ / "cloned";
+    ASSERT_EQ(gbm_repo_clone(origin.string().c_str(), dest.string().c_str()), 0);
+
+    GbmSessionHandle session =
+        gbm_session_open(dest.string().c_str(), (dest / ".git").string().c_str(), nullptr);
+    ASSERT_NE(session, nullptr);
+    gbm_session_close(session);
+}
+
+}  // namespace
+}  // namespace gbm::capi

--- a/tests/capi/RemoteApiTest.cpp
+++ b/tests/capi/RemoteApiTest.cpp
@@ -293,5 +293,50 @@ TEST_F(RemoteApiTest, PruneDeletesExactlyTheSelectedRemoteTrackingRef) {
     EXPECT_EQ(runGit({"rev-parse", "--verify", "origin/main"}), 0);
 }
 
+TEST_F(RemoteApiTest, AddRemoteAddsANewRemote) {
+    const std::filesystem::path upstream = remote_.parent_path() / "gbm-capi-remote-upstream";
+    std::error_code ec;
+    std::filesystem::remove_all(upstream, ec);
+    ASSERT_EQ(runIn(upstream.parent_path(), {"init", "--quiet", "--bare", upstream.string()}), 0);
+
+    gbm_remote_add(session_, "upstream", upstream.string().c_str());
+    ASSERT_TRUE(waitForOperationFinished(log_));
+
+    const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_OPERATION_FINISHED);
+    EXPECT_NE(outcome.find("\"succeeded\":true"), std::string::npos) << outcome;
+    ASSERT_TRUE(log_.waitFor([](const auto& events) { return anyEventOfType(events, GBM_EVENT_REMOTES_UPDATED); }));
+    const std::string json = remotesJson();
+    EXPECT_NE(json.find("\"name\":\"upstream\""), std::string::npos) << json;
+
+    std::filesystem::remove_all(upstream, ec);
+}
+
+TEST_F(RemoteApiTest, AddRemoteFailsWhenNameAlreadyExists) {
+    gbm_remote_add(session_, "origin", remote_.string().c_str());
+    ASSERT_TRUE(waitForOperationFinished(log_));
+
+    const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_OPERATION_FINISHED);
+    EXPECT_NE(outcome.find("\"succeeded\":false"), std::string::npos) << outcome;
+}
+
+TEST_F(RemoteApiTest, RemoveRemoteRemovesIt) {
+    gbm_remote_remove(session_, "origin");
+    ASSERT_TRUE(waitForOperationFinished(log_));
+
+    const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_OPERATION_FINISHED);
+    EXPECT_NE(outcome.find("\"succeeded\":true"), std::string::npos) << outcome;
+    ASSERT_TRUE(log_.waitFor([](const auto& events) { return anyEventOfType(events, GBM_EVENT_REMOTES_UPDATED); }));
+    const std::string json = remotesJson();
+    EXPECT_EQ(json.find("\"name\":\"origin\""), std::string::npos) << json;
+}
+
+TEST_F(RemoteApiTest, RemoveRemoteFailsWhenNoSuchRemote) {
+    gbm_remote_remove(session_, "does-not-exist");
+    ASSERT_TRUE(waitForOperationFinished(log_));
+
+    const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_OPERATION_FINISHED);
+    EXPECT_NE(outcome.find("\"succeeded\":false"), std::string::npos) << outcome;
+}
+
 }  // namespace
 }  // namespace gbm::capi

--- a/tests/capi/RemoteApiTest.cpp
+++ b/tests/capi/RemoteApiTest.cpp
@@ -188,7 +188,7 @@ TEST_F(RemoteApiTest, FetchBringsInNewRemoteCommits) {
     ASSERT_EQ(runIn(other, {"push", "--quiet", "origin", "main"}), 0);
     std::filesystem::remove_all(other, ec);
 
-    gbm_remote_fetch(session_, "origin", /*prune=*/0, /*tags=*/0);
+    gbm_remote_fetch(session_, "origin", nullptr, 0, /*prune=*/0, /*tags=*/0);
     ASSERT_TRUE(waitForWorkingCopyOperationFinished(log_));
 
     const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_WORKING_COPY_OPERATION_FINISHED);
@@ -197,6 +197,39 @@ TEST_F(RemoteApiTest, FetchBringsInNewRemoteCommits) {
     EXPECT_EQ(runGit({"cat-file", "-e", "origin/main:from-other.txt"}), 0);
     // ...but a fetch never touches the work tree or local main.
     EXPECT_FALSE(std::filesystem::exists(repo_ / "from-other.txt"));
+}
+
+TEST_F(RemoteApiTest, FetchWithRefsBringsInOnlyTheNamedBranch) {
+    // Two new branches pushed to the bare remote. A successful push also
+    // updates the pushed branch's own local remote-tracking ref as a side
+    // effect (independent of any fetch) -- delete both right back off so
+    // the fetch below is really the one bringing them in, not the push.
+    ASSERT_EQ(runGit({"push", "--quiet", "origin", "main:refs/heads/wanted"}), 0);
+    ASSERT_EQ(runGit({"push", "--quiet", "origin", "main:refs/heads/unwanted"}), 0);
+    ASSERT_EQ(runGit({"update-ref", "-d", "refs/remotes/origin/wanted"}), 0);
+    ASSERT_EQ(runGit({"update-ref", "-d", "refs/remotes/origin/unwanted"}), 0);
+    ASSERT_NE(runGit({"rev-parse", "--verify", "origin/wanted"}), 0);
+    ASSERT_NE(runGit({"rev-parse", "--verify", "origin/unwanted"}), 0);
+
+    const char* refs[] = {"wanted"};
+    gbm_remote_fetch(session_, "origin", refs, 1, /*prune=*/0, /*tags=*/0);
+    ASSERT_TRUE(waitForWorkingCopyOperationFinished(log_));
+
+    const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_WORKING_COPY_OPERATION_FINISHED);
+    EXPECT_NE(outcome.find("\"succeeded\":true"), std::string::npos) << outcome;
+    EXPECT_EQ(runGit({"rev-parse", "--verify", "origin/wanted"}), 0);
+    // The other branch on the same remote is untouched -- gbm_remote_fetch
+    // with refs fetches exactly what it's given, not everything.
+    EXPECT_NE(runGit({"rev-parse", "--verify", "origin/unwanted"}), 0);
+}
+
+TEST_F(RemoteApiTest, FetchWithRefsButNoRemoteNameFailsCleanly) {
+    const char* refs[] = {"main"};
+    gbm_remote_fetch(session_, "", refs, 1, /*prune=*/0, /*tags=*/0);
+    ASSERT_TRUE(waitForWorkingCopyOperationFinished(log_));
+
+    const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_WORKING_COPY_OPERATION_FINISHED);
+    EXPECT_NE(outcome.find("\"succeeded\":false"), std::string::npos) << outcome;
 }
 
 TEST_F(RemoteApiTest, PullMergesRemoteCommitsIntoTheCurrentBranch) {
@@ -258,7 +291,7 @@ TEST_F(RemoteApiTest, PrunePreviewListsARemoteTrackingBranchDeletedOnTheRemote) 
     // resolves HEAD to a nonexistent refs/heads/master and exits 128 -- the
     // same trap the FetchBringsInNewRemoteCommits comment above calls out.
     ASSERT_EQ(runIn(remote_, {"branch", "gone", "main"}), 0);
-    gbm_remote_fetch(session_, "origin", /*prune=*/0, /*tags=*/0);
+    gbm_remote_fetch(session_, "origin", nullptr, 0, /*prune=*/0, /*tags=*/0);
     ASSERT_TRUE(waitForWorkingCopyOperationFinished(log_));
     ASSERT_EQ(runGit({"rev-parse", "--verify", "origin/gone"}), 0);
     ASSERT_EQ(runIn(remote_, {"branch", "-D", "gone"}), 0);
@@ -277,7 +310,7 @@ TEST_F(RemoteApiTest, PrunePreviewListsARemoteTrackingBranchDeletedOnTheRemote) 
 TEST_F(RemoteApiTest, PruneDeletesExactlyTheSelectedRemoteTrackingRef) {
     // Explicit start point -- see the note in the preview test above.
     ASSERT_EQ(runIn(remote_, {"branch", "gone", "main"}), 0);
-    gbm_remote_fetch(session_, "origin", /*prune=*/0, /*tags=*/0);
+    gbm_remote_fetch(session_, "origin", nullptr, 0, /*prune=*/0, /*tags=*/0);
     ASSERT_TRUE(waitForWorkingCopyOperationFinished(log_));
     ASSERT_EQ(runGit({"rev-parse", "--verify", "origin/gone"}), 0);
     ASSERT_EQ(runGit({"rev-parse", "--verify", "origin/main"}), 0);

--- a/tests/unit/InitCloneOpsTest.cpp
+++ b/tests/unit/InitCloneOpsTest.cpp
@@ -1,0 +1,120 @@
+// Tests for InitCloneOps: `git init <path>` and `git clone <url> <dest>`,
+// the two session-less operations run before any RepoPaths/Session exists
+// (see InitCloneOps.h's doc comment for why these are plain functions
+// rather than Operation subclasses).
+#include "core/git/ops/InitCloneOps.h"
+#include "support/FakeProcessRunner.h"
+
+#include <gtest/gtest.h>
+
+namespace gbm {
+namespace {
+
+using testing::FakeProcessRunner;
+
+TEST(RunInitRepo, RunsGitInitWithThePath) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"init", "--quiet", "/repos/new-project"}, response);
+
+    InitRepoRequest request;
+    request.path = "/repos/new-project";
+
+    GitResult<void> result = runInitRepo(runner, request, CancellationToken{});
+
+    EXPECT_TRUE(result);
+    ASSERT_EQ(runner.invocationCount(), 1u);
+    EXPECT_EQ(runner.invokedArgs(0),
+              (std::vector<std::string>{"init", "--quiet", "/repos/new-project"}));
+}
+
+TEST(RunInitRepo, RejectsEmptyPathWithoutRunningGit) {
+    FakeProcessRunner runner;
+    InitRepoRequest request;
+
+    GitResult<void> result = runInitRepo(runner, request, CancellationToken{});
+
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.error().code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
+TEST(RunInitRepo, ReportsGitErrorOnFailure) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 128;
+    failure.err = "fatal: cannot mkdir /root/no-permission: Permission denied\n";
+    runner.whenArgsContain({"init", "--quiet", "/root/no-permission"}, failure);
+
+    InitRepoRequest request;
+    request.path = "/root/no-permission";
+
+    GitResult<void> result = runInitRepo(runner, request, CancellationToken{});
+
+    ASSERT_FALSE(result);
+    EXPECT_FALSE(result.error().message.empty());
+}
+
+TEST(RunCloneRepo, RunsGitCloneWithUrlAndDestination) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"clone", "--quiet", "/remotes/origin.git", "/repos/cloned"}, response);
+
+    CloneRepoRequest request;
+    request.url = "/remotes/origin.git";
+    request.destPath = "/repos/cloned";
+
+    GitResult<void> result = runCloneRepo(runner, request, CancellationToken{});
+
+    EXPECT_TRUE(result);
+    ASSERT_EQ(runner.invocationCount(), 1u);
+    EXPECT_EQ(
+        runner.invokedArgs(0),
+        (std::vector<std::string>{"clone", "--quiet", "/remotes/origin.git", "/repos/cloned"}));
+}
+
+TEST(RunCloneRepo, RejectsEmptyUrlWithoutRunningGit) {
+    FakeProcessRunner runner;
+    CloneRepoRequest request;
+    request.destPath = "/repos/cloned";
+
+    GitResult<void> result = runCloneRepo(runner, request, CancellationToken{});
+
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.error().code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
+TEST(RunCloneRepo, RejectsEmptyDestinationWithoutRunningGit) {
+    FakeProcessRunner runner;
+    CloneRepoRequest request;
+    request.url = "/remotes/origin.git";
+
+    GitResult<void> result = runCloneRepo(runner, request, CancellationToken{});
+
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.error().code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
+TEST(RunCloneRepo, ReportsGitErrorOnFailure) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 128;
+    failure.err = "fatal: repository '/remotes/missing.git' does not exist\n";
+    runner.whenArgsContain({"clone", "--quiet", "/remotes/missing.git", "/repos/cloned"}, failure);
+
+    CloneRepoRequest request;
+    request.url = "/remotes/missing.git";
+    request.destPath = "/repos/cloned";
+
+    GitResult<void> result = runCloneRepo(runner, request, CancellationToken{});
+
+    ASSERT_FALSE(result);
+    EXPECT_FALSE(result.error().message.empty());
+}
+
+}  // namespace
+}  // namespace gbm

--- a/tests/unit/RemoteOpsTest.cpp
+++ b/tests/unit/RemoteOpsTest.cpp
@@ -115,6 +115,90 @@ TEST(PruneRemoteOperation, DoesNothingWhenNoRefsAreSelected) {
     EXPECT_EQ(runner.invocationCount(), 0u);
 }
 
+TEST(FetchOperation, FetchesEveryRemoteWhenNoRemoteNameIsGiven) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"fetch", "--all"}, response);
+
+    FetchRequest request;
+    auto operation = makeFetchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_TRUE(outcome.succeeded);
+    EXPECT_EQ(runner.invokedArgs(0), (std::vector<std::string>{"fetch", "--all"}));
+}
+
+TEST(FetchOperation, FetchesJustTheGivenRemoteWhenRefsIsEmpty) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"fetch", "origin"}, response);
+
+    FetchRequest request;
+    request.remoteName = "origin";
+    auto operation = makeFetchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_TRUE(outcome.succeeded);
+    EXPECT_EQ(runner.invokedArgs(0), (std::vector<std::string>{"fetch", "origin"}));
+}
+
+TEST(FetchOperation, FetchesExactlyTheGivenRefsFromTheRemote) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"fetch", "origin", "feature/one", "feature/two"}, response);
+
+    FetchRequest request;
+    request.remoteName = "origin";
+    request.refs = {"feature/one", "feature/two"};
+    auto operation = makeFetchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_TRUE(outcome.succeeded);
+    ASSERT_EQ(runner.invocationCount(), 1u);
+    EXPECT_EQ(runner.invokedArgs(0),
+             (std::vector<std::string>{"fetch", "origin", "feature/one", "feature/two"}));
+}
+
+TEST(FetchOperation, PruneAndTagsStillApplyWithSpecificRefs) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"fetch", "--prune", "--tags", "origin", "feature/one"}, response);
+
+    FetchRequest request;
+    request.remoteName = "origin";
+    request.refs = {"feature/one"};
+    request.prune = true;
+    request.tags = true;
+    auto operation = makeFetchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_TRUE(outcome.succeeded);
+    EXPECT_EQ(runner.invokedArgs(0),
+             (std::vector<std::string>{"fetch", "--prune", "--tags", "origin", "feature/one"}));
+}
+
+TEST(FetchOperation, RejectsSpecificRefsWithoutARemoteNameWithoutRunningGit) {
+    FakeProcessRunner runner;
+    FetchRequest request;
+    request.refs = {"feature/one"};
+    auto operation = makeFetchOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
 TEST(AddRemoteOperation, RunsRemoteAddWithNameAndUrl) {
     FakeProcessRunner runner;
     FakeProcessRunner::Response response;

--- a/tests/unit/RemoteOpsTest.cpp
+++ b/tests/unit/RemoteOpsTest.cpp
@@ -115,6 +115,125 @@ TEST(PruneRemoteOperation, DoesNothingWhenNoRefsAreSelected) {
     EXPECT_EQ(runner.invocationCount(), 0u);
 }
 
+TEST(AddRemoteOperation, RunsRemoteAddWithNameAndUrl) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"remote", "add", "origin", "git@github.com:example/repo.git"},
+                           response);
+
+    AddRemoteRequest request;
+    request.name = "origin";
+    request.url = "git@github.com:example/repo.git";
+    auto operation = makeAddRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_TRUE(outcome.succeeded);
+    ASSERT_EQ(runner.invocationCount(), 1u);
+    EXPECT_EQ(runner.invokedArgs(0),
+             (std::vector<std::string>{"remote", "add", "origin",
+                                       "git@github.com:example/repo.git"}));
+}
+
+TEST(AddRemoteOperation, RejectsEmptyNameWithoutRunningGit) {
+    FakeProcessRunner runner;
+    AddRemoteRequest request;
+    request.name = "";
+    request.url = "git@github.com:example/repo.git";
+    auto operation = makeAddRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
+TEST(AddRemoteOperation, RejectsEmptyUrlWithoutRunningGit) {
+    FakeProcessRunner runner;
+    AddRemoteRequest request;
+    request.name = "origin";
+    request.url = "";
+    auto operation = makeAddRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
+TEST(AddRemoteOperation, ReportsGitErrorOnFailure) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 1;
+    failure.err = "error: remote origin already exists.\n";
+    runner.whenArgsContain({"remote", "add", "origin", "git@github.com:example/repo.git"},
+                           failure);
+
+    AddRemoteRequest request;
+    request.name = "origin";
+    request.url = "git@github.com:example/repo.git";
+    auto operation = makeAddRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+}
+
+TEST(RemoveRemoteOperation, RunsRemoteRemoveWithName) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response response;
+    response.exitCode = 0;
+    runner.whenArgsContain({"remote", "remove", "origin"}, response);
+
+    RemoveRemoteRequest request;
+    request.name = "origin";
+    auto operation = makeRemoveRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_TRUE(outcome.succeeded);
+    ASSERT_EQ(runner.invocationCount(), 1u);
+    EXPECT_EQ(runner.invokedArgs(0),
+             (std::vector<std::string>{"remote", "remove", "origin"}));
+}
+
+TEST(RemoveRemoteOperation, RejectsEmptyNameWithoutRunningGit) {
+    FakeProcessRunner runner;
+    RemoveRemoteRequest request;
+    request.name = "";
+    auto operation = makeRemoveRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+    EXPECT_EQ(outcome.error->code, GitError::Code::InvalidArgument);
+    EXPECT_EQ(runner.invocationCount(), 0u);
+}
+
+TEST(RemoveRemoteOperation, ReportsGitErrorOnFailure) {
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 1;
+    failure.err = "error: No such remote: 'origin'\n";
+    runner.whenArgsContain({"remote", "remove", "origin"}, failure);
+
+    RemoveRemoteRequest request;
+    request.name = "origin";
+    auto operation = makeRemoveRemoteOperation(request);
+
+    OperationOutcome outcome = operation->run(runner, testPaths(), CancellationToken{});
+
+    EXPECT_FALSE(outcome.succeeded);
+    ASSERT_TRUE(outcome.error.has_value());
+}
+
 TEST(PruneRemoteOperation, ReportsGitErrorOnFailure) {
     FakeProcessRunner runner;
     FakeProcessRunner::Response failure;


### PR DESCRIPTION
GbmActionId.viewNextTab was hardcoded null in
WorkspaceScreen._buildActionHandlers() even though Ctrl/Cmd+Tab and the
View menu both dispatch it, so both silently no-op'd. Adds
nextWorkspaceTabRoute() (workspace_tab.dart), built on the existing
activeWorkspaceTabIndex()/defaultWorkspaceTabs() helpers, and wires it
through the handler map -- covered by a unit test group and a new
integration test that drives the real WorkspaceScreen via pumpWorkspace
and asserts on GoRouter's actual location (RED-verified: reverting the
handler to null fails all three cases with the expected diagnosis).

Also pins subosito/flutter-action's flutter-version (3.44.9, the latest
patch still on Dart 3.12.2 -- 3.44.0 ships Dart 3.12.0, below
pubspec.yaml's ^3.12.2 floor) across all three CI/release uses, with a
new lint-job guard step that fails if any use is left unpinned. This
closes CLAUDE.md's documented `dart format` flapping gap: reformats
desktop_launcher_test.dart back from the Dart-3.13.0 style a prior
commit applied for an unpinned CI run, now that CI is pinned to 3.12.2.

Verified: flutter analyze (0 issues), dart format --set-exit-if-changed
(clean), full suite 739 passed / 21 skipped / 0 failed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CsjSbxJTgFxm252Mz6j29Q