### PR TITLE
fix: 修復 Tier 0 spec-conformance 落差（#43–#48, #50，並補 #49 capi）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -634,7 +634,7 @@ dedicated `*_menu_items.dart` pure function each — the template to follow
 when this eventually gets fixed). Not fixed this round; tracked as skipped
 regression tests (below) so a future fix flips them green one at a time.
 
-**New defect found while writing test coverage, not from static reading
+~~**New defect found while writing test coverage, not from static reading
 (H2)**: `working_copy_view.dart`'s Commit/Amend buttons do not reactively
 enable while typing a commit summary — `_summaryController` has no listener
 wired to `setState`, so `canCommit` only recomputes on some *unrelated*
@@ -643,7 +643,16 @@ gate logic (`canCommit`) is correct in isolation — confirmed by pre-seeding
 `workingCopyDraftProvider` before mount — the defect is specifically the
 missing "text changed → rebuild" wiring. Both new test suites below had to
 route around this (stage-after-type ordering, or a full tab-away-and-back)
-rather than a plain `enterText` + assert. Not fixed this round.
+rather than a plain `enterText` + assert. Not fixed this round.~~ — **Fixed**
+(Tier 0, see below): `_summaryController` now carries a listener
+(`..addListener(_onSummaryChanged)`, mirroring `_diffScrollController`'s
+existing pattern) that calls `setState(() {})` on every keystroke, so
+`canCommit` recomputes immediately instead of waiting for an unrelated
+rebuild. `test/integration/workspace_states_table_test.dart` gained a test
+that drives this with a real `tester.enterText()` instead of the
+provider-override workaround the pre-existing test in that file still uses
+(that one verifies gate *logic*; the new one verifies the typing → rebuild
+wiring, which is what H2 was actually missing).
 
 **Other confirmed gaps**: `branchRenameCurrentBranch` has no keyboard
 shortcut bound despite F2 being unclaimed by anything else in spec's MENUS
@@ -651,7 +660,16 @@ table (unlike two *other* absent bindings — Find-in-files, Stash-changes —
 which are absent because spec's own table double-assigns their key to
 something else; this one is a genuine omission). It compounds with the
 `Rename branch` dialog route itself being entirely missing from
-`route_paths.dart`. `lib/features/workspace/widgets/tab_row.dart`'s 18-item
+`route_paths.dart`. **Deliberately still not fixed** (Tier 0's 0c/#45 was
+scoped out during planning, not silently skipped): the two existing rename
+entry points (`sidebar_panel.dart:119`, `workspace_screen.dart:887`) already
+work and share a plain `promptText` input, so nothing is actually broken —
+what's missing is the dedicated dialog spec calls for, and building that
+without a design draft for it risked a rewrite later. Deferred until a
+rename-dialog design draft exists; issue #45 stays open (not `Fixes #45`
+anywhere) rather than being marked resolved for a partial fix.
+
+`lib/features/workspace/widgets/tab_row.dart`'s 18-item
 `_MoreMenu` overflow menu plus 3 standalone buttons (Merge/Cherry-pick/
 Reset) is, per this audit's user-confirmed scope rule ("beyond-spec
 functionality is fine only via context menu or menu bar"), the sole
@@ -680,3 +698,52 @@ as a directory — running the whole directory in one `flutter test` command
 was found to be unreliable on macOS specifically (each app launch after the
 first fails to attach a debug connection), not a defect in the tests
 themselves.
+
+### Tier 0 fixes (fix/tier-0-spec-conformance-gaps)
+
+The audit above turned into 8 GitHub issues (#43–#50), grouped into tiers by
+dependency risk; Tier 0 was the "independent, no shared file" batch. Per
+user decision, all 8 landed as 7 sequential commits on one branch (not
+parallel worktrees, not squashed) rather than the 8th (#45) — see below.
+Commit order: `0b → 0a → 0h → 0f → 0d → 0e → 0g`.
+
+- **0a / #43** (`613f80c`) — H2 above, fixed.
+- **0b / #44** (`2a60b47`) — `gbm_context_menus.dart`'s 05-C doc comment
+  said "Not yet wired"; `branch_tree_item.dart`'s `_buildGoneMenuItems()`
+  already implemented it (confirmed by this same audit, see 05-C in the H1
+  paragraph above). Comment-only fix, no behavior change.
+- **0d / #46** (`2307ef7`) — History's ref chips now merge a synced
+  local+upstream pair into one chip with a cloud-icon suffix instead of
+  drawing both separately, and draw a dashed chip at the commit the
+  upstream actually points to when the two have diverged (spec page 02).
+- **0e / #47** (`a928bd5`) — the List/Tree file-view preference
+  (`fileListViewModeProvider`) is spec page 03 item 10's *one* shared
+  setting, but History's Changed files panel, Compare's two file lists, and
+  the conflict-resolution rail each drew their own hardcoded flat list with
+  no toggle. All three now read the shared provider and render through the
+  same `FileListModeSwitcher`/`FileTreeFolderRow` Working Copy already
+  used — proved cross-page, not just per-view, via a new
+  `test/integration/workspace_file_list_view_mode_test.dart`.
+- **0f / #48** (`16626b2`) — the status bar's folded "+N task" label is now
+  a tappable `showMenu` popover listing every background task with its own
+  Cancel button (spec page 10), not inert text.
+- **0g / #49** (`3e65208`) — see its own commit message for the five
+  sub-items and the capi extension (`gbm_discovery_set_base_folder_depth`,
+  `RepoIndexDb`'s schema-3 `lastScanSkipped` column) two of them needed.
+- **0h / #50** (`503e326`) — `operationLog`'s cap was a hardcoded module
+  constant whose doc comment incorrectly claimed it mirrored
+  `OperationRunner::kMaxUndoEntries` (a different, unrelated 200-entry list
+  for Undo Last); it now reads `AppPreferences.logMemoryLimit`, the field
+  spec's LOGRULES table actually describes ("上限寫在 Preferences，不隱
+  藏").
+- **0c / #45 — deliberately not in this batch.** See the F2 paragraph
+  above for why; issue #45 stays open, not closed by this branch's PR.
+
+Two premises in the original issues were corrected during planning, not
+just during implementation — worth knowing before re-reading #49/#50's
+issue text literally: #50 assumed the C++ `kMaxUndoEntries` constant needed
+changing in lockstep with the Flutter cap; it doesn't; they were never
+actually linked. #49 assumed all five Preferences sub-items were pure
+Flutter-side wiring; two needed a real capi addition, which the user
+explicitly approved doing as part of this round rather than splitting into
+a separate capi-only issue.

--- a/app_flutter/lib/data/ffi/gbm_bindings.dart
+++ b/app_flutter/lib/data/ffi/gbm_bindings.dart
@@ -1180,6 +1180,11 @@ typedef _DiscoverySetBaseFolderEnabledNative =
 typedef DiscoverySetBaseFolderEnabledDart =
     int Function(Pointer<Void> discovery, int baseFolderId, int enabled);
 
+typedef _DiscoverySetBaseFolderDepthNative =
+    Int32 Function(Pointer<Void> discovery, Int64 baseFolderId, Int32 maxDepth);
+typedef DiscoverySetBaseFolderDepthDart =
+    int Function(Pointer<Void> discovery, int baseFolderId, int maxDepth);
+
 /// Thin, allocation-free wrapper around the `gbm_capi` symbol table. One
 /// instance per isolate is enough; construct it once via [GbmBindings.open]
 /// and share it through a Riverpod provider.
@@ -1719,7 +1724,12 @@ class GbmBindings {
           .lookupFunction<
             _DiscoverySetBaseFolderEnabledNative,
             DiscoverySetBaseFolderEnabledDart
-          >('gbm_discovery_set_base_folder_enabled');
+          >('gbm_discovery_set_base_folder_enabled'),
+      discoverySetBaseFolderDepth = library
+          .lookupFunction<
+            _DiscoverySetBaseFolderDepthNative,
+            DiscoverySetBaseFolderDepthDart
+          >('gbm_discovery_set_base_folder_depth');
 
   final FreeEventPayloadDart freeEventPayload;
   final LastResultJsonLenDart lastResultJsonLen;
@@ -1862,4 +1872,5 @@ class GbmBindings {
   final DiscoveryBaseFoldersJsonDart discoveryBaseFoldersJson;
   final DiscoveryRemoveBaseFolderDart discoveryRemoveBaseFolder;
   final DiscoverySetBaseFolderEnabledDart discoverySetBaseFolderEnabled;
+  final DiscoverySetBaseFolderDepthDart discoverySetBaseFolderDepth;
 }

--- a/app_flutter/lib/data/models/base_folder_record.dart
+++ b/app_flutter/lib/data/models/base_folder_record.dart
@@ -11,6 +11,7 @@ class BaseFolderRecord {
     required this.lastScanFinished,
     required this.lastScanDirs,
     required this.lastScanMs,
+    required this.lastScanSkipped,
   });
 
   factory BaseFolderRecord.fromJson(Map<String, dynamic> json) {
@@ -24,6 +25,7 @@ class BaseFolderRecord {
       lastScanFinished: json['lastScanFinished'] as int,
       lastScanDirs: json['lastScanDirs'] as int,
       lastScanMs: json['lastScanMs'] as int,
+      lastScanSkipped: json['lastScanSkipped'] as int,
     );
   }
 
@@ -40,4 +42,8 @@ class BaseFolderRecord {
   final int lastScanFinished;
   final int lastScanDirs;
   final int lastScanMs;
+
+  /// Directories the last scan did not descend into because they lay past
+  /// [maxDepth]. Zero until at least one scan has completed.
+  final int lastScanSkipped;
 }

--- a/app_flutter/lib/data/repositories/app_preferences_repository.dart
+++ b/app_flutter/lib/data/repositories/app_preferences_repository.dart
@@ -28,6 +28,7 @@ class AppPreferences {
     this.autoScanMinutes = 30,
     this.globalGitignoreEnabled = false,
     this.globalGitignorePath = '',
+    this.globalGitignoreSource = '',
     this.cherryPickAddsSourceLine = true,
     this.confirmForcePush = true,
     this.logMemoryLimit = 2000,
@@ -54,6 +55,19 @@ class AppPreferences {
   final bool globalGitignoreEnabled;
   final String globalGitignorePath;
 
+  /// Where [globalGitignorePath] came from: `''` (never set), `'imported'`
+  /// (read from the user's pre-existing `git config --global
+  /// core.excludesFile` at some point), or `'manual'` (typed into the path
+  /// field). Scoped down from the original ask: nothing in this app
+  /// currently *detects* an importable value (that would mean reading the
+  /// user's global git config, which has no capi entry point yet), so today
+  /// only the `''`/`'manual'` states are ever actually reached in
+  /// production. `'imported'` exists so a future round can wire up
+  /// detection without another field-plus-migration round trip, and so the
+  /// label-rendering logic in `_GitSection` has something real to switch on
+  /// and test now.
+  final String globalGitignoreSource;
+
   /// Git. Spec page 07's `MSGS` table, Cherry-pick row: the trailing
   /// "(cherry picked from commit …)" line "可在 Preferences 關閉".
   final bool cherryPickAddsSourceLine;
@@ -75,6 +89,7 @@ class AppPreferences {
     int? autoScanMinutes,
     bool? globalGitignoreEnabled,
     String? globalGitignorePath,
+    String? globalGitignoreSource,
     bool? cherryPickAddsSourceLine,
     bool? confirmForcePush,
     int? logMemoryLimit,
@@ -90,6 +105,8 @@ class AppPreferences {
       globalGitignoreEnabled:
           globalGitignoreEnabled ?? this.globalGitignoreEnabled,
       globalGitignorePath: globalGitignorePath ?? this.globalGitignorePath,
+      globalGitignoreSource:
+          globalGitignoreSource ?? this.globalGitignoreSource,
       cherryPickAddsSourceLine:
           cherryPickAddsSourceLine ?? this.cherryPickAddsSourceLine,
       confirmForcePush: confirmForcePush ?? this.confirmForcePush,
@@ -133,6 +150,9 @@ class AppPreferencesRepository {
       globalGitignorePath:
           _prefs.getString('${_kPrefix}globalGitignorePath') ??
           defaults.globalGitignorePath,
+      globalGitignoreSource:
+          _prefs.getString('${_kPrefix}globalGitignoreSource') ??
+          defaults.globalGitignoreSource,
       cherryPickAddsSourceLine:
           _prefs.getBool('${_kPrefix}cherryPickAddsSourceLine') ??
           defaults.cherryPickAddsSourceLine,
@@ -161,6 +181,10 @@ class AppPreferencesRepository {
     await _prefs.setString(
       '${_kPrefix}globalGitignorePath',
       p.globalGitignorePath,
+    );
+    await _prefs.setString(
+      '${_kPrefix}globalGitignoreSource',
+      p.globalGitignoreSource,
     );
     await _prefs.setBool(
       '${_kPrefix}cherryPickAddsSourceLine',

--- a/app_flutter/lib/data/repositories/discovery_repository.dart
+++ b/app_flutter/lib/data/repositories/discovery_repository.dart
@@ -167,6 +167,24 @@ class DiscoveryController extends StateNotifier<DiscoveryState> {
     _listBaseFolders();
   }
 
+  /// Changes how many levels below the base folder are scanned. See
+  /// gbm_discovery_set_base_folder_depth()'s doc comment in gbm_capi.h --
+  /// this also clears the base folder's stored directory signatures, so the
+  /// next scan re-visits subtrees a shallower depth had pruned.
+  void setBaseFolderDepth(int baseFolderId, int maxDepth) {
+    if (_discovery == nullptr) return;
+    final int result = _bindings.discoverySetBaseFolderDepth(
+      _discovery,
+      baseFolderId,
+      maxDepth,
+    );
+    if (result != 0) {
+      state = state.copyWith(lastError: _decodeLastError());
+      return;
+    }
+    _listBaseFolders();
+  }
+
   /// Unregisters a base folder. Its already-discovered repositories stay in
   /// the list (see gbm_discovery_remove_base_folder()'s doc comment).
   void removeBaseFolder(int baseFolderId) {

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -36,6 +36,7 @@ import '../models/submodule_info.dart';
 import '../models/undo_entry.dart';
 import '../models/working_copy_status.dart';
 import '../models/worktree_info.dart';
+import 'app_preferences_repository.dart';
 import 'gbm_bindings_provider.dart';
 import 'pending_operation_tracker.dart';
 import 'recents_repository.dart';
@@ -236,15 +237,21 @@ class CompareWithWorkingCopyResult {
   final ParsedDiff diff;
 }
 
-/// Caps how many [OperationRecord]s [RepoSessionState.operationLog] keeps,
-/// mirroring OperationRunner's own undo-journal cap (`kMaxUndoEntries` in
-/// OperationRunner.cpp) -- a live panel fed one record per `git` invocation
-/// needs a bound too, or a long session slowly grows an unbounded list.
-const int _kMaxOperationLogEntries = 500;
+/// Default cap for how many [OperationRecord]s [RepoSessionState.operationLog]
+/// keeps, used only when [RepoSessionController] isn't given an explicit
+/// value. The real cap in normal operation comes from
+/// [AppPreferences.logMemoryLimit] (spec page 10 LOGRULES: "記憶體中保留最近
+/// 2,000 筆…上限寫在 Preferences，不隱藏") -- this constant is *not* mirroring
+/// `OperationRunner.cpp`'s `kMaxUndoEntries` (that guards a different list,
+/// `undoJournal_`, the one Undo Last reads; it has never been the same
+/// number as this one, and changing it has no effect here). This value
+/// matches [AppPreferences]'s own default so the two stay in sync absent an
+/// explicit override.
+const int _kDefaultMaxOperationLogEntries = 2000;
 
 /// Caps how many entries [RepoSessionState.commitMetaCache] keeps. Unlike
-/// [_kMaxOperationLogEntries], there is no core-side precedent to mirror --
-/// this cache has no cap at all today, so a long session that scrolls
+/// [_kDefaultMaxOperationLogEntries], there is no core-side precedent to
+/// mirror -- this cache has no cap at all today, so a long session that scrolls
 /// through a very large repo's entire history grows it without bound. 5000
 /// is generous enough that normal browsing (a viewport's worth of rows plus
 /// scrollback) never hits it, while still bounding worst-case memory for a
@@ -324,7 +331,8 @@ class RepoSessionState {
   /// answer is this side's own action.
   final String? credentialPrompt;
 
-  /// Newest-last, capped at [_kMaxOperationLogEntries].
+  /// Newest-last, capped at [RepoSessionController.maxOperationLogEntries]
+  /// (sourced from [AppPreferences.logMemoryLimit]).
   final List<OperationRecord> operationLog;
   final BlameResult? lastBlame;
 
@@ -540,8 +548,9 @@ class RepoSessionState {
   /// Merges [metas] into [commitMetaCache] keyed by oid -- see that field's
   /// doc comment for why a reply must add to the cache rather than replace
   /// it -- then caps the result at [_kMaxCommitMetaCacheEntries] by
-  /// dropping the oldest entries in insertion order, mirroring
-  /// [operationLog]'s [_kMaxOperationLogEntries] cap.
+  /// dropping the oldest entries in insertion order, the same sublist
+  /// pattern [operationLog]'s cap uses (though that one's cap is
+  /// configurable via [AppPreferences.logMemoryLimit]; this one is not).
   RepoSessionState withCommitMeta(List<CommitMeta> metas) {
     final Map<String, CommitMeta> merged = <String, CommitMeta>{
       ...commitMetaCache,
@@ -555,6 +564,30 @@ class RepoSessionState {
           );
     return copyWith(commitMetaCache: capped);
   }
+
+  /// Appends [record] to [operationLog], then evicts the oldest entries
+  /// (sublist from the tail) once over [maxEntries] -- the same shape as
+  /// [withCommitMeta]'s eviction, extracted here (rather than left inline in
+  /// [RepoSessionController]'s event handler) so the cap logic is
+  /// unit-testable against a plain [RepoSessionState] without a live FFI
+  /// session. [maxEntries] is a parameter, not a class constant, because the
+  /// real cap is [RepoSessionController.maxOperationLogEntries] (sourced
+  /// from [AppPreferences.logMemoryLimit]), which this pure state class has
+  /// no way to read for itself.
+  RepoSessionState withOperationRecord(
+    OperationRecord record, {
+    required int maxEntries,
+  }) {
+    final List<OperationRecord> updated = <OperationRecord>[
+      ...operationLog,
+      record,
+    ];
+    return copyWith(
+      operationLog: updated.length > maxEntries
+          ? updated.sublist(updated.length - maxEntries)
+          : updated,
+    );
+  }
 }
 
 /// Owns one `gbm_capi` session handle end to end: opens it, subscribes to
@@ -562,14 +595,30 @@ class RepoSessionState {
 /// (`workspaceScreen`'s route scope owns the provider lifetime -- see the
 /// routing table in the plan).
 class RepoSessionController extends StateNotifier<RepoSessionState> {
-  RepoSessionController(this._bindings, this._identity, this._recents)
-    : super(const RepoSessionState()) {
+  RepoSessionController(
+    this._bindings,
+    this._identity,
+    this._recents, {
+    this.maxOperationLogEntries = _kDefaultMaxOperationLogEntries,
+  }) : super(const RepoSessionState()) {
     _open();
   }
 
   final GbmBindings _bindings;
   final RepoIdentity _identity;
   final RecentsRepository _recents;
+
+  /// Cap for [RepoSessionState.operationLog], read once at construction from
+  /// [AppPreferences.logMemoryLimit] by [repoSessionProvider] (via
+  /// `ref.read`, deliberately not `ref.watch` -- watching would rebuild this
+  /// whole controller, tearing down and reopening the live `gbm_capi`
+  /// session, every time the user changes the Preferences slider). A
+  /// preference change takes effect the next time a repository is opened,
+  /// not retroactively on an already-open session. Not underscore-prefixed
+  /// like this class's other fields, since it doubles as a test seam --
+  /// tests that need a small cap to exercise eviction pass it explicitly
+  /// instead of feeding thousands of events.
+  final int maxOperationLogEntries;
   Pointer<Void> _session = nullptr;
   GbmSessionEvents? _events;
   StreamSubscription<GbmEvent>? _subscription;
@@ -706,14 +755,9 @@ class RepoSessionController extends StateNotifier<RepoSessionState> {
       case GbmEventType.operationLogRecord:
         final Object? payload = decodeEventPayload(event.payload);
         if (payload is Map<String, dynamic>) {
-          final List<OperationRecord> updated = <OperationRecord>[
-            ...state.operationLog,
+          state = state.withOperationRecord(
             OperationRecord.fromJson(payload),
-          ];
-          state = state.copyWith(
-            operationLog: updated.length > _kMaxOperationLogEntries
-                ? updated.sublist(updated.length - _kMaxOperationLogEntries)
-                : updated,
+            maxEntries: maxOperationLogEntries,
           );
         }
       case GbmEventType.blameReady:
@@ -2875,5 +2919,17 @@ repoSessionProvider =
     >((ref, identity) {
       final GbmBindings bindings = ref.watch(gbmBindingsProvider);
       final RecentsRepository recents = ref.watch(recentsRepositoryProvider);
-      return RepoSessionController(bindings, identity, recents);
+      // `ref.read`, not `ref.watch`: this cap only needs to be current as of
+      // the moment the session opens. Watching would rebuild the whole
+      // controller -- tearing down and reopening the live `gbm_capi` session
+      // -- every time the user moves the Preferences slider.
+      final int maxOperationLogEntries = ref
+          .read(appPreferencesProvider)
+          .logMemoryLimit;
+      return RepoSessionController(
+        bindings,
+        identity,
+        recents,
+        maxOperationLogEntries: maxOperationLogEntries,
+      );
     });

--- a/app_flutter/lib/features/compare/compare_page.dart
+++ b/app_flutter/lib/features/compare/compare_page.dart
@@ -7,11 +7,14 @@ import '../../data/models/parsed_diff.dart';
 import '../../data/models/ref_snapshot.dart';
 import '../../data/models/stash_entry.dart';
 import '../../data/repositories/compare_tabs_repository.dart';
+import '../../data/repositories/file_list_view_mode_repository.dart';
 import '../../data/repositories/repo_identity.dart';
 import '../../data/repositories/repo_session_repository.dart';
 import '../../routing/route_paths.dart';
 import '../../theme/gbm_theme.dart';
 import '../../theme/tokens.dart';
+import '../../widgets/file_list_mode_switcher.dart';
+import '../../widgets/file_list_mode_toggle_button.dart';
 import '../../widgets/gbm_badge.dart';
 import '../diff/diff_page.dart';
 import 'widgets/compare_ref_picker.dart';
@@ -325,6 +328,10 @@ class _ComparePageState extends ConsumerState<ComparePage> {
     CompareTabSpec spec,
     RepoSessionState session,
   ) {
+    // Spec page 03 item 10: same List/Tree preference as Working Copy,
+    // History's Changed files, and the Conflict window's file rail.
+    final FileListViewMode viewMode = ref.watch(fileListViewModeProvider);
+
     if (spec.rightIsWorkingCopy) {
       final CompareWithWorkingCopyResult? result =
           session
@@ -344,6 +351,7 @@ class _ComparePageState extends ConsumerState<ComparePage> {
               onScrollEnd: _onScrollEnd,
               files: result.diff.files,
               selectedPath: _selectedPath,
+              viewMode: viewMode,
               onSelect: (String path) => setState(() => _selectedPath = path),
               onCheckout: (String path) =>
                   _confirmCheckout(context, path: path, source: spec.left),
@@ -374,6 +382,7 @@ class _ComparePageState extends ConsumerState<ComparePage> {
             onScrollEnd: _onScrollEnd,
             files: result.files,
             selectedPath: _selectedPath,
+            viewMode: viewMode,
             onSelect: (String path) {
               setState(() => _selectedPath = path);
               ref
@@ -462,6 +471,7 @@ class _RefCompareFileList extends StatelessWidget {
     required this.files,
     required this.selectedPath,
     required this.onSelect,
+    this.viewMode = FileListViewMode.list,
   });
 
   final ScrollController controller;
@@ -470,59 +480,127 @@ class _RefCompareFileList extends StatelessWidget {
   final String? selectedPath;
   final ValueChanged<String> onSelect;
 
+  /// List vs Tree display, from the shared [fileListViewModeProvider] --
+  /// see [_FileListPanelHeader]'s doc comment.
+  final FileListViewMode viewMode;
+
   @override
   Widget build(BuildContext context) {
     final GbmColors colors = context.gbmColors;
     if (files.isEmpty) {
-      return Center(
-        child: Text('No changes', style: TextStyle(color: colors.textTertiary)),
+      return Column(
+        children: <Widget>[
+          const _FileListPanelHeader(),
+          Expanded(
+            child: Center(
+              child: Text(
+                'No changes',
+                style: TextStyle(color: colors.textTertiary),
+              ),
+            ),
+          ),
+        ],
       );
     }
-    return NotificationListener<ScrollEndNotification>(
-      onNotification: (ScrollEndNotification notification) {
-        onScrollEnd();
-        return false;
-      },
-      child: ListView.builder(
-        controller: controller,
-        itemCount: files.length,
-        itemBuilder: (context, index) {
-          final DiffFile file = files[index];
-          final bool isSelected = file.displayPath == selectedPath;
-          return Container(
-            color: isSelected ? colors.surfaceSelected : null,
-            child: ListTile(
-              dense: true,
-              title: Text(
-                file.displayPath,
-                style: TextStyle(
-                  fontSize: GbmTypography.textSm,
-                  color: colors.textPrimary,
+    return Column(
+      children: <Widget>[
+        const _FileListPanelHeader(),
+        Expanded(
+          child: viewMode == FileListViewMode.list
+              ? NotificationListener<ScrollEndNotification>(
+                  onNotification: (ScrollEndNotification notification) {
+                    onScrollEnd();
+                    return false;
+                  },
+                  child: ListView.builder(
+                    controller: controller,
+                    itemCount: files.length,
+                    itemBuilder: (context, index) =>
+                        _buildFileRow(context, files[index]),
+                  ),
+                )
+              // Tree mode has no scroll-offset persistence: FileTreeList
+              // builds its own internal ListView with no controller seam.
+              : FileListModeSwitcher<DiffFile>(
+                  mode: viewMode,
+                  items: files,
+                  pathOf: (DiffFile file) => file.displayPath,
+                  leafBuilder: (BuildContext context, DiffFile file) =>
+                      _buildFileRow(context, file),
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFileRow(BuildContext context, DiffFile file) {
+    final GbmColors colors = context.gbmColors;
+    final bool isSelected = file.displayPath == selectedPath;
+    return Container(
+      color: isSelected ? colors.surfaceSelected : null,
+      child: ListTile(
+        dense: true,
+        title: Text(
+          file.displayPath,
+          style: TextStyle(
+            fontSize: GbmTypography.textSm,
+            color: colors.textPrimary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (file.addedLines > 0)
+              GbmBadge(label: '+${file.addedLines}', kind: GbmBadgeKind.added),
+            if (file.removedLines > 0) ...<Widget>[
+              const SizedBox(width: GbmSpacing.space1),
+              GbmBadge(
+                label: '-${file.removedLines}',
+                kind: GbmBadgeKind.removed,
               ),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  if (file.addedLines > 0)
-                    GbmBadge(
-                      label: '+${file.addedLines}',
-                      kind: GbmBadgeKind.added,
-                    ),
-                  if (file.removedLines > 0) ...<Widget>[
-                    const SizedBox(width: GbmSpacing.space1),
-                    GbmBadge(
-                      label: '-${file.removedLines}',
-                      kind: GbmBadgeKind.removed,
-                    ),
-                  ],
-                ],
+            ],
+          ],
+        ),
+        onTap: () => onSelect(file.displayPath),
+      ),
+    );
+  }
+}
+
+/// "FILES" label + the shared [FileListModeToggleButton], reused atop both
+/// [_RefCompareFileList] and [_WorkingCopyFileList] -- spec page 03 item 10:
+/// the same List/Tree preference applies to Working Copy, History's Changed
+/// files, Compare's Files, and the Conflict window's file rail.
+class _FileListPanelHeader extends StatelessWidget {
+  const _FileListPanelHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        GbmSpacing.space3,
+        GbmSpacing.space1,
+        GbmSpacing.space1,
+        GbmSpacing.space1,
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              'FILES',
+              style: TextStyle(
+                fontSize: GbmTypography.textXs,
+                fontWeight: GbmTypography.weightSemibold,
+                color: colors.textTertiary,
+                letterSpacing: 0.5,
               ),
-              onTap: () => onSelect(file.displayPath),
             ),
-          );
-        },
+          ),
+          const FileListModeToggleButton(),
+        ],
       ),
     );
   }
@@ -541,6 +619,7 @@ class _WorkingCopyFileList extends StatelessWidget {
     required this.selectedPath,
     required this.onSelect,
     required this.onCheckout,
+    this.viewMode = FileListViewMode.list,
   });
 
   final ScrollController controller;
@@ -550,51 +629,85 @@ class _WorkingCopyFileList extends StatelessWidget {
   final ValueChanged<String> onSelect;
   final ValueChanged<String> onCheckout;
 
+  /// List vs Tree display, from the shared [fileListViewModeProvider] --
+  /// see [_FileListPanelHeader]'s doc comment.
+  final FileListViewMode viewMode;
+
   @override
   Widget build(BuildContext context) {
     final GbmColors colors = context.gbmColors;
     if (files.isEmpty) {
-      return Center(
-        child: Text('No changes', style: TextStyle(color: colors.textTertiary)),
+      return Column(
+        children: <Widget>[
+          const _FileListPanelHeader(),
+          Expanded(
+            child: Center(
+              child: Text(
+                'No changes',
+                style: TextStyle(color: colors.textTertiary),
+              ),
+            ),
+          ),
+        ],
       );
     }
-    return NotificationListener<ScrollEndNotification>(
-      onNotification: (ScrollEndNotification notification) {
-        onScrollEnd();
-        return false;
-      },
-      child: ListView.builder(
-        controller: controller,
-        itemCount: files.length,
-        itemBuilder: (context, index) {
-          final DiffFile file = files[index];
-          final bool isSelected = file.displayPath == selectedPath;
-          return Container(
-            color: isSelected ? colors.surfaceSelected : null,
-            child: ListTile(
-              dense: true,
-              title: Text(
-                file.displayPath,
-                style: TextStyle(
-                  fontSize: GbmTypography.textSm,
-                  color: colors.textPrimary,
+    return Column(
+      children: <Widget>[
+        const _FileListPanelHeader(),
+        Expanded(
+          child: viewMode == FileListViewMode.list
+              ? NotificationListener<ScrollEndNotification>(
+                  onNotification: (ScrollEndNotification notification) {
+                    onScrollEnd();
+                    return false;
+                  },
+                  child: ListView.builder(
+                    controller: controller,
+                    itemCount: files.length,
+                    itemBuilder: (context, index) =>
+                        _buildFileRow(context, files[index]),
+                  ),
+                )
+              // Tree mode has no scroll-offset persistence: FileTreeList
+              // builds its own internal ListView with no controller seam.
+              : FileListModeSwitcher<DiffFile>(
+                  mode: viewMode,
+                  items: files,
+                  pathOf: (DiffFile file) => file.displayPath,
+                  leafBuilder: (BuildContext context, DiffFile file) =>
+                      _buildFileRow(context, file),
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              trailing: IconButton(
-                tooltip: 'Checkout (overwrite working copy)',
-                icon: Icon(
-                  Icons.settings_backup_restore,
-                  size: 16,
-                  color: colors.textSecondary,
-                ),
-                onPressed: () => onCheckout(file.displayPath),
-              ),
-              onTap: () => onSelect(file.displayPath),
-            ),
-          );
-        },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFileRow(BuildContext context, DiffFile file) {
+    final GbmColors colors = context.gbmColors;
+    final bool isSelected = file.displayPath == selectedPath;
+    return Container(
+      color: isSelected ? colors.surfaceSelected : null,
+      child: ListTile(
+        dense: true,
+        title: Text(
+          file.displayPath,
+          style: TextStyle(
+            fontSize: GbmTypography.textSm,
+            color: colors.textPrimary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: IconButton(
+          tooltip: 'Checkout (overwrite working copy)',
+          icon: Icon(
+            Icons.settings_backup_restore,
+            size: 16,
+            color: colors.textSecondary,
+          ),
+          onPressed: () => onCheckout(file.displayPath),
+        ),
+        onTap: () => onSelect(file.displayPath),
       ),
     );
   }

--- a/app_flutter/lib/features/conflict_resolution/conflict_resolve_window.dart
+++ b/app_flutter/lib/features/conflict_resolution/conflict_resolve_window.dart
@@ -9,12 +9,15 @@ import '../../actions/gbm_sequencer_operation.dart';
 import '../../data/models/parsed_conflict_file.dart';
 import '../../data/models/repo_state.dart';
 import '../../data/models/working_copy_status.dart';
+import '../../data/repositories/file_list_view_mode_repository.dart';
 import '../../data/repositories/repo_identity.dart';
 import '../../data/repositories/repo_session_repository.dart';
 import '../../data/repositories/working_copy_repository.dart' as wc;
 import '../../routing/route_paths.dart';
 import '../../theme/gbm_theme.dart';
 import '../../theme/tokens.dart';
+import '../../widgets/file_list_mode_switcher.dart';
+import '../../widgets/file_list_mode_toggle_button.dart';
 import '../../widgets/gbm_button.dart';
 import '../../widgets/gbm_menu.dart';
 import '../../widgets/split_pane.dart';
@@ -516,6 +519,38 @@ class _ConflictResolveWindowState extends ConsumerState<ConflictResolveWindow> {
     _applyParsedContentIfNeeded(session);
     if (_allResolved) _ensureResultSeeded();
 
+    // Spec page 03 item 10: same List/Tree preference as Working Copy,
+    // History's Changed files, and Compare's Files.
+    final FileListViewMode viewMode = ref.watch(fileListViewModeProvider);
+
+    Widget buildRailRow(ConflictBatchEntry entry) {
+      final WorkingCopyEntry? wc = conflicted
+          .cast<WorkingCopyEntry?>()
+          .firstWhere((e) => e?.path == entry.path, orElse: () => null);
+      return _ConflictRailRow(
+        entry: entry,
+        selected: entry.path == _selectedPath,
+        onTap: () => _selectPath(entry.path),
+        onTakeOurs: () => ref
+            .read(repoSessionProvider(widget.identity).notifier)
+            .resolveConflict(
+              entry.path,
+              ConflictResolution.takeOurs,
+              oursBlobMissing: wc?.oursBlob.isEmpty ?? false,
+            ),
+        onTakeTheirs: () => ref
+            .read(repoSessionProvider(widget.identity).notifier)
+            .resolveConflict(
+              entry.path,
+              ConflictResolution.takeTheirs,
+              theirsBlobMissing: wc?.theirsBlob.isEmpty ?? false,
+            ),
+        onMarkResolved: () => ref
+            .read(repoSessionProvider(widget.identity).notifier)
+            .resolveConflict(entry.path, ConflictResolution.markResolved),
+      );
+    }
+
     return _ConflictResolveWindowShortcuts(
       isMacOS: widget.isMacOS ?? Platform.isMacOS,
       onUndoDiscard: _undoLastDiscard,
@@ -582,76 +617,42 @@ class _ConflictResolveWindowState extends ConsumerState<ConflictResolveWindow> {
                                 horizontal: GbmSpacing.space3,
                                 vertical: GbmSpacing.space1,
                               ),
-                              child: Text(
-                                '${_batch.resolvedCount} of ${_batch.entries.length} resolved',
-                                style: TextStyle(
-                                  fontSize: GbmTypography.textXs,
-                                  color: colors.textTertiary,
-                                ),
+                              child: Row(
+                                children: <Widget>[
+                                  Expanded(
+                                    child: Text(
+                                      '${_batch.resolvedCount} of ${_batch.entries.length} resolved',
+                                      style: TextStyle(
+                                        fontSize: GbmTypography.textXs,
+                                        color: colors.textTertiary,
+                                      ),
+                                    ),
+                                  ),
+                                  const FileListModeToggleButton(),
+                                ],
                               ),
                             ),
                             Expanded(
-                              child: ListView(
-                                children: <Widget>[
-                                  for (final entry in _batch.entries)
-                                    _ConflictRailRow(
-                                      entry: entry,
-                                      selected: entry.path == _selectedPath,
-                                      onTap: () => _selectPath(entry.path),
-                                      onTakeOurs: () {
-                                        final WorkingCopyEntry? wc = conflicted
-                                            .cast<WorkingCopyEntry?>()
-                                            .firstWhere(
-                                              (e) => e?.path == entry.path,
-                                              orElse: () => null,
-                                            );
-                                        ref
-                                            .read(
-                                              repoSessionProvider(
-                                                widget.identity,
-                                              ).notifier,
-                                            )
-                                            .resolveConflict(
-                                              entry.path,
-                                              ConflictResolution.takeOurs,
-                                              oursBlobMissing:
-                                                  wc?.oursBlob.isEmpty ?? false,
-                                            );
-                                      },
-                                      onTakeTheirs: () {
-                                        final WorkingCopyEntry? wc = conflicted
-                                            .cast<WorkingCopyEntry?>()
-                                            .firstWhere(
-                                              (e) => e?.path == entry.path,
-                                              orElse: () => null,
-                                            );
-                                        ref
-                                            .read(
-                                              repoSessionProvider(
-                                                widget.identity,
-                                              ).notifier,
-                                            )
-                                            .resolveConflict(
-                                              entry.path,
-                                              ConflictResolution.takeTheirs,
-                                              theirsBlobMissing:
-                                                  wc?.theirsBlob.isEmpty ??
-                                                  false,
-                                            );
-                                      },
-                                      onMarkResolved: () => ref
-                                          .read(
-                                            repoSessionProvider(
-                                              widget.identity,
-                                            ).notifier,
-                                          )
-                                          .resolveConflict(
-                                            entry.path,
-                                            ConflictResolution.markResolved,
-                                          ),
+                              child: viewMode == FileListViewMode.list
+                                  ? ListView(
+                                      children: <Widget>[
+                                        for (final entry in _batch.entries)
+                                          buildRailRow(entry),
+                                      ],
+                                    )
+                                  // Tree mode has no scroll-offset
+                                  // persistence: FileTreeList builds its own
+                                  // internal ListView with no controller seam.
+                                  : FileListModeSwitcher<ConflictBatchEntry>(
+                                      mode: viewMode,
+                                      items: _batch.entries,
+                                      pathOf: (ConflictBatchEntry e) => e.path,
+                                      leafBuilder:
+                                          (
+                                            BuildContext context,
+                                            ConflictBatchEntry entry,
+                                          ) => buildRailRow(entry),
                                     ),
-                                ],
-                              ),
                             ),
                           ],
                         ),

--- a/app_flutter/lib/features/context_menus/gbm_context_menus.dart
+++ b/app_flutter/lib/features/context_menus/gbm_context_menus.dart
@@ -20,10 +20,12 @@ enum GbmContextMenuTarget {
   repository, // 05-A
   /// Right-click a local branch row in the sidebar.
   localBranch, // 05-B
-  /// Right-click a remote-only or "gone" branch row in the sidebar.
-  /// Not yet wired; will need to distinguish remote-only rows from gone.
-  /// Per spec note: for a "gone" row specifically, only "Prune this ref" and
-  /// "Copy branch name" stay enabled; others disabled.
+  /// Right-click a remote-only or "gone" branch row in the sidebar. Wired via
+  /// `branch_tree_item.dart`'s `_buildMenuItems()`, which distinguishes the
+  /// two cases itself: a remote-only row gets its own 05-C subset, and a
+  /// "gone" row goes through `_buildGoneMenuItems()`, which per the spec
+  /// note leaves only "Prune this ref" and "Copy branch name" enabled with
+  /// the rest disabled (not omitted).
   remoteOnlyOrGoneBranch, // 05-C
   /// Right-click a branch folder row (e.g., feature/, bugfix/) in the sidebar.
   /// Not yet wired.

--- a/app_flutter/lib/features/dialogs/manage_base_folders/manage_base_folders_dialog.dart
+++ b/app_flutter/lib/features/dialogs/manage_base_folders/manage_base_folders_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -53,6 +55,10 @@ class _BaseFolderRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final GbmColors colors = context.gbmColors;
+    // Same pure local filesystem check as preferences_dialog.dart's
+    // _BaseFolderRow -- see that copy's doc comment. A visual marker only;
+    // the folder's settings are kept and enable/remove still work normally.
+    final bool isOffline = !Directory(folder.path).existsSync();
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: GbmSpacing.space1),
       child: Row(
@@ -64,6 +70,19 @@ class _BaseFolderRow extends ConsumerWidget {
                 .setBaseFolderEnabled(folder.id, value ?? true),
             visualDensity: VisualDensity.compact,
           ),
+          if (isOffline) ...<Widget>[
+            Tooltip(
+              message:
+                  'This folder is not reachable right now — its settings '
+                  'are kept.',
+              child: Icon(
+                Icons.warning_amber_rounded,
+                size: 16,
+                color: colors.warning,
+              ),
+            ),
+            const SizedBox(width: GbmSpacing.space1),
+          ],
           Expanded(
             child: Text(
               folder.path,

--- a/app_flutter/lib/features/dialogs/preferences/preferences_dialog.dart
+++ b/app_flutter/lib/features/dialogs/preferences/preferences_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -494,16 +496,25 @@ class _RepositorySourcesSectionState
         ],
         const SizedBox(height: GbmSpacing.space4),
         const _SectionHeading('MANUALLY OPENED'),
-        Text(
-          recents.isEmpty
-              ? 'Nothing recorded yet.'
-              : '${recents.length} recorded · most recent: '
-                    '${recents.first.workDir}',
-          style: TextStyle(
-            fontSize: GbmTypography.textSm,
-            color: colors.textSecondary,
-          ),
-        ),
+        if (recents.isEmpty)
+          Text(
+            'Nothing recorded yet.',
+            style: TextStyle(
+              fontSize: GbmTypography.textSm,
+              color: colors.textSecondary,
+            ),
+          )
+        else
+          for (final RecentRepoEntry entry in recents)
+            _RecentEntryRow(
+              entry: entry,
+              // Same non-notifier refresh pattern as Clear list below --
+              // RecentsRepository has no state of its own to watch.
+              onRemove: () async {
+                await ref.read(recentsRepositoryProvider).remove(entry.workDir);
+                if (mounted) setState(() {});
+              },
+            ),
         const SizedBox(height: GbmSpacing.space1),
         Text(
           'Clearing this list only forgets the entries — nothing on disk is '
@@ -531,6 +542,45 @@ class _RepositorySourcesSectionState
   }
 }
 
+/// One recorded manual open, with its own delete affordance -- spec page 11
+/// item 7's "手動加入的可單獨移除" (a manually-opened entry can be removed on
+/// its own, separate from the batch "Clear list" below).
+class _RecentEntryRow extends StatelessWidget {
+  const _RecentEntryRow({required this.entry, required this.onRemove});
+
+  final RecentRepoEntry entry;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              entry.workDir,
+              style: TextStyle(
+                fontSize: GbmTypography.textSm,
+                color: colors.textPrimary,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          IconButton(
+            key: ValueKey<String>('recent-entry-remove-${entry.workDir}'),
+            icon: Icon(Icons.close, size: 16, color: colors.textTertiary),
+            tooltip: 'Remove from list',
+            visualDensity: VisualDensity.compact,
+            onPressed: onRemove,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _BaseFolderRow extends ConsumerWidget {
   const _BaseFolderRow({required this.folder});
 
@@ -539,9 +589,22 @@ class _BaseFolderRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final GbmColors colors = context.gbmColors;
+    // A pure local filesystem check -- no capi call, no persisted state.
+    // Re-evaluated on every rebuild, so it never goes stale the way a
+    // one-time-at-scan-time flag would if the folder disappeared afterwards.
+    // Settings are kept either way (see the class doc comment on
+    // DiscoveryController): this is a visual marker only, never a block.
+    final bool isOffline = !Directory(folder.path).existsSync();
+
+    final String scanSummary =
+        'depth ${folder.maxDepth} · ${folder.lastScanDirs} director(ies) '
+        'scanned'
+        '${folder.lastScanSkipped > 0 ? ' · ${folder.lastScanSkipped} skipped (depth limit)' : ''}';
+
     return Padding(
       padding: const EdgeInsets.only(bottom: GbmSpacing.space1),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           Checkbox(
             value: folder.enabled,
@@ -550,6 +613,19 @@ class _BaseFolderRow extends ConsumerWidget {
                 .read(discoveryProvider.notifier)
                 .setBaseFolderEnabled(folder.id, value ?? true),
           ),
+          if (isOffline) ...<Widget>[
+            Tooltip(
+              message:
+                  'This folder is not reachable right now — its settings '
+                  'are kept and nothing will be removed automatically.',
+              child: Icon(
+                Icons.warning_amber_rounded,
+                size: 16,
+                color: colors.warning,
+              ),
+            ),
+            const SizedBox(width: GbmSpacing.space1),
+          ],
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -563,8 +639,7 @@ class _BaseFolderRow extends ConsumerWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
                 Text(
-                  'depth ${folder.maxDepth} · ${folder.lastScanDirs} '
-                  'director(ies) scanned',
+                  scanSummary,
                   style: TextStyle(
                     fontSize: GbmTypography.textXs,
                     color: colors.textTertiary,
@@ -572,6 +647,13 @@ class _BaseFolderRow extends ConsumerWidget {
                 ),
               ],
             ),
+          ),
+          const SizedBox(width: GbmSpacing.space2),
+          _DepthField(
+            value: folder.maxDepth,
+            onChanged: (int depth) => ref
+                .read(discoveryProvider.notifier)
+                .setBaseFolderDepth(folder.id, depth),
           ),
           IconButton(
             icon: Icon(Icons.delete_outline, size: 18, color: colors.danger),
@@ -581,6 +663,64 @@ class _BaseFolderRow extends ConsumerWidget {
                 .removeBaseFolder(folder.id),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Compact inline editor for one base folder's scan depth -- a slimmed-down
+/// sibling of [_NumberField] (no label/border) sized to sit in a folder row
+/// next to the checkbox and delete button instead of stacked on its own
+/// line.
+class _DepthField extends StatefulWidget {
+  const _DepthField({required this.value, required this.onChanged});
+
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  State<_DepthField> createState() => _DepthFieldState();
+}
+
+class _DepthFieldState extends State<_DepthField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.value.toString());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 56,
+      child: TextField(
+        controller: _controller,
+        keyboardType: TextInputType.number,
+        textAlign: TextAlign.center,
+        decoration: const InputDecoration(
+          isDense: true,
+          border: OutlineInputBorder(),
+          contentPadding: EdgeInsets.symmetric(
+            horizontal: GbmSpacing.space1,
+            vertical: 6,
+          ),
+        ),
+        style: const TextStyle(fontSize: GbmTypography.textSm),
+        // Only a parseable non-negative value is committed -- a half-typed
+        // field must not momentarily send 0 (which would mean "this base
+        // folder is itself the only thing scanned") mid-keystroke.
+        onSubmitted: (String text) {
+          final int? parsed = int.tryParse(text.trim());
+          if (parsed != null && parsed >= 0) widget.onChanged(parsed);
+        },
       ),
     );
   }
@@ -616,9 +756,23 @@ class _GitSection extends ConsumerWidget {
           _GitignorePathField(
             initialValue: prefs.globalGitignorePath,
             onChanged: (String v) => notifier.update(
-              (AppPreferences p) => p.copyWith(globalGitignorePath: v),
+              (AppPreferences p) => p.copyWith(
+                globalGitignorePath: v,
+                globalGitignoreSource: 'manual',
+              ),
             ),
           ),
+          if (prefs.globalGitignoreSource == 'imported') ...<Widget>[
+            const SizedBox(height: GbmSpacing.space1),
+            Text(
+              'Imported from .gitconfig',
+              style: TextStyle(
+                fontSize: GbmTypography.textXs,
+                fontStyle: FontStyle.italic,
+                color: context.gbmColors.textTertiary,
+              ),
+            ),
+          ],
         ],
         const SizedBox(height: GbmSpacing.space4),
         const _SectionHeading('COMMIT MESSAGES'),

--- a/app_flutter/lib/features/history_graph/commit_graph_view.dart
+++ b/app_flutter/lib/features/history_graph/commit_graph_view.dart
@@ -240,7 +240,7 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
               showGraph: query.isEmpty,
               selected: oid.isNotEmpty && oid == selectedOid,
               refChips: oid.isEmpty
-                  ? const <RefInfo>[]
+                  ? const <RefChipData>[]
                   : refChipsForCommit(refs, oid),
               isOwnCommit:
                   meta != null &&

--- a/app_flutter/lib/features/history_graph/widgets/changed_files_panel.dart
+++ b/app_flutter/lib/features/history_graph/widgets/changed_files_panel.dart
@@ -4,11 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../data/models/changed_file.dart';
+import '../../../data/repositories/file_list_view_mode_repository.dart';
 import '../../../data/repositories/history_repository.dart';
 import '../../../data/repositories/repo_identity.dart';
 import '../../../routing/route_paths.dart';
 import '../../../theme/gbm_theme.dart';
 import '../../../theme/tokens.dart';
+import '../../../widgets/file_list_mode_switcher.dart';
+import '../../../widgets/file_list_mode_toggle_button.dart';
 import '../../../widgets/gbm_menu.dart';
 
 /// Container: watches the changed-files providers for [identity] and wires
@@ -28,10 +31,12 @@ class ChangedFilesPanel extends ConsumerWidget {
     final String? selectedCommitOid = ref.watch(
       selectedCommitProvider(identity),
     );
+    final FileListViewMode viewMode = ref.watch(fileListViewModeProvider);
 
     return ChangedFilesPanelCore(
       hasSelectedCommit: selectedCommitOid != null,
       files: files,
+      viewMode: viewMode,
       selectedPath: selectedPath,
       onFileTap: selectedCommitOid == null
           ? null
@@ -83,11 +88,18 @@ class ChangedFilesPanelCore extends StatelessWidget {
     this.onFileHistory,
     this.onBlame,
     this.onRestoreToThisState,
+    this.viewMode = FileListViewMode.list,
   });
 
   final bool hasSelectedCommit;
   final List<ChangedFile> files;
   final String? selectedPath;
+
+  /// List vs Tree display, from the shared [fileListViewModeProvider]
+  /// (spec page 03 item 10 -- "同一個設定套用到...History 的 Changed
+  /// files"). Defaults to list so existing callers/tests that don't pass it
+  /// keep their prior behavior unchanged.
+  final FileListViewMode viewMode;
   final ValueChanged<String>? onFileTap;
   final ValueChanged<String>? onFileHistory;
   final ValueChanged<String>? onBlame;
@@ -110,30 +122,67 @@ class ChangedFilesPanelCore extends StatelessWidget {
 
     final GbmColors colors = context.gbmColors;
 
-    return ListView.builder(
-      itemCount: files.length,
-      itemBuilder: (context, index) {
-        final ChangedFile file = files[index];
-        final bool isSelected = selectedPath == file.path;
-
-        return GestureDetector(
-          onSecondaryTapDown: (details) =>
-              _openContextMenu(context, details, file.path),
-          child: Container(
-            color: isSelected ? colors.surfaceSelected : null,
-            child: ListTile(
-              dense: true,
-              title: Text(
-                file.path,
-                style: Theme.of(context).textTheme.bodySmall,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              onTap: onFileTap == null ? null : () => onFileTap!(file.path),
-            ),
+    return Column(
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            GbmSpacing.space3,
+            GbmSpacing.space1,
+            GbmSpacing.space1,
+            GbmSpacing.space1,
           ),
-        );
-      },
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  'CHANGED FILES',
+                  style: TextStyle(
+                    fontSize: GbmTypography.textXs,
+                    fontWeight: GbmTypography.weightSemibold,
+                    color: colors.textTertiary,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+              ),
+              // Spec page 03 item 10: same List/Tree preference as Working
+              // Copy, Compare, and the Conflict window's file lists.
+              const FileListModeToggleButton(),
+            ],
+          ),
+        ),
+        Expanded(
+          child: FileListModeSwitcher<ChangedFile>(
+            mode: viewMode,
+            items: files,
+            pathOf: (ChangedFile file) => file.path,
+            leafBuilder: (BuildContext context, ChangedFile file) =>
+                _buildFileRow(context, file),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFileRow(BuildContext context, ChangedFile file) {
+    final GbmColors colors = context.gbmColors;
+    final bool isSelected = selectedPath == file.path;
+
+    return GestureDetector(
+      onSecondaryTapDown: (details) =>
+          _openContextMenu(context, details, file.path),
+      child: Container(
+        color: isSelected ? colors.surfaceSelected : null,
+        child: ListTile(
+          dense: true,
+          title: Text(
+            file.path,
+            style: Theme.of(context).textTheme.bodySmall,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          onTap: onFileTap == null ? null : () => onFileTap!(file.path),
+        ),
+      ),
     );
   }
 

--- a/app_flutter/lib/features/history_graph/widgets/commit_row.dart
+++ b/app_flutter/lib/features/history_graph/widgets/commit_row.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 
 import '../../../data/models/commit_meta.dart';
 import '../../../data/models/graph_snapshot.dart';
-import '../../../data/models/ref_snapshot.dart';
 import '../../../theme/gbm_theme.dart';
 import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_menu.dart';
@@ -11,6 +10,7 @@ import '../../../widgets/gbm_row.dart';
 import '../../../widgets/gbm_tag_chip.dart';
 import 'graph_column_painter.dart';
 import 'graph_date_format.dart';
+import 'graph_ref_chips.dart';
 
 const double kGraphLaneWidth = 18;
 const double kCommitRowHeight = GbmSpacing.rowHeightComfortable;
@@ -35,7 +35,7 @@ class CommitRow extends StatelessWidget {
     this.meta,
     this.selected = false,
     this.onTap,
-    this.refChips = const <RefInfo>[],
+    this.refChips = const <RefChipData>[],
     this.isOwnCommit = false,
     this.showGraph = true,
     this.onCheckout,
@@ -58,9 +58,10 @@ class CommitRow extends StatelessWidget {
   final bool selected;
   final VoidCallback? onTap;
 
-  /// All refs pointing at this commit (from `graph_ref_chips.dart`'s
-  /// `refChipsForCommit`), rendered as `GbmTagChip`s before the subject.
-  final List<RefInfo> refChips;
+  /// Chip render data for this commit (from `graph_ref_chips.dart`'s
+  /// `refChipsForCommit`, already carrying the local/origin merge rule),
+  /// rendered as `GbmTagChip`s before the subject.
+  final List<RefChipData> refChips;
 
   /// True when [meta]'s author email matches the effective git identity --
   /// bolds and accent-colors the author text only (never the row
@@ -160,11 +161,13 @@ class CommitRow extends StatelessWidget {
                   child: Wrap(
                     spacing: 4,
                     children: <Widget>[
-                      for (final RefInfo ref in refChips)
+                      for (final RefChipData chip in refChips)
                         GbmTagChip(
-                          label: ref.shortName,
-                          kind: ref.kind,
-                          isCurrent: ref.isHead,
+                          label: chip.label,
+                          kind: chip.kind,
+                          isCurrent: chip.isCurrent,
+                          showCloudIcon: chip.showCloudIcon,
+                          isDashed: chip.isDashed,
                         ),
                     ],
                   ),

--- a/app_flutter/lib/features/history_graph/widgets/graph_ref_chips.dart
+++ b/app_flutter/lib/features/history_graph/widgets/graph_ref_chips.dart
@@ -1,16 +1,103 @@
 import '../../../data/models/ref_snapshot.dart';
 
-/// Groups refs pointing to a single commit into chip data.
-/// Returns a list of RefInfo for all refs targeting the given OID.
-List<RefInfo> refChipsForCommit(RefSnapshot refs, String targetOid) {
-  final chips = <RefInfo>[];
+/// A single ref chip's render data for one commit row -- what
+/// [refChipsForCommit] hands to [CommitRow] instead of a bare [RefInfo], so
+/// the merge/divergence rule below (spec page 02: "local 與 origin 在同一個
+/// commit 時只出一個 chip，尾端加一個雲朵圖示…虛線外框＝只有在分歧時才會
+/// 出現") is computed once here rather than re-derived at render time.
+class RefChipData {
+  const RefChipData({
+    required this.label,
+    required this.kind,
+    this.isCurrent = false,
+    this.showCloudIcon = false,
+    this.isDashed = false,
+  });
 
-  // Collect all refs pointing to this commit
-  for (final ref in refs.refs) {
-    if (ref.target == targetOid) {
-      chips.add(ref);
+  final String label;
+  final RefKind kind;
+
+  /// True for the branch HEAD currently points at -- unrelated to
+  /// [showCloudIcon]/[isDashed], which are purely about local/remote sync.
+  final bool isCurrent;
+
+  /// A local branch chip whose upstream remote branch points at the same
+  /// commit: the remote branch's own chip is suppressed and this flag adds
+  /// a cloud icon to the local chip instead, per spec's "同一件事寫兩遍只
+  /// 是佔寬度".
+  final bool showCloudIcon;
+
+  /// A remote branch chip whose tracking local branch exists but points at
+  /// a *different* commit (diverged) -- spec's dashed-outline chip marking
+  /// where the remote actually sits. Never true for a local branch chip, and
+  /// never true for a remote branch with no local branch tracking it at all
+  /// (that's the sidebar's distinct "Remote only" state, not this rule).
+  final bool isDashed;
+}
+
+/// Groups refs pointing to a single commit into chip data, applying spec
+/// page 02's local/origin merge rule: a local branch synced with its
+/// upstream renders as one chip with a cloud icon instead of two chips, and
+/// a diverged upstream renders as its own dashed chip on the commit it
+/// actually points at.
+List<RefChipData> refChipsForCommit(RefSnapshot refs, String targetOid) {
+  // fullName -> RefInfo, for resolving a local branch's `upstream` (which is
+  // the tracked ref's *full* name, confirmed against real `git for-each-ref`
+  // output -- see branch_tree_builder.dart's mergeLocalAndRemoteBranches(),
+  // whose upstream-matching semantics this reuses) back to the remote
+  // branch it names.
+  final Map<String, RefInfo> remoteByFullName = <String, RefInfo>{
+    for (final RefInfo r in refs.refs)
+      if (r.kind == RefKind.remoteBranch && !r.isSymbolic) r.fullName: r,
+  };
+
+  // Every local branch with a resolvable upstream, keyed by that upstream's
+  // fullName -- used below to tell a "diverged, still tracked" remote chip
+  // apart from a true remote-only ref with no local branch tracking it.
+  final Map<String, RefInfo> localByUpstream = <String, RefInfo>{
+    for (final RefInfo r in refs.refs)
+      if (r.kind == RefKind.localBranch && r.upstream.isNotEmpty) r.upstream: r,
+  };
+
+  final List<RefInfo> refsAtRow = refs.refs
+      .where((RefInfo r) => r.target == targetOid)
+      .toList(growable: false);
+
+  // A local branch at this row is "synced" when its upstream remote branch
+  // also points here -- that remote's chip gets suppressed below in favor
+  // of a cloud icon on the local chip.
+  final Set<String> syncedRemoteFullNames = <String>{};
+  for (final RefInfo ref in refsAtRow) {
+    if (ref.kind != RefKind.localBranch || ref.upstream.isEmpty) continue;
+    final RefInfo? remote = remoteByFullName[ref.upstream];
+    if (remote != null && remote.target == targetOid) {
+      syncedRemoteFullNames.add(remote.fullName);
     }
   }
 
+  final List<RefChipData> chips = <RefChipData>[];
+  for (final RefInfo ref in refsAtRow) {
+    if (ref.kind == RefKind.remoteBranch &&
+        syncedRemoteFullNames.contains(ref.fullName)) {
+      continue; // Merged into its tracking local branch's cloud chip.
+    }
+
+    final bool showCloudIcon =
+        ref.kind == RefKind.localBranch &&
+        syncedRemoteFullNames.contains(ref.upstream);
+    final bool isDashed =
+        ref.kind == RefKind.remoteBranch &&
+        localByUpstream.containsKey(ref.fullName);
+
+    chips.add(
+      RefChipData(
+        label: ref.shortName,
+        kind: ref.kind,
+        isCurrent: ref.isHead,
+        showCloudIcon: showCloudIcon,
+        isDashed: isDashed,
+      ),
+    );
+  }
   return chips;
 }

--- a/app_flutter/lib/features/status_bar/status_bar.dart
+++ b/app_flutter/lib/features/status_bar/status_bar.dart
@@ -8,6 +8,7 @@ import '../../data/models/working_copy_status.dart';
 import '../../theme/gbm_theme.dart';
 import '../../theme/tokens.dart';
 import '../../widgets/gbm_badge.dart';
+import '../../widgets/gbm_panel.dart';
 import 'background_task.dart';
 
 /// A horizontal status bar with three zones:
@@ -277,12 +278,9 @@ class _StatusBarState extends State<StatusBar> {
         ),
         const SizedBox(width: GbmSpacing.space2),
         if (extraCount > 0)
-          Text(
-            '+$extraCount more',
-            style: TextStyle(
-              fontSize: GbmTypography.textXs,
-              color: colors.textTertiary,
-            ),
+          _ExtraTasksChip(
+            extraTasks: tasks.skip(1).toList(growable: false),
+            onCancelTask: widget.onCancelTask,
           )
         else
           Tooltip(
@@ -311,6 +309,176 @@ class _StatusBarState extends State<StatusBar> {
             ),
           ),
       ],
+    );
+  }
+}
+
+/// The "+N task" fold (spec page 10 STATUSPARTS #2: "其餘作業摺疊成 +N
+/// task，點了展開清單"). Tapping opens a small panel listing every folded
+/// task's label, progress, and its own Cancel affordance, reusing
+/// [onCancelTask] rather than opening a second data path to the same
+/// cancellation call. Anchored to this chip's own render box (a plain tap
+/// target, not a right-click point), using the same low-chrome `showMenu`
+/// idiom `gbm_menu.dart`'s `showGbmMenu` establishes -- `color: transparent`
+/// / `elevation: 0` / a single disabled [PopupMenuItem] wrapping a custom
+/// panel -- but with this widget's own row content instead of
+/// `GbmMenuItem`'s simple label+onTap shape, since a progress bar and a
+/// Cancel button don't fit that model.
+class _ExtraTasksChip extends StatelessWidget {
+  const _ExtraTasksChip({required this.extraTasks, required this.onCancelTask});
+
+  final List<BackgroundTask> extraTasks;
+  final ValueChanged<String> onCancelTask;
+
+  Future<void> _showExtraTasksMenu(BuildContext context) {
+    final RenderBox button = context.findRenderObject()! as RenderBox;
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final RelativeRect position = RelativeRect.fromRect(
+      Rect.fromPoints(
+        button.localToGlobal(Offset.zero, ancestor: overlay),
+        button.localToGlobal(
+          button.size.bottomRight(Offset.zero),
+          ancestor: overlay,
+        ),
+      ),
+      Offset.zero & overlay.size,
+    );
+
+    return showMenu<void>(
+      context: context,
+      position: position,
+      color: Colors.transparent,
+      elevation: 0,
+      surfaceTintColor: Colors.transparent,
+      shadowColor: Colors.transparent,
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero),
+      items: <PopupMenuEntry<void>>[
+        PopupMenuItem<void>(
+          enabled: false,
+          padding: EdgeInsets.zero,
+          child: _ExtraTasksPanel(
+            extraTasks: extraTasks,
+            onCancelTask: onCancelTask,
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return GestureDetector(
+      onTap: () => _showExtraTasksMenu(context),
+      child: Text(
+        '+${extraTasks.length} more',
+        style: TextStyle(
+          fontSize: GbmTypography.textXs,
+          color: colors.textLink,
+          decoration: TextDecoration.underline,
+        ),
+      ),
+    );
+  }
+}
+
+class _ExtraTasksPanel extends StatelessWidget {
+  const _ExtraTasksPanel({
+    required this.extraTasks,
+    required this.onCancelTask,
+  });
+
+  final List<BackgroundTask> extraTasks;
+  final ValueChanged<String> onCancelTask;
+
+  @override
+  Widget build(BuildContext context) {
+    return GbmPanel(
+      padding: const EdgeInsets.symmetric(
+        vertical: GbmSpacing.space1,
+        horizontal: GbmSpacing.space2,
+      ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 260),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            for (final BackgroundTask task in extraTasks)
+              _ExtraTaskRow(task: task, onCancelTask: onCancelTask),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ExtraTaskRow extends StatelessWidget {
+  const _ExtraTaskRow({required this.task, required this.onCancelTask});
+
+  final BackgroundTask task;
+  final ValueChanged<String> onCancelTask;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: GbmSpacing.space1),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  task.label,
+                  style: TextStyle(
+                    fontSize: GbmTypography.textXs,
+                    color: colors.textPrimary,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(2),
+                  child: LinearProgressIndicator(
+                    value: task.progress,
+                    minHeight: 2,
+                    backgroundColor: colors.surfaceSunken,
+                    valueColor: AlwaysStoppedAnimation<Color>(colors.accent),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: GbmSpacing.space2),
+          Tooltip(
+            message: task.cancellable
+                ? 'Cancel this operation'
+                : 'Cannot cancel ${task.label.toLowerCase()} operation',
+            child: TextButton(
+              onPressed: task.cancellable ? () => onCancelTask(task.id) : null,
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: GbmSpacing.space2,
+                ),
+                minimumSize: const Size(0, 24),
+              ),
+              child: Text(
+                'Cancel',
+                style: TextStyle(
+                  fontSize: GbmTypography.textXs,
+                  color: task.cancellable
+                      ? colors.textLink
+                      : colors.textTertiary,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app_flutter/lib/features/working_copy/working_copy_view.dart
+++ b/app_flutter/lib/features/working_copy/working_copy_view.dart
@@ -65,7 +65,8 @@ class _WorkingCopyViewState extends ConsumerState<WorkingCopyView> {
   void initState() {
     super.initState();
     final draft = ref.read(workingCopyDraftProvider(widget.identity));
-    _summaryController = TextEditingController(text: draft.summary);
+    _summaryController = TextEditingController(text: draft.summary)
+      ..addListener(_onSummaryChanged);
     _descriptionController = TextEditingController(text: draft.description);
     _diffScrollController = ScrollController(
       initialScrollOffset: draft.diffScrollOffset,
@@ -90,6 +91,20 @@ class _WorkingCopyViewState extends ConsumerState<WorkingCopyView> {
     ref
         .read(workingCopyDraftProvider(widget.identity).notifier)
         .updateDiffScrollOffset(_diffScrollController.offset);
+  }
+
+  /// Triggers a rebuild on every keystroke in the summary field, mirroring
+  /// [_onDiffScroll]'s listener pattern. Without this, [_buildCommitBox]'s
+  /// `canCommit` (which reads `_summaryController.text.trim()` directly,
+  /// not a watched provider) only recomputes on some *unrelated* rebuild --
+  /// e.g. staging a file -- not when the summary text itself changes, so
+  /// the Commit/Amend buttons stay stale until something else happens to
+  /// force a rebuild (code-review-2026-08.md H2). No state to update here;
+  /// `onSummaryChanged` (wired separately, below) already persists the text
+  /// into [workingCopyDraftProvider] -- this listener exists purely to make
+  /// `canCommit` re-evaluate.
+  void _onSummaryChanged() {
+    setState(() {});
   }
 
   @override

--- a/app_flutter/lib/widgets/file_list_mode_switcher.dart
+++ b/app_flutter/lib/widgets/file_list_mode_switcher.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import '../data/models/file_tree.dart';
+import '../data/repositories/file_list_view_mode_repository.dart';
+import 'file_tree_folder_row.dart';
+import 'file_tree_list.dart';
+
+/// Switches a flat file list between List and Tree display modes, per
+/// [mode] (read from the shared [fileListViewModeProvider] by each caller --
+/// spec page 03 item 10: "同一個設定套用到 Working Copy 兩欄、History 的
+/// Changed files、Compare 的 Files、以及 Conflict 視窗的檔案清單"). List
+/// mode renders exactly the flat list [leafBuilder] would have produced on
+/// its own; tree mode groups by folder via [FileTree.fromPaths] and renders
+/// folders with [FileTreeFolderRow].
+///
+/// For read-only file lists with no staging/selection checkboxes --
+/// `working_copy_board.dart`'s own tree rendering needs a tri-state folder
+/// checkbox for bulk stage/unstage, so it builds `FileTreeList` directly
+/// instead of going through this widget. Expand/collapse state is not
+/// threaded through here at all: [FileTreeList] already owns and persists
+/// it internally across rebuilds (see that widget's own `_expandedFolders`
+/// State), so there is nothing for this wrapper to manage.
+class FileListModeSwitcher<T> extends StatelessWidget {
+  const FileListModeSwitcher({
+    super.key,
+    required this.mode,
+    required this.items,
+    required this.pathOf,
+    required this.leafBuilder,
+    this.emptyBuilder,
+  });
+
+  final FileListViewMode mode;
+  final List<T> items;
+  final String Function(T item) pathOf;
+  final Widget Function(BuildContext context, T item) leafBuilder;
+  final WidgetBuilder? emptyBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return emptyBuilder?.call(context) ?? const SizedBox.shrink();
+    }
+
+    if (mode == FileListViewMode.list) {
+      return ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (BuildContext context, int index) =>
+            leafBuilder(context, items[index]),
+      );
+    }
+
+    final Map<String, T> byPath = <String, T>{
+      for (final T item in items) pathOf(item): item,
+    };
+    final FileTree tree = FileTree.fromPaths(
+      items.map(pathOf).toList(growable: false),
+    );
+
+    return FileTreeList(
+      fileTree: tree,
+      mode: mode,
+      selectedPaths: const <String>{},
+      onFolderCheckStateChanged: (_) {}, // Read-only: no staging here.
+      onItemBuilder:
+          (
+            BuildContext context,
+            FileTreeNode node,
+            int level,
+            VoidCallback? onFolderToggle,
+          ) {
+            if (node.isDirectory) {
+              return FileTreeFolderRow(node: node, onToggle: onFolderToggle);
+            }
+            final T? item = byPath[node.displayPath];
+            return item == null
+                ? const SizedBox.shrink()
+                : leafBuilder(context, item);
+          },
+    );
+  }
+}

--- a/app_flutter/lib/widgets/file_tree_folder_row.dart
+++ b/app_flutter/lib/widgets/file_tree_folder_row.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../data/models/file_tree.dart';
+import '../theme/gbm_theme.dart';
+import '../theme/tokens.dart';
+
+/// A read-only folder row for [FileTreeList]'s tree mode: an expand/collapse
+/// chevron plus the folder's display name, no checkbox. For views whose file
+/// list has no staging semantics (History's Changed files panel, Compare's
+/// Files, the Conflict window's file rail) -- unlike
+/// `working_copy_board.dart`'s own folder row, which needs a tri-state
+/// checkbox for bulk stage/unstage and so isn't reused here.
+class FileTreeFolderRow extends StatelessWidget {
+  const FileTreeFolderRow({super.key, required this.node, this.onToggle});
+
+  final FileTreeNode node;
+  final VoidCallback? onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return InkWell(
+      onTap: onToggle,
+      child: SizedBox(
+        height: GbmSpacing.rowHeightCompact,
+        child: Row(
+          children: <Widget>[
+            Icon(Icons.arrow_right, size: 16, color: colors.textTertiary),
+            Expanded(
+              child: Text(
+                node.name,
+                style: TextStyle(
+                  fontSize: GbmTypography.textSm,
+                  color: colors.textPrimary,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app_flutter/lib/widgets/gbm_dialog_shell.dart
+++ b/app_flutter/lib/widgets/gbm_dialog_shell.dart
@@ -27,22 +27,33 @@ class GbmDialogShell extends StatelessWidget {
   Widget build(BuildContext context) {
     final GbmColors colors = context.gbmColors;
     return Center(
-      child: Material(
-        color: Colors.transparent,
-        child: Container(
-          width: width,
-          constraints: const BoxConstraints(maxHeight: 560),
-          decoration: BoxDecoration(
-            color: colors.surfaceOverlay,
-            borderRadius: BorderRadius.circular(GbmSpacing.radiusLg),
-            boxShadow: <BoxShadow>[
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.3),
-                blurRadius: 24,
-                offset: const Offset(0, 8),
-              ),
-            ],
-          ),
+      // The shadow lives on this outer, colorless DecoratedBox rather than
+      // on the Material below -- a DecoratedBox with its own `color` sitting
+      // between a Material and a descendant ListTile/InkWell hides that
+      // descendant's ink splashes (Flutter's own debugCheckHasMaterial-style
+      // "background color or ink splashes may be invisible" assertion,
+      // which only ever fires once something in [child] actually renders a
+      // ListTile -- nothing did until preferences_dialog_test.dart, the
+      // first test to pump a dialog whose body uses CheckboxListTile). The
+      // panel's fill color now lives directly on Material itself instead, so
+      // Material is the nearest colored ancestor with nothing opaque
+      // between it and any ListTile in [child].
+      child: Container(
+        width: width,
+        constraints: const BoxConstraints(maxHeight: 560),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(GbmSpacing.radiusLg),
+          boxShadow: <BoxShadow>[
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.3),
+              blurRadius: 24,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: Material(
+          color: colors.surfaceOverlay,
+          borderRadius: BorderRadius.circular(GbmSpacing.radiusLg),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[

--- a/app_flutter/lib/widgets/gbm_tag_chip.dart
+++ b/app_flutter/lib/widgets/gbm_tag_chip.dart
@@ -1,9 +1,12 @@
+import 'dart:ui' show PathMetric;
+
 import 'package:flutter/material.dart';
 
 import '../data/models/ref_snapshot.dart';
 import '../theme/gbm_theme.dart';
 import '../theme/ref_chip_colors.dart';
 import '../theme/tokens.dart';
+import 'lucide_icon.dart';
 
 /// `.gbm-tag`/`.gbm-tag-branch`/`.gbm-tag-branch.current`/`.gbm-tag-tag`
 /// (docs/design/tokens-reference.md's components.css).
@@ -13,11 +16,24 @@ class GbmTagChip extends StatelessWidget {
     required this.label,
     required this.kind,
     this.isCurrent = false,
+    this.showCloudIcon = false,
+    this.isDashed = false,
   });
 
   final String label;
   final RefKind kind;
   final bool isCurrent;
+
+  /// Trailing cloud icon marking a local branch chip whose upstream remote
+  /// branch is synced to the same commit (`graph_ref_chips.dart`'s
+  /// `RefChipData.showCloudIcon`) -- spec page 02: "local 與 origin 在同一
+  /// 個 commit 時只出一個 chip，尾端加一個雲朵圖示".
+  final bool showCloudIcon;
+
+  /// Dashed outline marking a remote branch chip whose tracking local
+  /// branch has diverged (`RefChipData.isDashed`) -- spec page 02: "虛線外
+  /// 框＝只有在分歧時才會出現，標出遠端落在哪個 commit".
+  final bool isDashed;
 
   @override
   Widget build(BuildContext context) {
@@ -26,22 +42,91 @@ class GbmTagChip extends StatelessWidget {
       kind,
       isCurrent: isCurrent,
     );
-    return Container(
+    final BorderRadius radius = BorderRadius.circular(GbmSpacing.radiusFull);
+    final Widget content = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Text(
+            label,
+            style: TextStyle(
+              fontFamily: GbmTypography.fontMono,
+              fontSize: GbmTypography.textXs,
+              fontWeight: GbmTypography.weightMedium,
+              color: chip.text,
+            ),
+          ),
+          if (showCloudIcon) ...<Widget>[
+            const SizedBox(width: 3),
+            LucideIcon('cloud', size: 9.5, color: chip.text),
+          ],
+        ],
+      ),
+    );
+
+    if (isDashed) {
+      // Flutter's Border has no dashed style, so the dashed outline is
+      // painted separately over a border-less fill instead of going through
+      // BoxDecoration.border like the solid case below.
+      return CustomPaint(
+        painter: _DashedRRectPainter(radius: radius, color: chip.border),
+        child: DecoratedBox(
+          decoration: BoxDecoration(color: chip.fill, borderRadius: radius),
+          child: content,
+        ),
+      );
+    }
+
+    return Container(
       decoration: BoxDecoration(
         color: chip.fill,
         border: Border.all(color: chip.border),
-        borderRadius: BorderRadius.circular(GbmSpacing.radiusFull),
+        borderRadius: radius,
       ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontFamily: GbmTypography.fontMono,
-          fontSize: GbmTypography.textXs,
-          fontWeight: GbmTypography.weightMedium,
-          color: chip.text,
-        ),
-      ),
+      child: content,
     );
   }
+}
+
+/// Paints a dashed rounded-rect outline, since [Border] has no built-in
+/// dashed style. Kept private and narrowly scoped to [GbmTagChip]'s dashed
+/// variant rather than a general-purpose dashed-border widget -- no other
+/// caller needs one yet (YAGNI).
+class _DashedRRectPainter extends CustomPainter {
+  const _DashedRRectPainter({required this.radius, required this.color});
+
+  final BorderRadius radius;
+  final Color color;
+
+  static const double _dashWidth = 3;
+  static const double _dashGap = 2;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Deflate by half the stroke width so the 1px stroke draws inside the
+    // chip's bounds instead of getting clipped at the edge.
+    final RRect rrect = radius.toRRect(Offset.zero & size).deflate(0.5);
+    final Path path = Path()..addRRect(rrect);
+    final Paint paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+
+    for (final PathMetric metric in path.computeMetrics()) {
+      double distance = 0;
+      while (distance < metric.length) {
+        final double next = distance + _dashWidth;
+        canvas.drawPath(
+          metric.extractPath(distance, next.clamp(0, metric.length)),
+          paint,
+        );
+        distance = next + _dashGap;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DashedRRectPainter oldDelegate) =>
+      oldDelegate.color != color || oldDelegate.radius != radius;
 }

--- a/app_flutter/test/data/models/model_parsing_test.dart
+++ b/app_flutter/test/data/models/model_parsing_test.dart
@@ -234,7 +234,8 @@ void main() {
   test('BaseFolderRecord.listFromJson decodes an array', () {
     final List<dynamic> json = jsonDecode(
       '[{"id":1,"path":"/code","enabled":true,"maxDepth":3,"followLinks":false,'
-      '"lastScanStarted":0,"lastScanFinished":0,"lastScanDirs":0,"lastScanMs":0}]',
+      '"lastScanStarted":0,"lastScanFinished":0,"lastScanDirs":0,"lastScanMs":0,'
+      '"lastScanSkipped":2}]',
     );
     final List<BaseFolderRecord> folders = BaseFolderRecord.listFromJson(json);
 
@@ -242,6 +243,9 @@ void main() {
     expect(folders.single.path, '/code');
     expect(folders.single.enabled, isTrue);
     expect(folders.single.maxDepth, 3);
+    // Directories skipped past maxDepth on the last scan -- see
+    // gbm::BaseFolderRecord::lastScanSkipped's doc comment.
+    expect(folders.single.lastScanSkipped, 2);
   });
 
   test('StashEntry.listFromJson decodes an array', () {

--- a/app_flutter/test/data/repositories/app_preferences_repository_test.dart
+++ b/app_flutter/test/data/repositories/app_preferences_repository_test.dart
@@ -24,6 +24,9 @@ void main() {
       // Spec page 10's LOGRULES retention row.
       expect(p.logMemoryLimit, 2000);
       expect(p.logRetentionDays, 7);
+      // Nothing has been imported yet -- see the field's own doc comment for
+      // why detection is not wired up this round.
+      expect(p.globalGitignoreSource, '');
     });
 
     test('round-trips every field through SharedPreferences', () async {
@@ -40,6 +43,7 @@ void main() {
         autoScanMinutes: 45,
         globalGitignoreEnabled: true,
         globalGitignorePath: '~/.config/git/ignore',
+        globalGitignoreSource: 'imported',
         cherryPickAddsSourceLine: false,
         confirmForcePush: false,
         logMemoryLimit: 500,
@@ -56,6 +60,7 @@ void main() {
       expect(read.autoScanMinutes, 45);
       expect(read.globalGitignoreEnabled, isTrue);
       expect(read.globalGitignorePath, '~/.config/git/ignore');
+      expect(read.globalGitignoreSource, 'imported');
       expect(read.cherryPickAddsSourceLine, isFalse);
       expect(read.confirmForcePush, isFalse);
       expect(read.logMemoryLimit, 500);

--- a/app_flutter/test/data/repositories/repo_session_operation_log_cap_test.dart
+++ b/app_flutter/test/data/repositories/repo_session_operation_log_cap_test.dart
@@ -1,0 +1,87 @@
+// RepoSessionState.operationLog's cap used to be a hardcoded module constant
+// (_kMaxOperationLogEntries = 500) whose doc comment incorrectly claimed to
+// mirror OperationRunner.cpp's kMaxUndoEntries -- that C++ constant is 200
+// and guards an entirely different list (undoJournal_, the one Undo Last
+// reads), so the two numbers were never actually the same thing. The cap now
+// comes from AppPreferences.logMemoryLimit (spec page 10 LOGRULES: "上限寫在
+// Preferences，不隱藏"), read once into RepoSessionController.
+// maxOperationLogEntries when a session opens (see repoSessionProvider's
+// factory). This mirrors repo_session_commit_meta_cache_test.dart's pattern
+// for the analogous commitMetaCache cap, testing the pure
+// RepoSessionState.withOperationRecord eviction logic directly rather than
+// going through a live FFI session.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/operation_record.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+
+OperationRecord _record(int whenEpochMs) => OperationRecord(
+  whenEpochMs: whenEpochMs,
+  repoDir: '/repo',
+  argv: const <String>['git', 'status'],
+  commandLine: 'git status',
+  exitCode: 0,
+  durationMs: 1,
+  stderrText: '',
+  cancelled: false,
+  timedOut: false,
+);
+
+void main() {
+  group('RepoSessionState.withOperationRecord', () {
+    test('appends to an empty log', () {
+      const state = RepoSessionState(isOpen: true);
+      final RepoSessionState next = state.withOperationRecord(
+        _record(1),
+        maxEntries: 5,
+      );
+      expect(next.operationLog.length, 1);
+      expect(next.operationLog.single.whenEpochMs, 1);
+    });
+
+    test('does not evict anything while under maxEntries', () {
+      RepoSessionState state = const RepoSessionState(isOpen: true);
+      for (int i = 0; i < 5; i++) {
+        state = state.withOperationRecord(_record(i), maxEntries: 5);
+      }
+      expect(state.operationLog.length, 5);
+      expect(state.operationLog.first.whenEpochMs, 0);
+    });
+
+    test('evicts the oldest entry (newest-last, sublist from the tail) once '
+        'over maxEntries -- the cap must come from the caller-supplied '
+        'maxEntries, not a hardcoded constant', () {
+      RepoSessionState state = const RepoSessionState(isOpen: true);
+      // Feed one over a small explicit cap, one event at a time -- the
+      // same way a real session accumulates operationLogRecord events.
+      const int maxEntries = 5;
+      for (int i = 0; i < maxEntries + 1; i++) {
+        state = state.withOperationRecord(_record(i), maxEntries: maxEntries);
+      }
+
+      expect(
+        state.operationLog.length,
+        maxEntries,
+        reason: 'the log must stay bounded at the supplied maxEntries',
+      );
+      expect(
+        state.operationLog.map((r) => r.whenEpochMs),
+        <int>[1, 2, 3, 4, 5],
+        reason:
+            'the oldest entry (whenEpochMs 0) must be evicted, and the '
+            'rest must stay in newest-last order',
+      );
+    });
+
+    test('a larger maxEntries (as Preferences -> logMemoryLimit allows up to '
+        '2000 by default) keeps proportionally more history', () {
+      RepoSessionState state = const RepoSessionState(isOpen: true);
+      const int maxEntries = 2000;
+      for (int i = 0; i < 2001; i++) {
+        state = state.withOperationRecord(_record(i), maxEntries: maxEntries);
+      }
+      expect(state.operationLog.length, maxEntries);
+      expect(state.operationLog.first.whenEpochMs, 1);
+      expect(state.operationLog.last.whenEpochMs, 2000);
+    });
+  });
+}

--- a/app_flutter/test/features/compare/compare_page_test.dart
+++ b/app_flutter/test/features/compare/compare_page_test.dart
@@ -1,0 +1,185 @@
+// Verifies ComparePage's file list (both the ref-vs-ref and
+// ref-vs-Working-Copy sides) actually reads the shared
+// fileListViewModeProvider and renders through FileTreeFolderRow in tree
+// mode -- spec page 03 item 10: the same List/Tree preference applies to
+// Working Copy, History's Changed files, Compare's Files, and the Conflict
+// window's file rail. _RefCompareFileList/_WorkingCopyFileList are private
+// to compare_page.dart, so this drives them through the real ComparePage
+// rather than importing them directly (mirrors
+// manage_remotes_dialog_test.dart's FakeRepoSessionController pattern).
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/compare_commit_entry.dart';
+import 'package:gbm_flutter/data/models/parsed_diff.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/compare_tabs_repository.dart';
+import 'package:gbm_flutter/data/repositories/file_list_view_mode_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/compare/compare_page.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:gbm_flutter/widgets/file_list_mode_toggle_button.dart';
+import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+
+DiffFile _file(String path) => DiffFile(
+  oldPath: path,
+  newPath: path,
+  kind: FileChangeKind.modified,
+  oldMode: '100644',
+  newMode: '100644',
+  oldBlob: 'aaa',
+  newBlob: 'bbb',
+  binary: false,
+  similarity: 0,
+  addedLines: 1,
+  removedLines: 0,
+  displayPath: path,
+  hunks: const <DiffHunk>[],
+);
+
+/// Pumps a ComparePage with [tab] already open and [viewMode] preset via
+/// SharedPreferences (read once at container construction -- see
+/// fileListViewModeRepositoryProvider), backed by [state]'s compare
+/// results.
+Future<void> _pump(
+  WidgetTester tester, {
+  required CompareTabSpec tab,
+  required RepoSessionState state,
+  required FileListViewMode viewMode,
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{
+    'fileListViewMode': viewMode == FileListViewMode.tree ? 'tree' : 'list',
+  });
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _identity,
+    state,
+  );
+  final CompareTabsNotifier tabsNotifier = CompareTabsNotifier();
+  tabsNotifier.open(left: tab.left, right: tab.right, threeDot: tab.threeDot);
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoSessionProvider(_identity).overrideWith((ref) => fake),
+      compareTabsProvider(_identity).overrideWith((ref) => tabsNotifier),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        home: Scaffold(
+          body: ComparePage(
+            identity: _identity,
+            tabId: tabsNotifier.state.single.id,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ComparePage file list -- ref vs ref', () {
+    const String left = 'main';
+    const String right = 'feature';
+    final List<DiffFile> files = <DiffFile>[
+      _file('a.dart'),
+      _file('b/c.dart'),
+      _file('b/d.dart'),
+    ];
+    final RepoSessionState stateWithResult = RepoSessionState(
+      compareResults: <String, CompareResult>{
+        CompareResult.key(left, right, true): CompareResult(
+          left: left,
+          right: right,
+          threeDot: true,
+          mergeBase: 'abc123',
+          commits: const <CompareCommitEntry>[],
+          files: files,
+        ),
+      },
+    );
+
+    testWidgets('shows the shared list/tree toggle button', (tester) async {
+      await _pump(
+        tester,
+        tab: const CompareTabSpec(id: 'unused', left: left, right: right),
+        state: stateWithResult,
+        viewMode: FileListViewMode.list,
+      );
+
+      expect(find.byType(FileListModeToggleButton), findsOneWidget);
+    });
+
+    testWidgets('tree mode renders a FileTreeFolderRow for a multi-file '
+        'folder', (tester) async {
+      await _pump(
+        tester,
+        tab: const CompareTabSpec(id: 'unused', left: left, right: right),
+        state: stateWithResult,
+        viewMode: FileListViewMode.tree,
+      );
+
+      expect(find.byType(FileTreeFolderRow), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('a.dart'), findsOneWidget);
+    });
+  });
+
+  group('ComparePage file list -- ref vs Working Copy', () {
+    const String left = 'main';
+    final List<DiffFile> files = <DiffFile>[
+      _file('a.dart'),
+      _file('b/c.dart'),
+      _file('b/d.dart'),
+    ];
+    final RepoSessionState stateWithResult = RepoSessionState(
+      compareWithWorkingCopyResults: <String, CompareWithWorkingCopyResult>{
+        CompareWithWorkingCopyResult.key(left): CompareWithWorkingCopyResult(
+          ref: left,
+          diff: ParsedDiff(files: files, truncated: false, inputBytes: 0),
+        ),
+      },
+    );
+
+    testWidgets('shows the shared list/tree toggle button', (tester) async {
+      await _pump(
+        tester,
+        tab: const CompareTabSpec(id: 'unused', left: left),
+        state: stateWithResult,
+        viewMode: FileListViewMode.list,
+      );
+
+      expect(find.byType(FileListModeToggleButton), findsOneWidget);
+    });
+
+    testWidgets('tree mode renders a FileTreeFolderRow for a multi-file '
+        'folder', (tester) async {
+      await _pump(
+        tester,
+        tab: const CompareTabSpec(id: 'unused', left: left),
+        state: stateWithResult,
+        viewMode: FileListViewMode.tree,
+      );
+
+      expect(find.byType(FileTreeFolderRow), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('a.dart'), findsOneWidget);
+    });
+  });
+}

--- a/app_flutter/test/features/conflict_resolution/conflict_resolve_window_test.dart
+++ b/app_flutter/test/features/conflict_resolution/conflict_resolve_window_test.dart
@@ -20,6 +20,8 @@ import 'package:gbm_flutter/routing/route_paths.dart';
 import 'package:gbm_flutter/theme/gbm_theme.dart';
 import 'package:gbm_flutter/theme/theme_mode_provider.dart';
 import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:gbm_flutter/widgets/file_list_mode_toggle_button.dart';
+import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
 import 'package:gbm_flutter/widgets/split_pane.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -56,6 +58,27 @@ ConflictSegment _regionSegment({
 
 final WorkingCopyEntry _conflictEntry = const WorkingCopyEntry(
   path: 'conflict.txt',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+/// A conflicted entry at an arbitrary [path], for tests that need several
+/// distinct conflicted files (e.g. proving the rail groups them by folder
+/// in tree mode) rather than the single fixed `conflict.txt` [_conflictEntry]
+/// uses.
+WorkingCopyEntry _conflictAt(String path) => WorkingCopyEntry(
+  path: path,
   oldPath: '',
   untracked: false,
   staged: false,
@@ -1131,6 +1154,61 @@ void main() {
       // Test passed if no errors were thrown
       expect(find.text('Select a file'), findsOneWidget);
     });
+
+    testWidgets('shows the shared list/tree mode toggle button', (
+      tester,
+    ) async {
+      final parsed = ParsedConflictFile(
+        segments: <ConflictSegment>[
+          _regionSegment(ours: <String>['ours-line1'], theirs: <String>[]),
+        ],
+        regionCount: 1,
+        wellFormed: true,
+      );
+
+      await _pumpWindow(tester, identity, _sessionWith(_conflictEntry), parsed);
+
+      expect(find.byType(FileListModeToggleButton), findsOneWidget);
+    });
+
+    testWidgets(
+      'tree mode renders the conflicted-file rail via FileTreeFolderRow -- '
+      'spec page 03 item 10: the same List/Tree preference applies to the '
+      "Conflict window's file rail",
+      (tester) async {
+        final parsed = ParsedConflictFile(
+          segments: <ConflictSegment>[
+            _regionSegment(ours: <String>['ours-line1'], theirs: <String>[]),
+          ],
+          regionCount: 1,
+          wellFormed: true,
+        );
+        final RepoSessionState multiFileState = RepoSessionState(
+          isOpen: true,
+          workingCopyStatus: WorkingCopyStatus(
+            entries: <WorkingCopyEntry>[
+              _conflictAt('a.txt'),
+              _conflictAt('b/c.txt'),
+              _conflictAt('b/d.txt'),
+            ],
+          ),
+        );
+
+        await _pumpWindow(
+          tester,
+          identity,
+          multiFileState,
+          parsed,
+          initialPrefs: <String, Object>{'fileListViewMode': 'tree'},
+        );
+
+        // 'b' has two children (c.txt, d.txt) so it does not single-child
+        // collapse -- see file_tree.dart's _collapseIfSingleChild.
+        expect(find.byType(FileTreeFolderRow), findsOneWidget);
+        expect(find.text('b'), findsOneWidget);
+        expect(find.text('a.txt'), findsOneWidget);
+      },
+    );
   });
 }
 
@@ -1168,8 +1246,9 @@ Future<ProviderContainer> _pumpWindow(
   WidgetTester tester,
   RepoIdentity identity,
   RepoSessionState sessionState,
-  ParsedConflictFile parsedFile,
-) async {
+  ParsedConflictFile parsedFile, {
+  Map<String, Object> initialPrefs = const <String, Object>{},
+}) async {
   // The rail (158px) plus three panes (220px min each, splitterCwPanes) need
   // >=830 logical px -- wider than flutter_test's default surface, which
   // would otherwise overflow every Row in the three-column layout.
@@ -1178,7 +1257,7 @@ Future<ProviderContainer> _pumpWindow(
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
 
-  SharedPreferences.setMockInitialValues(<String, Object>{});
+  SharedPreferences.setMockInitialValues(initialPrefs);
   final SharedPreferences prefs = await SharedPreferences.getInstance();
 
   final GoRouter router = GoRouter(

--- a/app_flutter/test/features/dialogs/manage_base_folders/manage_base_folders_dialog_test.dart
+++ b/app_flutter/test/features/dialogs/manage_base_folders/manage_base_folders_dialog_test.dart
@@ -1,0 +1,101 @@
+// Covers the offline marker added alongside preferences_dialog_test.dart's
+// copy of the same behaviour -- see that file's header comment for the
+// broader 0g context. This dialog otherwise only exercises the pre-existing
+// enable/remove wiring, which had no prior test file either.
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/base_folder_record.dart';
+import 'package:gbm_flutter/data/models/repo_record.dart';
+import 'package:gbm_flutter/data/repositories/discovery_repository.dart';
+import 'package:gbm_flutter/features/dialogs/manage_base_folders/manage_base_folders_dialog.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+
+BaseFolderRecord _folder({required int id, required String path}) =>
+    BaseFolderRecord(
+      id: id,
+      path: path,
+      enabled: true,
+      maxDepth: 3,
+      followLinks: false,
+      lastScanStarted: 0,
+      lastScanFinished: 0,
+      lastScanDirs: 0,
+      lastScanMs: 0,
+      lastScanSkipped: 0,
+    );
+
+class _TestDiscoveryController extends StateNotifier<DiscoveryState>
+    implements DiscoveryController {
+  _TestDiscoveryController(List<BaseFolderRecord> folders)
+    : super(DiscoveryState(baseFolders: folders, repos: const <RepoRecord>[]));
+
+  @override
+  void addBaseFolderAndScan(String path) {}
+
+  @override
+  void removeBaseFolder(int baseFolderId) {}
+
+  @override
+  void rescan() {}
+
+  @override
+  void setBaseFolderEnabled(int baseFolderId, bool enabled) {}
+
+  @override
+  void setBaseFolderDepth(int baseFolderId, int maxDepth) {}
+}
+
+Future<void> _pump(WidgetTester tester, List<BaseFolderRecord> folders) async {
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      discoveryProvider.overrideWith(
+        (ref) => _TestDiscoveryController(folders),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        home: const Scaffold(body: ManageBaseFoldersDialogContent()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ManageBaseFoldersDialogContent', () {
+    testWidgets('a base folder that no longer exists on disk shows a warning', (
+      tester,
+    ) async {
+      await _pump(tester, <BaseFolderRecord>[
+        _folder(id: 1, path: '/definitely/does/not/exist/gbm-test-xyz'),
+      ]);
+
+      expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    });
+
+    testWidgets('a base folder that exists on disk shows no warning', (
+      tester,
+    ) async {
+      final Directory realDir = Directory.systemTemp.createTempSync(
+        'gbm-manage-folders-test-',
+      );
+      addTearDown(() => realDir.deleteSync(recursive: true));
+
+      await _pump(tester, <BaseFolderRecord>[
+        _folder(id: 1, path: realDir.path),
+      ]);
+
+      expect(find.byIcon(Icons.warning_amber_rounded), findsNothing);
+    });
+  });
+}

--- a/app_flutter/test/features/dialogs/preferences/preferences_dialog_test.dart
+++ b/app_flutter/test/features/dialogs/preferences/preferences_dialog_test.dart
@@ -1,0 +1,258 @@
+// Regression coverage for the five Preferences fields that had data flowing
+// through them already but no UI entry point -- see CLAUDE.md's 0g spec
+// conformance note. Two (per-folder depth edit, scan summary's skipped
+// count) needed a capi wrapper first (gbm_discovery_set_base_folder_depth,
+// RepoIndexDb::finishScan's new dirsSkipped param); the other three
+// (offline marker, manual-open per-entry delete, gitignore import-source
+// label) are Flutter-only.
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/base_folder_record.dart';
+import 'package:gbm_flutter/data/models/repo_record.dart';
+import 'package:gbm_flutter/data/repositories/discovery_repository.dart';
+import 'package:gbm_flutter/features/dialogs/preferences/preferences_dialog.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+BaseFolderRecord _folder({
+  int id = 1,
+  required String path,
+  int maxDepth = 3,
+  int lastScanSkipped = 0,
+}) => BaseFolderRecord(
+  id: id,
+  path: path,
+  enabled: true,
+  maxDepth: maxDepth,
+  followLinks: false,
+  lastScanStarted: 0,
+  lastScanFinished: 0,
+  lastScanDirs: 0,
+  lastScanMs: 0,
+  lastScanSkipped: lastScanSkipped,
+);
+
+/// Records every call instead of no-op'ing like the read-only fakes in
+/// repo_switcher_popover_test.dart/welcome_screen_test.dart -- this dialog's
+/// whole point is dispatching these calls, so the test needs to see them.
+class _RecordingDiscoveryController extends StateNotifier<DiscoveryState>
+    implements DiscoveryController {
+  _RecordingDiscoveryController(List<BaseFolderRecord> folders)
+    : super(DiscoveryState(baseFolders: folders, repos: const <RepoRecord>[]));
+
+  final List<(int, int)> depthCalls = <(int, int)>[];
+
+  @override
+  void addBaseFolderAndScan(String path) {}
+
+  @override
+  void removeBaseFolder(int baseFolderId) {}
+
+  @override
+  void rescan() {}
+
+  @override
+  void setBaseFolderEnabled(int baseFolderId, bool enabled) {}
+
+  @override
+  void setBaseFolderDepth(int baseFolderId, int maxDepth) {
+    depthCalls.add((baseFolderId, maxDepth));
+  }
+}
+
+Future<({ProviderContainer container, _RecordingDiscoveryController discovery})>
+_pump(
+  WidgetTester tester, {
+  List<BaseFolderRecord> folders = const <BaseFolderRecord>[],
+  Map<String, Object> initialPrefs = const <String, Object>{},
+}) async {
+  SharedPreferences.setMockInitialValues(initialPrefs);
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  final _RecordingDiscoveryController discovery = _RecordingDiscoveryController(
+    folders,
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      discoveryProvider.overrideWith((ref) => discovery),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        home: const Scaffold(body: PreferencesDialogContent()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  // Repository sources is the section every new field in this round lives
+  // under (except the gitignore label, which switches section itself).
+  await tester.tap(find.text('Repository sources'));
+  await tester.pumpAndSettle();
+
+  return (container: container, discovery: discovery);
+}
+
+void main() {
+  group('PreferencesDialogContent - Repository sources', () {
+    testWidgets(
+      'editing the depth field and submitting calls setBaseFolderDepth',
+      (tester) async {
+        final result = await _pump(
+          tester,
+          folders: <BaseFolderRecord>[
+            _folder(id: 7, path: '/code', maxDepth: 3),
+          ],
+        );
+
+        // The depth field is the first TextField in this section -- the
+        // folder row renders above the "Add folder…" path field below it.
+        await tester.enterText(find.byType(TextField).first, '5');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        expect(result.discovery.depthCalls, contains((7, 5)));
+      },
+    );
+
+    testWidgets(
+      'scan summary reports the skipped-past-depth-limit count when nonzero',
+      (tester) async {
+        await _pump(
+          tester,
+          folders: <BaseFolderRecord>[
+            _folder(id: 1, path: '/code', lastScanSkipped: 4),
+          ],
+        );
+
+        expect(find.textContaining('4 skipped (depth limit)'), findsOneWidget);
+      },
+    );
+
+    testWidgets('scan summary omits the skipped count when it is zero', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        folders: <BaseFolderRecord>[
+          _folder(id: 1, path: '/code', lastScanSkipped: 0),
+        ],
+      );
+
+      expect(find.textContaining('skipped'), findsNothing);
+    });
+
+    testWidgets('a base folder that no longer exists on disk shows a warning', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        folders: <BaseFolderRecord>[
+          _folder(id: 1, path: '/definitely/does/not/exist/gbm-test-xyz'),
+        ],
+      );
+
+      expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    });
+
+    testWidgets('a base folder that exists on disk shows no warning', (
+      tester,
+    ) async {
+      final Directory realDir = Directory.systemTemp.createTempSync(
+        'gbm-prefs-test-',
+      );
+      addTearDown(() => realDir.deleteSync(recursive: true));
+
+      await _pump(
+        tester,
+        folders: <BaseFolderRecord>[_folder(id: 1, path: realDir.path)],
+      );
+
+      expect(find.byIcon(Icons.warning_amber_rounded), findsNothing);
+    });
+
+    testWidgets('removing one manually-opened entry only forgets that entry', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        initialPrefs: <String, Object>{
+          'recents.repos':
+              '[{"workDir":"/a","lastOpenedEpochMs":2},'
+              '{"workDir":"/b","lastOpenedEpochMs":1}]',
+        },
+      );
+
+      expect(find.text('/a'), findsOneWidget);
+      expect(find.text('/b'), findsOneWidget);
+
+      // Keyed by workDir rather than found by icon or tooltip:
+      // GbmDialogShell's own header close button uses the same Icons.close
+      // (would ambiguously match), and there are two "Remove from list"
+      // rows once /a and /b both render (order not worth depending on).
+      // ensureVisible: "Manually opened" sits below the fold of the
+      // dialog's fixed-height SingleChildScrollView, so a bare tap()
+      // computes an offset outside the scrolled viewport and silently
+      // hits whatever else happens to occupy that screen position.
+      final Finder removeA = find.byKey(
+        const ValueKey<String>('recent-entry-remove-/a'),
+      );
+      await tester.ensureVisible(removeA);
+      await tester.pumpAndSettle();
+      await tester.tap(removeA);
+      await tester.pumpAndSettle();
+
+      expect(find.text('/a'), findsNothing);
+      expect(
+        find.text('/b'),
+        findsOneWidget,
+        reason: 'removing one recorded entry must not clear the others',
+      );
+    });
+  });
+
+  group('PreferencesDialogContent - Git', () {
+    testWidgets(
+      'shows the imported-from-.gitconfig label when the source is imported',
+      (tester) async {
+        await _pump(
+          tester,
+          initialPrefs: <String, Object>{
+            'appPrefs.globalGitignoreEnabled': true,
+            'appPrefs.globalGitignoreSource': 'imported',
+          },
+        );
+
+        await tester.tap(find.text('Git'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Imported from .gitconfig'), findsOneWidget);
+      },
+    );
+
+    testWidgets('shows no source label when nothing has been imported', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        initialPrefs: <String, Object>{'appPrefs.globalGitignoreEnabled': true},
+      );
+
+      await tester.tap(find.text('Git'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Imported from .gitconfig'), findsNothing);
+    });
+  });
+}

--- a/app_flutter/test/features/history_graph/commit_row_test.dart
+++ b/app_flutter/test/features/history_graph/commit_row_test.dart
@@ -9,7 +9,9 @@ import 'package:gbm_flutter/data/models/graph_snapshot.dart';
 import 'package:gbm_flutter/data/models/ref_snapshot.dart';
 import 'package:gbm_flutter/data/models/signature.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/graph_ref_chips.dart';
 import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:gbm_flutter/widgets/gbm_tag_chip.dart';
 
 import '../../support/pump_app.dart';
 
@@ -184,35 +186,13 @@ void main() {
             rowIndex: 0,
             maxLane: 0,
             meta: _meta(),
-            refChips: <RefInfo>[
-              RefInfo(
-                fullName: 'refs/heads/main',
-                shortName: 'main',
+            refChips: const <RefChipData>[
+              RefChipData(
+                label: 'main',
                 kind: RefKind.localBranch,
-                target: 'a' * 40,
-                upstream: '',
-                ahead: 0,
-                behind: 0,
-                hasTrackingInfo: false,
-                isGone: false,
-                isHead: true,
-                isSymbolic: false,
-                worktreePath: '',
+                isCurrent: true,
               ),
-              RefInfo(
-                fullName: 'refs/tags/v1.0',
-                shortName: 'v1.0',
-                kind: RefKind.tag,
-                target: 'a' * 40,
-                upstream: '',
-                ahead: 0,
-                behind: 0,
-                hasTrackingInfo: false,
-                isGone: false,
-                isHead: false,
-                isSymbolic: false,
-                worktreePath: '',
-              ),
+              RefChipData(label: 'v1.0', kind: RefKind.tag),
             ],
           ),
         );
@@ -220,6 +200,55 @@ void main() {
         expect(find.text('main'), findsOneWidget);
         expect(find.text('v1.0'), findsOneWidget);
       });
+
+      testWidgets(
+        'forwards showCloudIcon/isDashed from RefChipData straight through '
+        'to GbmTagChip (graph_ref_chips_test.dart covers the merge/'
+        'divergence logic itself; this locks in the render-time wiring)',
+        (tester) async {
+          await pumpGbmWidget(
+            tester,
+            variant: variant,
+            child: CommitRow(
+              row: _row,
+              oidHex: 'a' * 40,
+              graph: GraphSnapshotView.empty,
+              rowIndex: 0,
+              maxLane: 0,
+              meta: _meta(),
+              refChips: const <RefChipData>[
+                RefChipData(
+                  label: 'main',
+                  kind: RefKind.localBranch,
+                  showCloudIcon: true,
+                ),
+                RefChipData(
+                  label: 'origin/main',
+                  kind: RefKind.remoteBranch,
+                  isDashed: true,
+                ),
+              ],
+            ),
+          );
+
+          final List<GbmTagChip> chips = tester
+              .widgetList<GbmTagChip>(find.byType(GbmTagChip))
+              .toList();
+          expect(chips, hasLength(2));
+
+          final GbmTagChip mainChip = chips.firstWhere(
+            (c) => c.label == 'main',
+          );
+          expect(mainChip.showCloudIcon, isTrue);
+          expect(mainChip.isDashed, isFalse);
+
+          final GbmTagChip originChip = chips.firstWhere(
+            (c) => c.label == 'origin/main',
+          );
+          expect(originChip.isDashed, isTrue);
+          expect(originChip.showCloudIcon, isFalse);
+        },
+      );
 
       testWidgets('renders no chips when nothing points to this commit', (
         tester,

--- a/app_flutter/test/features/history_graph/widgets/changed_files_panel_test.dart
+++ b/app_flutter/test/features/history_graph/widgets/changed_files_panel_test.dart
@@ -2,7 +2,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/data/models/changed_file.dart';
 import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/file_list_view_mode_repository.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/changed_files_panel.dart';
+import 'package:gbm_flutter/widgets/file_list_mode_toggle_button.dart';
+import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
 
 import '../../../support/pump_app.dart';
 
@@ -174,4 +177,47 @@ void main() {
     expect(find.text('File history'), findsNothing);
     expect(find.text('Blame at this commit'), findsNothing);
   });
+
+  testWidgets('shows the shared list/tree mode toggle button', (tester) async {
+    await pumpGbmWidget(
+      tester,
+      child: ChangedFilesPanelCore(
+        hasSelectedCommit: true,
+        files: <ChangedFile>[_file('a.dart')],
+        selectedPath: null,
+        onFileTap: (_) {},
+      ),
+    );
+
+    expect(find.byType(FileListModeToggleButton), findsOneWidget);
+  });
+
+  testWidgets(
+    'renders folders via FileTreeFolderRow when viewMode is tree -- spec '
+    'page 03 item 10: the same List/Tree preference applies to History\'s '
+    'Changed files panel',
+    (tester) async {
+      await pumpGbmWidget(
+        tester,
+        child: ChangedFilesPanelCore(
+          hasSelectedCommit: true,
+          files: <ChangedFile>[
+            _file('a.dart'),
+            _file('b/c.dart'),
+            _file('b/d.dart'),
+          ],
+          selectedPath: null,
+          onFileTap: (_) {},
+          viewMode: FileListViewMode.tree,
+        ),
+      );
+
+      // 'b' has two children (c.dart, d.dart) so it does not single-child
+      // collapse -- unlike a lone-file folder, which FileTree.fromPaths
+      // flattens away entirely (see file_tree.dart's _collapseIfSingleChild).
+      expect(find.byType(FileTreeFolderRow), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('a.dart'), findsOneWidget);
+    },
+  );
 }

--- a/app_flutter/test/features/history_graph/widgets/graph_ref_chips_test.dart
+++ b/app_flutter/test/features/history_graph/widgets/graph_ref_chips_test.dart
@@ -2,11 +2,33 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/data/models/ref_snapshot.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/graph_ref_chips.dart';
 
-RefInfo _ref(String name, String target, {RefKind kind = RefKind.localBranch}) {
+RefInfo _local(
+  String name,
+  String target, {
+  String upstream = '',
+  bool isHead = false,
+}) {
   return RefInfo(
     fullName: 'refs/heads/$name',
     shortName: name,
-    kind: kind,
+    kind: RefKind.localBranch,
+    target: target,
+    upstream: upstream,
+    ahead: 0,
+    behind: 0,
+    hasTrackingInfo: upstream.isNotEmpty,
+    isGone: false,
+    isHead: isHead,
+    isSymbolic: false,
+    worktreePath: '',
+  );
+}
+
+RefInfo _remote(String remoteQualifiedName, String target) {
+  return RefInfo(
+    fullName: 'refs/remotes/$remoteQualifiedName',
+    shortName: remoteQualifiedName,
+    kind: RefKind.remoteBranch,
     target: target,
     upstream: '',
     ahead: 0,
@@ -19,6 +41,30 @@ RefInfo _ref(String name, String target, {RefKind kind = RefKind.localBranch}) {
   );
 }
 
+RefInfo _tag(String name, String target) {
+  return RefInfo(
+    fullName: 'refs/tags/$name',
+    shortName: name,
+    kind: RefKind.tag,
+    target: target,
+    upstream: '',
+    ahead: 0,
+    behind: 0,
+    hasTrackingInfo: false,
+    isGone: false,
+    isHead: false,
+    isSymbolic: false,
+    worktreePath: '',
+  );
+}
+
+RefSnapshot _snapshot(List<RefInfo> refs) => RefSnapshot(
+  head: RefSnapshot.empty.head,
+  refs: refs,
+  refCountGuardTripped: false,
+  totalRefCount: refs.length,
+);
+
 void main() {
   group('refChipsForCommit', () {
     test('returns an empty list when no ref points to the commit', () {
@@ -28,39 +74,102 @@ void main() {
     });
 
     test('returns the single ref pointing to the commit', () {
-      final RefInfo main = _ref('main', 'abc123');
-      final refs = RefSnapshot(
-        head: RefSnapshot.empty.head,
-        refs: <RefInfo>[main],
-        refCountGuardTripped: false,
-        totalRefCount: 1,
-      );
+      final refs = _snapshot(<RefInfo>[_local('main', 'abc123')]);
 
       final result = refChipsForCommit(refs, 'abc123');
 
       expect(result, hasLength(1));
-      expect(result.single.shortName, 'main');
+      expect(result.single.label, 'main');
+      expect(result.single.showCloudIcon, isFalse);
+      expect(result.single.isDashed, isFalse);
     });
 
-    test('returns every ref pointing to the same commit', () {
-      final RefInfo main = _ref('main', 'abc123');
-      final RefInfo tag = _ref('v1.0', 'abc123', kind: RefKind.tag);
-      final RefInfo other = _ref('other', 'def456');
-      final refs = RefSnapshot(
-        head: RefSnapshot.empty.head,
-        refs: <RefInfo>[main, tag, other],
-        refCountGuardTripped: false,
-        totalRefCount: 3,
-      );
+    test('returns every unrelated ref pointing to the same commit as-is', () {
+      final refs = _snapshot(<RefInfo>[
+        _local('main', 'abc123'),
+        _tag('v1.0', 'abc123'),
+        _local('other', 'def456'),
+      ]);
 
       final result = refChipsForCommit(refs, 'abc123');
 
       expect(result, hasLength(2));
-      expect(
-        result.map((r) => r.shortName),
-        containsAll(<String>['main', 'v1.0']),
-      );
-      expect(result.map((r) => r.shortName), isNot(contains('other')));
+      expect(result.map((c) => c.label), containsAll(<String>['main', 'v1.0']));
+      expect(result.map((c) => c.label), isNot(contains('other')));
+    });
+
+    test('a local branch synced with its upstream merges into one chip with '
+        'a cloud icon, suppressing the separate remote chip -- spec page 02: '
+        '"local 與 origin 在同一個 commit 時只出一個 chip"', () {
+      final refs = _snapshot(<RefInfo>[
+        _local('main', 'abc123', upstream: 'refs/remotes/origin/main'),
+        _remote('origin/main', 'abc123'),
+      ]);
+
+      final result = refChipsForCommit(refs, 'abc123');
+
+      expect(result, hasLength(1));
+      expect(result.single.label, 'main');
+      expect(result.single.kind, RefKind.localBranch);
+      expect(result.single.showCloudIcon, isTrue);
+      expect(result.single.isDashed, isFalse);
+    });
+
+    test('a diverged upstream keeps its own dashed chip on the commit it '
+        'actually points at, and the local branch chip on its own row shows '
+        'no cloud icon -- spec page 02: "虛線外框＝只有在分歧時才會出現"', () {
+      final refs = _snapshot(<RefInfo>[
+        _local('main', 'abc123', upstream: 'refs/remotes/origin/main'),
+        _remote('origin/main', 'def456'), // diverged: different commit
+      ]);
+
+      final localRow = refChipsForCommit(refs, 'abc123');
+      expect(localRow, hasLength(1));
+      expect(localRow.single.label, 'main');
+      expect(localRow.single.showCloudIcon, isFalse);
+      expect(localRow.single.isDashed, isFalse);
+
+      final remoteRow = refChipsForCommit(refs, 'def456');
+      expect(remoteRow, hasLength(1));
+      expect(remoteRow.single.label, 'origin/main');
+      expect(remoteRow.single.kind, RefKind.remoteBranch);
+      expect(remoteRow.single.isDashed, isTrue);
+      expect(remoteRow.single.showCloudIcon, isFalse);
+    });
+
+    test(
+      'a remote branch with no local branch tracking it (remote-only) '
+      'renders as a plain chip, neither cloud nor dashed -- that is the '
+      "sidebar's distinct \"Remote only\" state, not this divergence rule",
+      () {
+        final refs = _snapshot(<RefInfo>[_remote('origin/feature', 'abc123')]);
+
+        final result = refChipsForCommit(refs, 'abc123');
+
+        expect(result, hasLength(1));
+        expect(result.single.label, 'origin/feature');
+        expect(result.single.isDashed, isFalse);
+        expect(result.single.showCloudIcon, isFalse);
+      },
+    );
+
+    test('a local-only branch (no upstream) renders as a plain chip', () {
+      final refs = _snapshot(<RefInfo>[_local('scratch', 'abc123')]);
+
+      final result = refChipsForCommit(refs, 'abc123');
+
+      expect(result, hasLength(1));
+      expect(result.single.label, 'scratch');
+      expect(result.single.showCloudIcon, isFalse);
+      expect(result.single.isDashed, isFalse);
+    });
+
+    test('isCurrent carries through from RefInfo.isHead', () {
+      final refs = _snapshot(<RefInfo>[_local('main', 'abc123', isHead: true)]);
+
+      final result = refChipsForCommit(refs, 'abc123');
+
+      expect(result.single.isCurrent, isTrue);
     });
   });
 }

--- a/app_flutter/test/features/repo_switcher/repo_switcher_popover_test.dart
+++ b/app_flutter/test/features/repo_switcher/repo_switcher_popover_test.dart
@@ -483,4 +483,7 @@ class _TestDiscoveryController extends StateNotifier<DiscoveryState>
 
   @override
   void setBaseFolderEnabled(int baseFolderId, bool enabled) {}
+
+  @override
+  void setBaseFolderDepth(int baseFolderId, int maxDepth) {}
 }

--- a/app_flutter/test/features/status_bar/status_bar_test.dart
+++ b/app_flutter/test/features/status_bar/status_bar_test.dart
@@ -178,6 +178,79 @@ void main() {
       expect(find.text('+2 more'), findsOneWidget);
     });
 
+    testWidgets('tapping "+N more" expands the folded tasks (spec page 10 '
+        'STATUSPARTS #2: "其餘作業摺疊成 +N task，點了展開清單")', (tester) async {
+      final tasks = [
+        BackgroundTask.fetch(
+          id: 'fetch-1',
+          label: 'Fetching',
+          current: 50,
+          total: 100,
+        ),
+        BackgroundTask.push(
+          id: 'push-1',
+          label: 'Pushing',
+          current: 0,
+          total: 1,
+        ),
+        BackgroundTask.checkout(
+          id: 'checkout-1',
+          label: 'Checking out',
+          current: 0,
+          total: 1,
+        ),
+      ];
+      String? cancelledId;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+          home: Scaffold(
+            body: StatusBar(
+              currentBranch: 'main',
+              ahead: 0,
+              behind: 0,
+              commitCount: 10,
+              lastScanDuration: const Duration(milliseconds: 100),
+              graphLaneCapacity: 6,
+              backgroundTasks: tasks,
+              hasUnreadLog: false,
+              onOpenLog: () {},
+              onCancelTask: (id) => cancelledId = id,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Before expanding: only the foreground task's label is visible,
+      // the two folded ones are not.
+      expect(find.text('Fetching'), findsOneWidget);
+      expect(find.text('Pushing'), findsNothing);
+      expect(find.text('Checking out'), findsNothing);
+
+      await tester.tap(find.text('+2 more'));
+      await tester.pumpAndSettle();
+
+      // After expanding: both folded tasks' labels are now visible.
+      expect(find.text('Pushing'), findsOneWidget);
+      expect(find.text('Checking out'), findsOneWidget);
+
+      // A cancellable folded task (push) has a live Cancel button that
+      // reaches the same onCancelTask callback the foreground task uses.
+      final Finder cancelButtons = find.widgetWithText(TextButton, 'Cancel');
+      expect(cancelButtons, findsNWidgets(2));
+      await tester.tap(cancelButtons.first);
+      expect(cancelledId, 'push-1');
+
+      // A non-cancellable folded task (checkout) has its Cancel button
+      // disabled, same rule as the foreground task's own Cancel button.
+      final TextButton checkoutCancel = tester.widget<TextButton>(
+        cancelButtons.last,
+      );
+      expect(checkoutCancel.onPressed, isNull);
+    });
+
     testWidgets('non-cancellable task Cancel button is disabled', (
       tester,
     ) async {

--- a/app_flutter/test/features/welcome/welcome_screen_test.dart
+++ b/app_flutter/test/features/welcome/welcome_screen_test.dart
@@ -145,4 +145,7 @@ class _TestDiscoveryController extends StateNotifier<DiscoveryState>
 
   @override
   void setBaseFolderEnabled(int baseFolderId, bool enabled) {}
+
+  @override
+  void setBaseFolderDepth(int baseFolderId, int maxDepth) {}
 }

--- a/app_flutter/test/integration/workspace_file_list_view_mode_test.dart
+++ b/app_flutter/test/integration/workspace_file_list_view_mode_test.dart
@@ -1,0 +1,126 @@
+// Integration coverage for spec page 03 item 10: "同一個設定套用到 Working
+// Copy 兩欄、History 的 Changed files、Compare 的 Files、以及 Conflict 視窗
+//的檔案清單" -- the List/Tree display mode is ONE shared preference
+// (fileListViewModeProvider), not four independent per-view toggles.
+// Widget-tier tests (changed_files_panel_test.dart, working_copy_board's own
+// tests, compare_page_test.dart, conflict_resolve_window_test.dart) each
+// prove their own view reads the provider correctly in isolation, but none
+// of them can prove the "same setting carries across a real navigation"
+// half of the claim -- that needs the actual WorkspaceScreen + GoRouter
+// stack, which is what this file adds.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/changed_file.dart';
+import 'package:gbm_flutter/data/models/commit_meta.dart';
+import 'package:gbm_flutter/data/models/signature.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/file_list_view_mode_repository.dart';
+import 'package:gbm_flutter/data/repositories/history_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/history_graph/history_page.dart';
+import 'package:gbm_flutter/features/working_copy/working_copy_view.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
+
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/view-mode-repo',
+  gitDir: '/test/view-mode-repo/.git',
+);
+
+ChangedFile _file(String path) => ChangedFile(
+  path: path,
+  oldPath: path,
+  kind: FileChangeKind.modified,
+  oldMode: '100644',
+  newMode: '100644',
+  oldBlob: 'aaa',
+  newBlob: 'bbb',
+  similarity: 0,
+);
+
+void main() {
+  testWidgets(
+    'setting Tree mode while on Working Copy carries over to History after '
+    'navigating away and back -- the same fileListViewModeProvider, not a '
+    'per-view copy',
+    (tester) async {
+      const Signature signature = Signature(
+        name: 'Test Author',
+        email: 'author@example.com',
+        when: 0,
+        tzOffsetMinutes: 0,
+      );
+      final RepoSessionState state = RepoSessionState(
+        isOpen: true,
+        commitFiles: <ChangedFile>[
+          _file('a.dart'),
+          _file('b/c.dart'),
+          _file('b/d.dart'),
+        ],
+        // Seeded so CommitDetailPanel resolves 'abc123' immediately instead
+        // of showing an indeterminate CircularProgressIndicator -- which,
+        // left spinning, would make pumpWorkspace's own pumpAndSettle()
+        // time out before this test ever gets to its own assertions.
+        commitMetaCache: const <String, CommitMeta>{
+          'abc123': CommitMeta(
+            oid: 'abc123',
+            tree: 'tree123',
+            parents: <String>[],
+            author: signature,
+            committer: signature,
+            subject: 'Test commit',
+            body: '',
+            signedCommit: false,
+          ),
+        },
+      );
+
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: state,
+        overrides: <Override>[
+          selectedCommitProvider(_identity).overrideWith((ref) => 'abc123'),
+        ],
+        workingCopyBuilder: (context, state) =>
+            WorkingCopyView(identity: _identity),
+        historyBuilder: (context, state) => HistoryPage(identity: _identity),
+      );
+      final String repoId = Uri.encodeComponent(_identity.workDir);
+
+      // Start on Working Copy (list mode, the default) -- nothing to
+      // assert yet beyond "it mounts", this just establishes the starting
+      // point of the round trip.
+      pumped.router.go(RoutePaths.workingCopyFor(repoId));
+      await tester.pumpAndSettle();
+      expect(find.byType(WorkingCopyView), findsOneWidget);
+
+      // Flip the shared preference while still on Working Copy -- this is
+      // what tapping any of the FileListModeToggleButton instances wired
+      // into History/Compare/Conflict does under the hood; driving the
+      // provider directly here is equivalent and avoids depending on
+      // WorkingCopyBoard's own internal toggle affordance (or lack of one)
+      // for a test that is really about propagation, not that button.
+      await pumped.container
+          .read(fileListViewModeProvider.notifier)
+          .setMode(FileListViewMode.tree);
+      await tester.pumpAndSettle();
+
+      // Navigate to History -- a fresh route, not just a rebuild of the
+      // same widget -- and confirm its Changed files panel already renders
+      // in tree mode with no further action needed.
+      pumped.router.go(RoutePaths.historyFor(repoId));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HistoryPage), findsOneWidget);
+      // 'b' has two children (c.dart, d.dart) so it does not single-child
+      // collapse -- see file_tree.dart's _collapseIfSingleChild.
+      expect(find.byType(FileTreeFolderRow), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('a.dart'), findsOneWidget);
+    },
+  );
+}

--- a/app_flutter/test/integration/workspace_states_table_test.dart
+++ b/app_flutter/test/integration/workspace_states_table_test.dart
@@ -152,10 +152,14 @@ Future<PumpedWorkspace> _pumpAtWorkingCopy(
 /// [WorkingCopyView.initState] seeds its summary `TextEditingController`
 /// from `ref.read(workingCopyDraftProvider(identity))` once, at mount time
 /// -- pre-populating the draft via provider override tests the "Commit"
-/// STATES row's actual gate logic (`canCommit`) directly, without depending
-/// on whether a later `tester.enterText` reliably triggers a rebuild of
-/// `WorkingCopyView` itself (see this file's own note below on why it does
-/// not, discovered while writing this test).
+/// STATES row's actual gate logic (`canCommit`) directly, independent of
+/// whether typing into the field triggers a rebuild. That rebuild-trigger
+/// path is its own concern, now covered separately by the `tester.enterText`
+/// test below (code-review-2026-08.md H2, fixed by `_onSummaryChanged`'s
+/// listener on `_summaryController` in `working_copy_view.dart`) -- kept as
+/// two distinct tests rather than one, since a provider-seeded mount can't
+/// tell "gate logic is right" apart from "typing rebuilds it", and a
+/// regression in either should fail independently of the other.
 Override _draftWithSummary(String summary) {
   return workingCopyDraftProvider(
     _identity,
@@ -237,6 +241,45 @@ void main() {
         expect(amendButton.onPressed, isNull);
       },
     );
+
+    testWidgets('clean: typing into the summary field alone (no other rebuild '
+        'trigger) enables Commit -- regression lock for H2 '
+        '(code-review-2026-08.md): _summaryController previously had no '
+        'listener wired to WorkingCopyView\'s own setState, so canCommit '
+        'only recomputed on some unrelated rebuild (e.g. staging a file), '
+        'not on the summary text itself changing', (tester) async {
+      // A staged file is already present via _cleanSession(); no summary
+      // yet, so Commit must start disabled.
+      await _pumpAtWorkingCopy(tester, _cleanSession());
+
+      GbmButton commitButton = tester.widget<GbmButton>(
+        find.widgetWithText(GbmButton, 'Commit'),
+      );
+      expect(
+        commitButton.onPressed,
+        isNull,
+        reason: 'no summary yet -- Commit should start disabled',
+      );
+
+      final Finder summaryField = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is TextField &&
+            widget.decoration?.hintText == 'Commit summary',
+      );
+      await tester.enterText(summaryField, 'A real summary');
+      await tester.pump();
+
+      commitButton = tester.widget<GbmButton>(
+        find.widgetWithText(GbmButton, 'Commit'),
+      );
+      expect(
+        commitButton.onPressed,
+        isNotNull,
+        reason:
+            'typing alone must trigger a rebuild that re-evaluates '
+            'canCommit -- no staging/other action happened in between',
+      );
+    });
   });
 
   group('spec page 07 STATES table -- "Status bar" row', () {

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -50,7 +50,13 @@ class FakeRepoSessionController extends RepoSessionController {
     RepoIdentity identity,
     RepoSessionState initialState, {
     ParsedConflictFile? parsedFile,
-  }) : super(FakeGbmBindings(), identity, FakeRecentsRepository()) {
+    int maxOperationLogEntries = 2000,
+  }) : super(
+         FakeGbmBindings(),
+         identity,
+         FakeRecentsRepository(),
+         maxOperationLogEntries: maxOperationLogEntries,
+       ) {
     _parsedFile = parsedFile;
     state = initialState;
   }

--- a/app_flutter/test/support/pump_workspace.dart
+++ b/app_flutter/test/support/pump_workspace.dart
@@ -84,6 +84,13 @@ Future<PumpedWorkspace> pumpWorkspace(
   /// already registered below, and go_router rejects a second [GoRoute] at
   /// the same path. This swaps that one route's builder in place instead.
   Widget Function(BuildContext, GoRouterState)? workingCopyBuilder,
+
+  /// Same as [workingCopyBuilder], for the History ShellRoute child --
+  /// swaps in the real [HistoryPage] for a test that needs to navigate to
+  /// it and assert on its actual rendered content (e.g. that the shared
+  /// [fileListViewModeProvider] carries over across a History<->Working-Copy
+  /// round trip), rather than the bare empty [Scaffold] most tests get.
+  Widget Function(BuildContext, GoRouterState)? historyBuilder,
   ui.Size surfaceSize = const ui.Size(1400, 900),
 }) async {
   tester.view.physicalSize = surfaceSize;
@@ -118,7 +125,9 @@ Future<PumpedWorkspace> pumpWorkspace(
         routes: <RouteBase>[
           GoRoute(
             path: RoutePaths.history,
-            builder: (context, state) => const Scaffold(body: SizedBox()),
+            builder:
+                historyBuilder ??
+                (context, state) => const Scaffold(body: SizedBox()),
           ),
           GoRoute(
             path: RoutePaths.workingCopy,

--- a/app_flutter/test/widgets/file_list_mode_switcher_test.dart
+++ b/app_flutter/test/widgets/file_list_mode_switcher_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/repositories/file_list_view_mode_repository.dart';
+import 'package:gbm_flutter/widgets/file_list_mode_switcher.dart';
+import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
+
+import '../support/pump_app.dart';
+
+void main() {
+  group('FileListModeSwitcher', () {
+    testWidgets('list mode renders every item via leafBuilder in a flat '
+        'list', (tester) async {
+      await pumpGbmWidget(
+        tester,
+        child: FileListModeSwitcher<String>(
+          mode: FileListViewMode.list,
+          items: const <String>['a.dart', 'b/c.dart', 'b/d.dart'],
+          pathOf: (String s) => s,
+          leafBuilder: (BuildContext context, String s) => Text(s),
+        ),
+      );
+
+      expect(find.byType(ListView), findsOneWidget);
+      expect(find.text('a.dart'), findsOneWidget);
+      expect(find.text('b/c.dart'), findsOneWidget);
+      expect(find.text('b/d.dart'), findsOneWidget);
+      // Flat list mode never groups by folder.
+      expect(find.byType(FileTreeFolderRow), findsNothing);
+    });
+
+    testWidgets('tree mode groups a multi-file folder under a '
+        'FileTreeFolderRow', (tester) async {
+      await pumpGbmWidget(
+        tester,
+        child: FileListModeSwitcher<String>(
+          mode: FileListViewMode.tree,
+          items: const <String>['a.dart', 'b/c.dart', 'b/d.dart'],
+          pathOf: (String s) => s,
+          leafBuilder: (BuildContext context, String s) => Text(s),
+        ),
+      );
+
+      expect(find.byType(FileTreeFolderRow), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('a.dart'), findsOneWidget);
+      // 'b's children are collapsed until the folder row is expanded.
+      expect(find.text('b/c.dart'), findsNothing);
+    });
+
+    testWidgets('tree mode expands a folder on tap to reveal its children', (
+      tester,
+    ) async {
+      await pumpGbmWidget(
+        tester,
+        child: FileListModeSwitcher<String>(
+          mode: FileListViewMode.tree,
+          items: const <String>['b/c.dart', 'b/d.dart'],
+          pathOf: (String s) => s,
+          leafBuilder: (BuildContext context, String s) => Text(s),
+        ),
+      );
+
+      // leafBuilder renders the original item string, so a leaf under 'b'
+      // still shows its full path ('b/c.dart'), not just the trailing
+      // segment -- only FileTreeFolderRow (used for directory nodes)
+      // renders a bare display name.
+      expect(find.text('b/c.dart'), findsNothing);
+
+      await tester.tap(find.byType(FileTreeFolderRow));
+      await tester.pump();
+
+      expect(find.text('b/c.dart'), findsOneWidget);
+      expect(find.text('b/d.dart'), findsOneWidget);
+    });
+
+    testWidgets('renders emptyBuilder when items is empty', (tester) async {
+      await pumpGbmWidget(
+        tester,
+        child: FileListModeSwitcher<String>(
+          mode: FileListViewMode.list,
+          items: const <String>[],
+          pathOf: (String s) => s,
+          leafBuilder: (BuildContext context, String s) => Text(s),
+          emptyBuilder: (BuildContext context) => const Text('Nothing here'),
+        ),
+      );
+
+      expect(find.text('Nothing here'), findsOneWidget);
+    });
+
+    testWidgets('renders a zero-size box when items is empty and no '
+        'emptyBuilder is given', (tester) async {
+      await pumpGbmWidget(
+        tester,
+        child: FileListModeSwitcher<String>(
+          mode: FileListViewMode.list,
+          items: const <String>[],
+          pathOf: (String s) => s,
+          leafBuilder: (BuildContext context, String s) => Text(s),
+        ),
+      );
+
+      expect(find.byType(SizedBox), findsOneWidget);
+      expect(find.byType(ListView), findsNothing);
+    });
+  });
+}

--- a/app_flutter/test/widgets/file_tree_folder_row_test.dart
+++ b/app_flutter/test/widgets/file_tree_folder_row_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/file_tree.dart';
+import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
+
+import '../support/pump_app.dart';
+
+void main() {
+  group('FileTreeFolderRow', () {
+    const FileTreeNode node = FileTreeNode(
+      name: 'src',
+      displayPath: 'src',
+      isDirectory: true,
+    );
+
+    testWidgets('shows the folder name', (tester) async {
+      await pumpGbmWidget(tester, child: const FileTreeFolderRow(node: node));
+
+      expect(find.text('src'), findsOneWidget);
+    });
+
+    testWidgets('tapping invokes onToggle', (tester) async {
+      int tapCount = 0;
+      await pumpGbmWidget(
+        tester,
+        child: FileTreeFolderRow(node: node, onToggle: () => tapCount++),
+      );
+
+      await tester.tap(find.byType(FileTreeFolderRow));
+      await tester.pump();
+
+      expect(tapCount, 1);
+    });
+
+    testWidgets('renders without error when onToggle is null', (tester) async {
+      await pumpGbmWidget(tester, child: const FileTreeFolderRow(node: node));
+
+      expect(find.byType(FileTreeFolderRow), findsOneWidget);
+    });
+  });
+}

--- a/src/capi/Discovery.cpp
+++ b/src/capi/Discovery.cpp
@@ -130,8 +130,8 @@ GBM_API int32_t gbm_discovery_set_base_folder_enabled(GbmDiscoveryHandle discove
 }
 
 GBM_API int32_t gbm_discovery_set_base_folder_depth(GbmDiscoveryHandle discovery,
-                                                     int64_t baseFolderId,
-                                                     int32_t maxDepth) {
+                                                    int64_t baseFolderId,
+                                                    int32_t maxDepth) {
     DiscoveryState* state = toDiscovery(discovery);
     const GitResult<void> result = state->db.setBaseFolderMaxDepth(baseFolderId, maxDepth);
     if (!result) {

--- a/src/capi/Discovery.cpp
+++ b/src/capi/Discovery.cpp
@@ -128,3 +128,15 @@ GBM_API int32_t gbm_discovery_set_base_folder_enabled(GbmDiscoveryHandle discove
     }
     return 0;
 }
+
+GBM_API int32_t gbm_discovery_set_base_folder_depth(GbmDiscoveryHandle discovery,
+                                                     int64_t baseFolderId,
+                                                     int32_t maxDepth) {
+    DiscoveryState* state = toDiscovery(discovery);
+    const GitResult<void> result = state->db.setBaseFolderMaxDepth(baseFolderId, maxDepth);
+    if (!result) {
+        setStagingBuffer(toJson(result.error()));
+        return errorCodeOrdinal(result.error());
+    }
+    return 0;
+}

--- a/src/capi/JsonCodec.cpp
+++ b/src/capi/JsonCodec.cpp
@@ -282,6 +282,8 @@ std::string toJson(const BaseFolderRecord& record) {
     jsonAppendInt(out, record.lastScanDirs);
     out += ",\"lastScanMs\":";
     jsonAppendInt(out, record.lastScanMs);
+    out += ",\"lastScanSkipped\":";
+    jsonAppendInt(out, record.lastScanSkipped);
     out += '}';
     return out;
 }

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -1250,3 +1250,12 @@ GBM_API int32_t gbm_discovery_remove_base_folder(GbmDiscoveryHandle discovery,
 GBM_API int32_t gbm_discovery_set_base_folder_enabled(GbmDiscoveryHandle discovery,
                                                       int64_t baseFolderId,
                                                       int32_t enabled);
+
+/// Changes how many levels below a base folder are scanned. Also clears its
+/// stored directory signatures (see RepoIndexDb::setBaseFolderMaxDepth's doc
+/// comment) -- a signature recorded "nothing below here" under the old depth
+/// would otherwise wrongly prune a subtree a deeper scan should now visit.
+/// Returns 0 on success, or a negative GbmErrorCode.
+GBM_API int32_t gbm_discovery_set_base_folder_depth(GbmDiscoveryHandle discovery,
+                                                     int64_t baseFolderId,
+                                                     int32_t maxDepth);

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -1257,5 +1257,5 @@ GBM_API int32_t gbm_discovery_set_base_folder_enabled(GbmDiscoveryHandle discove
 /// would otherwise wrongly prune a subtree a deeper scan should now visit.
 /// Returns 0 on success, or a negative GbmErrorCode.
 GBM_API int32_t gbm_discovery_set_base_folder_depth(GbmDiscoveryHandle discovery,
-                                                     int64_t baseFolderId,
-                                                     int32_t maxDepth);
+                                                    int64_t baseFolderId,
+                                                    int32_t maxDepth);

--- a/src/core/cache/RepoIndexDb.cpp
+++ b/src/core/cache/RepoIndexDb.cpp
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS base_folder(
   last_scan_started  INTEGER NOT NULL DEFAULT 0,
   last_scan_finished INTEGER NOT NULL DEFAULT 0,
   last_scan_dirs     INTEGER NOT NULL DEFAULT 0,
-  last_scan_ms       INTEGER NOT NULL DEFAULT 0
+  last_scan_ms       INTEGER NOT NULL DEFAULT 0,
+  last_scan_skipped  INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS repo(
@@ -196,7 +197,7 @@ GitResult<void> RepoIndexDb::migrate() {
     logMessage(LogLevel::Info,
                "Upgrading repository cache from schema " + std::to_string(oldVersion) + " to " +
                    std::to_string(kSchemaVersion));
-    return db_.transaction([this, oldVersion] {
+    return db_.transaction([this, oldVersion]() -> GitResult<void> {
         if (auto created = db_.execute(kSchema); !created) {
             return created;
         }
@@ -213,6 +214,45 @@ GitResult<void> RepoIndexDb::migrate() {
             logMessage(LogLevel::Info,
                        "Base folders were reset by the schema 2 upgrade (default scan depth "
                        "changed from 6 to 1); please re-add them.");
+        }
+        if (oldVersion < 3) {
+            // A plain new column with a default -- unlike the schema 2 step above,
+            // existing base folders and their scan history are safe to keep as-is.
+            //
+            // Checked for existence first rather than run unconditionally: the
+            // `db_.execute(kSchema)` above just created the table fresh (with this
+            // column already in it, per today's kSchema) for any DB that starts
+            // this transaction at schema_info version 0 *or* whose table was
+            // already created under today's layout (e.g. in tests that simulate
+            // an old cache by rolling `schema_info.version` back without reverting
+            // the table itself, see UpgradingFromSchemaOneClearsBaseFolders) -- an
+            // unconditional ALTER TABLE would then fail with "duplicate column".
+            auto columns = db_.prepare("PRAGMA table_info(base_folder);");
+            if (!columns) {
+                return fail(std::move(columns).error());
+            }
+            bool hasSkippedColumn = false;
+            for (;;) {
+                auto stepped = columns->step();
+                if (!stepped) {
+                    return fail(std::move(stepped).error());
+                }
+                if (!*stepped) {
+                    break;
+                }
+                if (columns->columnText(1) == "last_scan_skipped") {
+                    hasSkippedColumn = true;
+                    break;
+                }
+            }
+            if (!hasSkippedColumn) {
+                if (auto added = db_.execute(
+                        "ALTER TABLE base_folder ADD COLUMN last_scan_skipped INTEGER NOT NULL "
+                        "DEFAULT 0;");
+                    !added) {
+                    return added;
+                }
+            }
         }
         return db_.execute("UPDATE schema_info SET version = " + std::to_string(kSchemaVersion) +
                            ";");
@@ -323,7 +363,8 @@ GitResult<std::vector<BaseFolderRecord>> RepoIndexDb::baseFolders() const {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     auto statement = db_.prepare(
         "SELECT id, path, enabled, max_depth, follow_links, generation, last_scan_started, "
-        "last_scan_finished, last_scan_dirs, last_scan_ms FROM base_folder ORDER BY path;");
+        "last_scan_finished, last_scan_dirs, last_scan_ms, last_scan_skipped FROM base_folder "
+        "ORDER BY path;");
     if (!statement) {
         return fail(std::move(statement).error());
     }
@@ -348,6 +389,7 @@ GitResult<std::vector<BaseFolderRecord>> RepoIndexDb::baseFolders() const {
         record.lastScanFinished = statement->columnInt(7);
         record.lastScanDirs = statement->columnInt(8);
         record.lastScanMs = statement->columnInt(9);
+        record.lastScanSkipped = statement->columnInt(10);
         folders.push_back(std::move(record));
     }
     return folders;
@@ -385,11 +427,12 @@ GitResult<std::int64_t> RepoIndexDb::beginScan(std::int64_t baseFolderId) {
 
 GitResult<void> RepoIndexDb::finishScan(std::int64_t baseFolderId,
                                         std::int64_t dirsScanned,
-                                        std::int64_t elapsedMs) {
+                                        std::int64_t elapsedMs,
+                                        std::int64_t dirsSkipped) {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     auto statement = db_.prepare(
-        "UPDATE base_folder SET last_scan_finished = ?2, last_scan_dirs = ?3, last_scan_ms = ?4 "
-        "WHERE id = ?1;");
+        "UPDATE base_folder SET last_scan_finished = ?2, last_scan_dirs = ?3, last_scan_ms = ?4, "
+        "last_scan_skipped = ?5 WHERE id = ?1;");
     if (!statement) {
         return fail(std::move(statement).error());
     }
@@ -397,6 +440,7 @@ GitResult<void> RepoIndexDb::finishScan(std::int64_t baseFolderId,
     statement->bind(2, nowSeconds());
     statement->bind(3, dirsScanned);
     statement->bind(4, elapsedMs);
+    statement->bind(5, dirsSkipped);
     auto stepped = statement->step();
     if (!stepped) {
         return fail(std::move(stepped).error());

--- a/src/core/cache/RepoIndexDb.h
+++ b/src/core/cache/RepoIndexDb.h
@@ -26,6 +26,10 @@ struct BaseFolderRecord {
     std::int64_t lastScanFinished = 0;
     std::int64_t lastScanDirs = 0;
     std::int64_t lastScanMs = 0;
+    /// Directories the last scan did not descend into because they lay past
+    /// `maxDepth`. Surfaced so the UI can report "N folders skipped (depth
+    /// limit)" instead of silently under-counting what was scanned.
+    std::int64_t lastScanSkipped = 0;
 };
 
 struct RepoRecord {
@@ -93,7 +97,12 @@ public:
     /// Schema 2 lowered the default `max_depth` from 6 to 1 (see `addBaseFolder`)
     /// and, on upgrade, clears every existing base folder rather than silently
     /// reinterpreting a folder the user already configured under the old default.
-    static constexpr int kSchemaVersion = 2;
+    ///
+    /// Schema 3 added `base_folder.last_scan_skipped`. Unlike schema 2, existing
+    /// base folders are preserved on upgrade -- a new column with a `DEFAULT 0`
+    /// is safe to add onto rows that already exist, there is no stale-default
+    /// reinterpretation risk the way there was for `max_depth`.
+    static constexpr int kSchemaVersion = 3;
 
     GitResult<void> open(const std::filesystem::path& path);
     GitResult<void> openInMemory();
@@ -121,7 +130,8 @@ public:
     GitResult<std::int64_t> beginScan(std::int64_t baseFolderId);
     GitResult<void> finishScan(std::int64_t baseFolderId,
                                std::int64_t dirsScanned,
-                               std::int64_t elapsedMs);
+                               std::int64_t elapsedMs,
+                               std::int64_t dirsSkipped = 0);
 
     // --- repositories ------------------------------------------------------
     GitResult<std::int64_t> upsertRepo(const RepoRecord& record);

--- a/src/core/discovery/Scanner.cpp
+++ b/src/core/discovery/Scanner.cpp
@@ -392,8 +392,8 @@ GitResult<ScanResult> Scanner::scan(const BaseFolderRecord& baseFolder,
                            .count();
 
     if (!result.cancelled) {
-        if (auto finished =
-                db_.finishScan(baseFolder.id, result.directoriesScanned, result.elapsedMs);
+        if (auto finished = db_.finishScan(baseFolder.id, result.directoriesScanned,
+                                           result.elapsedMs, result.directoriesSkipped);
             !finished) {
             return fail(std::move(finished).error());
         }

--- a/src/core/discovery/Scanner.cpp
+++ b/src/core/discovery/Scanner.cpp
@@ -392,8 +392,10 @@ GitResult<ScanResult> Scanner::scan(const BaseFolderRecord& baseFolder,
                            .count();
 
     if (!result.cancelled) {
-        if (auto finished = db_.finishScan(baseFolder.id, result.directoriesScanned,
-                                           result.elapsedMs, result.directoriesSkipped);
+        if (auto finished = db_.finishScan(baseFolder.id,
+                                           result.directoriesScanned,
+                                           result.elapsedMs,
+                                           result.directoriesSkipped);
             !finished) {
             return fail(std::move(finished).error());
         }

--- a/tests/capi/DiscoveryApiTest.cpp
+++ b/tests/capi/DiscoveryApiTest.cpp
@@ -109,6 +109,18 @@ TEST_F(DiscoveryApiTest, SetBaseFolderEnabledTogglesFlag) {
     EXPECT_NE(lastResultJson().find("\"enabled\":false"), std::string::npos);
 }
 
+TEST_F(DiscoveryApiTest, SetBaseFolderDepthUpdatesMaxDepth) {
+    discovery_ = gbm_discovery_open("");
+    ASSERT_NE(discovery_, nullptr);
+    const int64_t folderId = gbm_discovery_add_base_folder(discovery_, base_.string().c_str(), 3, 0);
+    ASSERT_GE(folderId, 0);
+
+    ASSERT_EQ(gbm_discovery_set_base_folder_depth(discovery_, folderId, 7), 0);
+
+    ASSERT_EQ(gbm_discovery_base_folders_json(discovery_), 0);
+    EXPECT_NE(lastResultJson().find("\"maxDepth\":7"), std::string::npos);
+}
+
 TEST_F(DiscoveryApiTest, RemoveBaseFolderDropsItFromTheList) {
     discovery_ = gbm_discovery_open("");
     ASSERT_NE(discovery_, nullptr);

--- a/tests/unit/DiscoveryTest.cpp
+++ b/tests/unit/DiscoveryTest.cpp
@@ -401,6 +401,42 @@ TEST(RepoIndexDb, ChangingBaseFolderDepthClearsItsSignatures) {
     EXPECT_FALSE(*stored) << "the old signature must not survive a depth change";
 }
 
+TEST(RepoIndexDb, UpgradingFromSchemaTwoPreservesBaseFoldersAndAddsSkipColumn) {
+    // Unlike the schema 1 -> 2 step above, schema 3 only adds a column with a
+    // safe default -- an already-configured base folder must survive the
+    // upgrade instead of being cleared.
+    RepoIndexDb db;
+    ASSERT_TRUE(db.openInMemory());
+    ASSERT_TRUE(db.addBaseFolder("/work", 4, false));
+    ASSERT_EQ(db.baseFolders()->size(), 1u);
+
+    ASSERT_TRUE(db.forceSchemaVersionForTest(2));
+    ASSERT_TRUE(db.migrate());
+
+    auto folders = db.baseFolders();
+    ASSERT_TRUE(folders);
+    ASSERT_EQ(folders->size(), 1u);
+    EXPECT_EQ((*folders)[0].maxDepth, 4) << "schema 3 must not reset unrelated columns";
+    EXPECT_EQ((*folders)[0].lastScanSkipped, 0);
+}
+
+TEST(RepoIndexDb, FinishScanRecordsSkippedDirectoryCount) {
+    RepoIndexDb db;
+    ASSERT_TRUE(db.openInMemory());
+    auto folderId = db.addBaseFolder("/work", 2, false);
+    ASSERT_TRUE(folderId);
+    ASSERT_TRUE(db.beginScan(*folderId));
+
+    ASSERT_TRUE(db.finishScan(*folderId, /*dirsScanned=*/10, /*elapsedMs=*/5,
+                              /*dirsSkipped=*/3));
+
+    auto folders = db.baseFolders();
+    ASSERT_TRUE(folders);
+    ASSERT_EQ(folders->size(), 1u);
+    EXPECT_EQ((*folders)[0].lastScanDirs, 10);
+    EXPECT_EQ((*folders)[0].lastScanSkipped, 3);
+}
+
 TEST(RepoIndexDb, UpgradingFromSchemaOneClearsBaseFolders) {
     // Schema 2 lowered the default max_depth from 6 to 1. A base folder written
     // by a pre-upgrade build was configured under the old default, so the
@@ -569,6 +605,30 @@ TEST_F(ScannerTest, RespectsTheDepthLimit) {
     CancellationSource source;
     ASSERT_TRUE(scanner.scan((*folders)[0], ScanMode::Full, source.token()));
     EXPECT_EQ(db.repos()->size(), 0u) << "the repository lies past maxDepth";
+}
+
+TEST_F(ScannerTest, RecordsDirectoriesSkippedPastTheDepthLimit) {
+    // End-to-end check that Scanner::scan's ScanResult::directoriesSkipped
+    // reaches RepoIndexDb::finishScan and is persisted, not just that
+    // finishScan itself can store the number (see the RepoIndexDb-level
+    // FinishScanRecordsSkippedDirectoryCount test for that half).
+    makeNormalRepo("a/b/c/d/e/deep");
+
+    RepoIndexDb db;
+    ASSERT_TRUE(db.openInMemory());
+    ASSERT_TRUE(db.addBaseFolder(root_.string(), 2, false));
+    auto folders = db.baseFolders();
+    ASSERT_TRUE(folders);
+
+    Scanner scanner(db);
+    CancellationSource source;
+    ASSERT_TRUE(scanner.scan((*folders)[0], ScanMode::Full, source.token()));
+
+    auto rescanned = db.baseFolders();
+    ASSERT_TRUE(rescanned);
+    ASSERT_EQ(rescanned->size(), 1u);
+    EXPECT_GT((*rescanned)[0].lastScanSkipped, 0)
+        << "directories past maxDepth must be reported as skipped, not silently dropped";
 }
 
 TEST_F(ScannerTest, DepthOneFindsOnlyTheBaseFolderAndItsDirectChildren) {


### PR DESCRIPTION
## Summary

修復 spec-conformance-audit（`docs/reports/spec-conformance-matrix.md` /
`docs/reports/code-review-2026-08.md`）標記的 Tier 0（8 個彼此獨立、無依賴的
小落差）。7 個 commit 依序落在同一分支，每個都是可獨立 revert 的最小單位：

1. `2a60b47` fix #44 — 修正 05-C context menu 過期的 doc comment（純註解）
2. `613f80c` fix #43 — Commit/Amend 按鈕改為輸入時即時重新啟用（H2）
3. `503e326` fix #50 — operationLog 上限改讀 `AppPreferences.logMemoryLimit`
4. `16626b2` fix #48 — 狀態列「+N task」chip 改為可互動展開
5. `2307ef7` fix #46 — History ref chip 合併已同步的 local+origin 分支
6. `a928bd5` fix #47 — List/Tree 檢視模式偏好跨頁共用（History/Compare/Conflict）
7. `3e65208` fix #49 — Preferences 5 個未曝光欄位，含 capi 擴充
8. `5f1816f` docs — 依修復結果更新 `CLAUDE.md` Known gaps

**#45（Tier 0c，rename branch 對話框）不在這輪範圍內**，見下方說明。

## 規劃階段修正的兩個 issue 前提

- **#50**：issue 原文建議「C++/Flutter 兩邊常數一起改」，但直接讀
  `OperationRunner.cpp` 發現 `kMaxUndoEntries=200` 管的是 Undo Last 用的
  `undoJournal_`，跟這裡要修的 `operationLog`（Log Drawer/Operation Log
  面板用）完全無關、從未真正對齊過。改為讀取 `AppPreferences.logMemoryLimit`
  （該欄位已存在、預設 2000、Preferences UI 已可編輯，spec LOGRULES 原文
  正是「上限寫在 Preferences，不隱藏」）——不需要碰 C++，不需要 native
  rebuild。
- **#49**：issue 原文假設 5 個子項都是純 Flutter 端接線，但其中 2 項
  （per-folder 掃描深度編輯、掃描摘要回報「被深度上限跳過的資料夾數」）
  實際卡在 capi 缺口。使用者核准「順便補 capi」，因此這個 commit 額外新增
  `gbm_discovery_set_base_folder_depth` capi wrapper，以及
  `RepoIndexDb` schema 2→3 migration（新增 `last_scan_skipped` 欄位，
  安全新增、不清空既有資料）。子項⑤（全域 gitignore 匯入來源標籤）刻意
  縮小範圍：只加欄位與 UI 渲染邏輯，沒有新增「讀取使用者既有全域 git
  config」的偵測邏輯——這需要一個新的 capi 進入點，超出這次核准的範圍，
  commit message 已註明，留給之後的 issue。

## #45（Tier 0c）為何不在這批

Issue 原文說 rename 分支功能「缺失」，但直接讀原始碼發現兩個入口
（`sidebar_panel.dart:119`、`workspace_screen.dart:887`）其實都已經能用，
只是共用同一個陽春的 `promptText` 輸入框；真正缺的是 spec 要求的專屬
dialog route 與 F2 快捷鍵。原本規劃打算「功能面先做、畫面留給之後的設計
稿」，但使用者最終決定整項延後——避免做出之後要因為設計稿而整個重寫版面
的東西。**#45 這個 PR 合併後仍維持 open**——沒有任何 commit 或這份說明使用會觸發 GitHub 自動關閉的關鍵字＋編號組合指向它，等專屬設計稿完成後再開新一輪處理。

## Test plan

- [x] `flutter analyze` — 0 issue（含 info 級別）
- [x] `flutter test` — 927 passed / 6 skipped
- [x] `dart format --set-exit-if-changed .` — 0 diff
- [x] C++ `gbm_core_tests` — 390/390（含 2 個環境限制的 skip）
- [x] C++ `gbm_capi_tests` — 113/113
- [x] `cmake --build --preset capi-only --target gbm_capi` 與
      `./app_flutter/scripts/build_capi.sh` 皆成功（#49 需要的 native rebuild）
- [x] 新增的 regression test 涵蓋：H2 打字即時 reactive、operationLog 裁切
      改讀 Preferences、status bar 任務清單互動、ref chip 合併/虛線邏輯、
      List/Tree 偏好跨頁共用（含真的跨路由整合測試）、Preferences 5 個
      子項（含 C++ 端 schema migration/finishScan/capi depth setter）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJ1appxMmu6ekZESbH888Y
