### PR TITLE
fix: 依 spec P13 補上 Rename branch dialog、route 與 F2 綁定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -962,6 +962,39 @@ over-display one, not a missing feature. **#68** asks for the reading to be
 settled before any code moves — implementing off a guess here is the exact
 failure mode that closed #60.
 
+### Tier 0c (fix/tier-0c-rename-branch-dialog) — issue #45, addendum
+
+Two things worth carrying forward from the verification pass, both found by
+*running* rather than by reading — see the Tier 0c section further up for
+the feature itself.
+
+**`RefInfo.hasTrackingInfo` does not mean "has an upstream".** It mirrors
+git's `%(upstream:track)` (`RefStore.cpp`'s `parseTrack()`), which is an
+**empty string** for a branch exactly in sync with its upstream — 0 ahead,
+0 behind — even though `%(upstream)` is fully populated. The rename
+dialog's first version gated its whole "Remote handling" section on
+`hasTrackingInfo && upstream.isNotEmpty`, which therefore hid it for the
+single most common case (a branch that was just pushed) and silently
+downgraded those renames to local-only. Anything asking "does this branch
+track a remote?" must read `upstream`, and reserve `hasTrackingInfo` for
+"did git report ahead/behind numbers". The widget tests all passed
+throughout, because the test fixture hardcoded
+`hasTrackingInfo: upstream.isNotEmpty` — the same wrong assumption, written
+twice, so the tests could not disagree with the code. A fixture that
+derives one field from another is a fixture that cannot falsify the
+derivation.
+
+**Nothing but a device-tier test crosses the FFI signature seam.**
+`test/**` runs on `FakeGbmBindings`; `tests/capi/**` calls the C++ directly;
+`dart:ffi`'s `lookupFunction` matches by **symbol name only, never by
+signature**. So changing a capi function's parameter list and its Dart
+typedef in lockstep is checked by nothing — a mismatch compiles, analyzes,
+and unit-tests clean, then corrupts the stack at runtime.
+`integration_test/rename_branch_flow_test.dart` is the only thing that
+would catch it for `gbm_branch_rename`. Same trap as the stale-dylib note
+in `integration_test/README.md`, and it fired again here: the checked-in
+copy was 21KB behind a fresh build.
+
 ### Tier 4 (fix/tier-4-file-at-revision) — issues #58 + #59
 
 The 05-K batch, and the only tier since Tier 0h to need new `src/core` C++.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -681,7 +681,13 @@ with no defence. Neither is fixed here (Tier 0c scoped itself to rename);
 the matrix rows are corrected and each needs its own issue. Note the Stash
 one is not a free slot: `Ctrl/Cmd+Shift+S` currently belongs to
 `repositoryStageAll`, so honouring the revision means re-deciding that
-binding too.
+binding too. Two more REVISIONS casualties in the same table, both found
+after the first pass at these docs and both **not** fixed here:
+`repositoryStageSelectedLines` is now spec'd at `Ctrl/Cmd+Alt+S` but bound
+to `Ctrl/Cmd+Shift+Enter`, and `Edit → Select all` (`Ctrl/Cmd+A`) does not
+exist in `gbmMenus` at all — the latter is deliberately **sequenced after**
+the multi-select work (#54), since `Ctrl/Cmd+A` is also `MULTIKEYS`' "全選
+當前清單" and binding it first would give it nothing to select.
 
 `lib/features/workspace/widgets/tab_row.dart`'s 18-item
 `_MoreMenu` overflow menu plus 3 standalone buttons (Merge/Cherry-pick/
@@ -694,7 +700,12 @@ log, repository settings) is reachable *only* through it, and 2 of its 18
 items (`Repository Settings…`, `Preferences…`) duplicate menu-bar entries
 that already exist. Two competing Log implementations also still coexist:
 `features/log_drawer/` (matches spec page 10's bottom-drawer design) and
-the separate `operationLogDialog` route (doesn't).
+the separate `operationLogDialog` route (doesn't) — **and as of 260820
+that is no longer a tie to break**: P16's REVISIONS deletes the dialog
+from the spec by name ("只留抽屜；operation-log dialog 從規格中刪除"), so
+the route, its `_MoreMenu` entry and `features/operation_log/` are now
+非規格內容. This is the ruling **#61** was waiting on. Removing a live
+route is its own change with its own tests, so it is recorded, not done.
 
 New tests added this round: `test/features/context_menus/context_menu_parity_test.dart`
 asserts all 11 groups against `gbmContextMenuGroups` — the 6 conforming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -871,6 +871,20 @@ also records the untested hypothesis (a fixed 10s budget losing to parallel
 load) and warns against raising the timeout before confirming it — that
 would paper over a real refresh-coalescing bug if one exists.
 
+**A second, unrelated flake was isolated during Tier 0c's CI run and must
+not be folded into #70**: `WorkingCopyApiTest.UnstageHunkReversesAFullyStagedSingleHunkFile`
+fails with `LockHeld` — "Another Git process appears to be running in this
+repository", the lock being its *own* temp repo's `.git/index.lock`. Unlike
+#70's shape it is **not** a timeout and **not** load-dependent: run alone
+with no parallel `ctest`, it failed 1 in 12 and again at iteration 30 of
+40, each time in ~0.36s, nowhere near any timeout budget. So the test races
+itself — a working-copy operation is reported complete before git has
+released the index lock the next one needs. Tracked as **#77**, which
+records the captured error verbatim and warns that raising a timeout (the
+#70 remedy) does nothing here. Practical consequence: a red macOS capi job
+on an unrelated branch may be either flake, and they need different
+triage — read the failure text before assuming.
+
 ### Tier 5 (fix/tier-5-native-window-title) — issue closed, not implemented
 
 Issue #60 asked for a custom Windows/Linux title bar (a window package, two

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -670,20 +670,18 @@ provider-override workaround the pre-existing test in that file still uses
 (that one verifies gate *logic*; the new one verifies the typing → rebuild
 wiring, which is what H2 was actually missing).
 
-**Other confirmed gaps**: `branchRenameCurrentBranch` has no keyboard
-shortcut bound despite F2 being unclaimed by anything else in spec's MENUS
-table (unlike two *other* absent bindings — Find-in-files, Stash-changes —
-which are absent because spec's own table double-assigns their key to
-something else; this one is a genuine omission). It compounds with the
-`Rename branch` dialog route itself being entirely missing from
-`route_paths.dart`. **Deliberately still not fixed** (Tier 0's 0c/#45 was
-scoped out during planning, not silently skipped): the two existing rename
-entry points (`sidebar_panel.dart:119`, `workspace_screen.dart:887`) already
-work and share a plain `promptText` input, so nothing is actually broken —
-what's missing is the dedicated dialog spec calls for, and building that
-without a design draft for it risked a rewrite later. Deferred until a
-rename-dialog design draft exists; issue #45 stays open (not `Fixes #45`
-anywhere) rather than being marked resolved for a partial fix.
+~~**Other confirmed gaps**: `branchRenameCurrentBranch` has no keyboard
+shortcut bound despite F2 being unclaimed…~~ — **Fixed** (Tier 0c, see
+below). The two *other* absent bindings named there (Find-in-files,
+Stash-changes) were excused as spec-internal collisions — spec's own MENUS
+table double-assigned their keys. **That excuse expired on 260820**: P16's
+`REVISIONS` table reassigns Find-in-files to `Ctrl/Cmd+Shift+H` and Stash
+changes to `Ctrl/Cmd+Shift+S`, so both are now ordinary unbound shortcuts
+with no defence. Neither is fixed here (Tier 0c scoped itself to rename);
+the matrix rows are corrected and each needs its own issue. Note the Stash
+one is not a free slot: `Ctrl/Cmd+Shift+S` currently belongs to
+`repositoryStageAll`, so honouring the revision means re-deciding that
+binding too.
 
 `lib/features/workspace/widgets/tab_row.dart`'s 18-item
 `_MoreMenu` overflow menu plus 3 standalone buttons (Merge/Cherry-pick/
@@ -752,8 +750,8 @@ Commit order: `0b → 0a → 0h → 0f → 0d → 0e → 0g`.
   for Undo Last); it now reads `AppPreferences.logMemoryLimit`, the field
   spec's LOGRULES table actually describes ("上限寫在 Preferences，不隱
   藏").
-- **0c / #45 — deliberately not in this batch.** See the F2 paragraph
-  above for why; issue #45 stays open, not closed by this branch's PR.
+- **0c / #45 — deliberately not in this batch**, and shipped later on its
+  own branch once the blocker cleared. See "Tier 0c" below.
 
 Two premises in the original issues were corrected during planning, not
 just during implementation — worth knowing before re-reading #49/#50's
@@ -1040,3 +1038,103 @@ baseline and editing it mid-fix would redefine the thing being verified.
 Tracked as **#71**, which also flags that the page-05 audit's method —
 comparing each render site against the catalog — could not have caught a
 catalog-vs-spec drift in *any* group, so others may exist.
+
+### Tier 0c (fix/tier-0c-rename-branch-dialog) — issue #45
+
+The one item Tier 0 deferred, shipped once its blocker cleared. Read this
+before re-reading #45's issue text: **both the issue's premise and its
+deferral reason were out of date**, in opposite directions.
+
+**The deferral reason expired.** Tier 0 scoped #45 out because there was no
+design draft for the rename dialog and building one blind risked a rewrite.
+That draft now exists: the spec gained four pages on 260820 (commit
+`fc3bfb3`), and **P13 section A** is exactly it — layout, the two remote
+options, and a `RENAMEVALID` table of five live-validation rules. Nothing
+about the deferral was wrong; the condition it named simply came true.
+
+**The issue text overstated the gap.** "Rename branch dialog + route + F2
+missing" reads as though rename did not work. It did: `sidebar_panel.dart`
+and `workspace_screen.dart` both renamed branches through a shared plain
+`promptText` box. What was missing was the *dedicated* dialog, its route,
+and the shortcut. The issue body has been corrected in place (same
+convention as #60 and #50) rather than quietly retitled.
+
+**The issue also understated the work.** It read "`gbm_branch_rename`
+already exists; only wiring is missing." P13's 遠端連帶處理 section made
+that false — see below.
+
+Eight sequential commits, every one green and independently revertible.
+
+**`gbm_branch_rename` grew three parameters** (`renameRemote`,
+`remoteName`, plus an internal `askpassDir`). The remote option is
+push-then-delete — git has no atomic remote rename — and it lives in
+`RenameBranchOperation::run()` rather than being chained from Dart. Three
+capi calls chained in the controller would produce three
+`OPERATION_FINISHED` events and three error exits, against spec page 10's
+one-background-task rule; `run()` was already multi-step anyway (the
+case-only rename goes through a `.gbm-rename-tmp` two-stage). `TagOps.cpp`'s
+`DeleteTagOperation` is the template followed throughout: local step first,
+remote steps behind the flag with `askpass::wire()` and no local timeout,
+and a partial-failure summary that says which half landed.
+
+**Two things measurement caught that reading would not have:**
+
+- **`git branch -m` keeps the upstream.** Spec says a local-only rename
+  leaves the branch with no upstream, and the obvious reading is that
+  renaming naturally drops the tracking config. It does not — `branch -m`
+  carries `branch.<name>.remote/.merge` across, so the renamed branch
+  silently still tracks the *old* remote branch. That needed an explicit
+  `git branch --unset-upstream` step. Verified directly against a scratch
+  repo before writing the test, precisely so the test could not pass
+  vacuously.
+- **`Session::submitOperation` had no unconditional hook.** `beginAskpass()`
+  documents that `endAskpass()` must be paired unconditionally, but only
+  `submitWorkingCopyOperation` had an `onAlways`; `submitOperation` had just
+  `onSuccess`, which would leak the credential watch on failure. Rename had
+  to stay on `submitOperation` (it emits `OPERATION_FINISHED`, an existing
+  capi contract), so `onAlways` was added there as its own commit.
+
+**`RefInfo.upstream` is the full ref name**, `refs/remotes/origin/main`, not
+`origin/main` — it comes from `%(upstream)`, not `%(upstream:short)`. The
+dialog recovers the remote with `remoteBranchParts()`; splitting on the
+first slash would send `"refs"` as the remote name. **`delete_branch_dialog.dart`'s
+`_remoteOf()` does exactly that split and is therefore broken today** — its
+"also delete on remote" checkbox builds a request against a remote named
+`refs`. Found while writing this dialog, deliberately not fixed here
+(different feature, needs its own test), tracked as its own issue.
+
+**F2 targets the current branch, not the sidebar selection.** Spec says
+"sidebar 選中後按 F2", and the sidebar *does* have selection state — but
+`_selected` is `SidebarPanel`'s local `State`, which
+`WorkspaceScreen._buildActionHandlers()` cannot read. Lifting it into a
+provider is work #54's multi-select round needs anyway. So F2 and the Branch
+menu fall back to HEAD (matching the action id's own name) and the 05-B
+context menu is what names a branch, via the route's `branch` query
+parameter. Deliberate, not an oversight.
+
+**Validation was extracted, not copied.** `branchNameError()`
+(`features/dialogs/branch_name_validation.dart`) came out of
+`new_branch_dialog.dart`'s private `_nameError`; two dialogs needing the
+same rules is how two drifting copies start. The rename dialog additionally
+excludes the branch's own name from the duplicate check — that is
+RENAMEVALID's 未改動 row, which disables the button *without* red text.
+
+`branch_tree_item.dart`'s Rename item gained the `conflictActive` gate the
+menu and F2 paths already had through `isActionEnabled()`; it sets **both**
+`enabled: false` and `onTap: null`, since `enabled` alone is only a visual
+signal (`gbm_menu.dart`'s doc comment). Noted while there: `New branch from
+here`, `Merge into current branch` and `Delete branch` in that same menu are
+still ungated despite spec page 07 disabling all three mid-conflict — a real
+gap of the same shape, left alone as out of scope for #45.
+
+`test/integration/workspace_rename_branch_flow_test.dart` covers the seam the
+widget tests cannot: F2 → handler map → route → dialog → controller. Its
+value was confirmed by mutation rather than assumed — deleting the F2 binding
+fails three of its four cases (the fourth, "mid-conflict F2 opens nothing",
+correctly still passes).
+
+**Docs**: `spec-conformance-matrix.md` gained a baseline banner recording
+that the audit was written against 12 pages and the spec now has 16, and its
+`REVISIONS`-affected rows were corrected in place — including two that had
+been excused as spec-internal collisions and no longer are. P14/P15/P16 are
+**not** audited; nothing under `lib/` was changed for them.

--- a/app_flutter/integration_test/README.md
+++ b/app_flutter/integration_test/README.md
@@ -26,6 +26,7 @@ flutter test integration_test/repo_lifecycle_test.dart -d macos
 flutter test integration_test/commit_flow_test.dart -d macos
 flutter test integration_test/conflict_flow_test.dart -d macos
 flutter test integration_test/context_menu_flows_test.dart -d macos
+flutter test integration_test/rename_branch_flow_test.dart -d macos
 ```
 
 (`-d linux` / `-d windows` on those platforms.)

--- a/app_flutter/integration_test/rename_branch_flow_test.dart
+++ b/app_flutter/integration_test/rename_branch_flow_test.dart
@@ -1,0 +1,196 @@
+// Device-tier E2E for the Tier 0c rename flow (#45).
+//
+// Why this file has to exist: the rename work changed the `dart:ffi`
+// typedef and the exported C signature of `gbm_branch_rename` in lockstep,
+// and *nothing else in the suite crosses that seam*. `test/features/**` and
+// `test/integration/**` both run on `FakeGbmBindings`; `tests/capi/
+// BranchApiTest.cpp` calls the C++ side directly. `lookupFunction` matches
+// by symbol name, never by signature, so an arity or type mismatch between
+// the two halves compiles, analyzes, and unit-tests clean, then corrupts
+// the stack the first time a real user renames a branch.
+//
+// The two spec P13 remote options are also asserted here against a real
+// bare origin rather than a mock, because their whole difference is what
+// git's own refs look like afterwards -- `RefInfo.upstream` and the remote's
+// branch list -- which a fake controller has no way to model.
+import 'dart:io';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'support/real_repo_harness.dart';
+
+/// The branch these tests rename. Deliberately **not** `main`: a bare
+/// repo's HEAD points at its default branch, and git refuses
+/// `push --delete` on it ("By default, deleting the current branch is
+/// denied"). That refusal is correct git behaviour, not an app defect --
+/// the C++ side reports it honestly as "renamed locally and pushed, but
+/// could not delete" and `BranchApiTest`'s
+/// `RenameBranchReportsTheLocalRenameWhenTheRemoteStepFails` covers it.
+/// Renaming a feature branch is the case spec P13 actually describes.
+///
+/// Flat, with no `/`: `branch_tree_builder.dart` groups `feature/x` under a
+/// collapsible `feature` folder, so the sidebar row's text would be `x`,
+/// not the full name -- a dependency on tree rendering this test has no
+/// business carrying. Spec P13's own example is `feature/lane-allocator`;
+/// the slash is exercised by the branch-tree tests instead.
+const String _branch = 'lane-allocator';
+
+/// Creates a bare repo next to [repoPath] and wires it up as `origin`, with
+/// [_branch] pushed and tracking, mirroring `tests/capi/RemoteApiTest.cpp`'s
+/// fixture. Returns the bare repo's path.
+String _setUpBareOrigin(String repoPath) {
+  final Directory bare = Directory.systemTemp.createTempSync('gbm_e2e_origin_');
+  final String originPath = bare.resolveSymbolicLinksSync();
+  Process.runSync('git', <String>[
+    'init',
+    '--bare',
+    '--initial-branch=main',
+    originPath,
+  ]);
+  runGit(repoPath, <String>['remote', 'add', 'origin', originPath]);
+  runGit(repoPath, <String>['push', '--set-upstream', 'origin', 'main']);
+  runGit(repoPath, <String>['checkout', '-b', _branch]);
+  runGit(repoPath, <String>['push', '--set-upstream', 'origin', _branch]);
+  return originPath;
+}
+
+/// `git branch -vv`'s tracking suffix for [branch], or `''` when it has no
+/// upstream. Reading porcelain here rather than the app's own state on
+/// purpose: the point is what git believes, not what the UI cached.
+String _upstreamOf(String repoPath, String branch) {
+  final String out = runGit(repoPath, <String>[
+    'for-each-ref',
+    '--format=%(upstream:short)',
+    'refs/heads/$branch',
+  ]).stdout.toString();
+  return out.trim();
+}
+
+List<String> _remoteBranches(String originPath) {
+  final String out = runGit(originPath, <String>[
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/heads',
+  ]).stdout.toString();
+  return out
+      .split('\n')
+      .map((String s) => s.trim())
+      .where((String s) => s.isNotEmpty)
+      .toList();
+}
+
+/// Opens the rename dialog through the sidebar's own 05-B entry, which is
+/// the path a user actually takes. Right-click is not reachable via
+/// `tester.tap`, hence the explicit gesture.
+Future<void> _openRenameDialog(WidgetTester tester, String branch) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(find.text(branch).first));
+  await gesture.up();
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.text('Rename branch'));
+  await tester.pumpAndSettle(const Duration(seconds: 1));
+}
+
+Future<void> _submitRename(WidgetTester tester, String newName) async {
+  await tester.enterText(find.byType(TextField).last, newName);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Rename'));
+  // The dialog dispatches and pops immediately (spec page 10: progress
+  // belongs to the background-task row), so this settle is waiting on the
+  // operation itself, not on the dialog.
+  await tester.pumpAndSettle(const Duration(seconds: 3));
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late String repoPath;
+  late String originPath;
+
+  setUp(() {
+    repoPath = createTempGitRepo();
+    originPath = _setUpBareOrigin(repoPath);
+  });
+
+  tearDown(() {
+    deleteTempGitRepo(repoPath);
+    deleteTempGitRepo(originPath);
+  });
+
+  testWidgets('"一併更名遠端分支" pushes the new name and deletes the old one', (
+    tester,
+  ) async {
+    expect(_remoteBranches(originPath), <String>[_branch, 'main']);
+    expect(_upstreamOf(repoPath, _branch), 'origin/$_branch');
+
+    await pumpRealAppOn(tester, repoPath);
+    await _openRenameDialog(tester, _branch);
+    expect(
+      find.text('Rename Branch'),
+      findsOneWidget,
+      reason: 'the dialog is open (its GbmDialogShell title)',
+    );
+
+    // The remote-rename option is the default when the branch has an
+    // upstream, so this submits without touching the radio group.
+    await _submitRename(tester, 'lane-allocator-v2');
+
+    expect(
+      runGit(repoPath, <String>[
+        'rev-parse',
+        '--abbrev-ref',
+        'HEAD',
+      ]).stdout.toString().trim(),
+      'lane-allocator-v2',
+      reason: 'renaming the checked-out branch moves HEAD with it (spec P13)',
+    );
+    expect(
+      _remoteBranches(originPath),
+      <String>['lane-allocator-v2', 'main'],
+      reason:
+          'push new name then delete old -- in that order, so a failure '
+          'partway never leaves the branch unpublished',
+    );
+    expect(
+      _upstreamOf(repoPath, 'lane-allocator-v2'),
+      'origin/lane-allocator-v2',
+      reason: 'push --set-upstream must repoint tracking at the new ref',
+    );
+  });
+
+  testWidgets('"只改本地" clears the upstream and leaves the remote alone', (
+    tester,
+  ) async {
+    await pumpRealAppOn(tester, repoPath);
+    await _openRenameDialog(tester, _branch);
+
+    // "只改本地，保留遠端舊分支" in spec P13; the app's UI copy is English.
+    await tester.tap(find.textContaining('Rename locally, keep'));
+    await tester.pumpAndSettle();
+    await _submitRename(tester, 'lane-allocator-v2');
+
+    expect(
+      _remoteBranches(originPath),
+      <String>[_branch, 'main'],
+      reason: 'the local-only option must not touch origin at all',
+    );
+    expect(
+      _upstreamOf(repoPath, 'lane-allocator-v2'),
+      '',
+      reason:
+          'git branch -m *preserves* tracking config, so the local-only '
+          'path needs an explicit --unset-upstream -- verified by '
+          'experiment, not assumed. Without it this assertion reads '
+          '"origin/$_branch", pointing the renamed branch at a ref it no '
+          'longer corresponds to.',
+    );
+  });
+}

--- a/app_flutter/lib/actions/gbm_menu_model.dart
+++ b/app_flutter/lib/actions/gbm_menu_model.dart
@@ -218,8 +218,12 @@ const List<GbmMenuModel> gbmMenus = <GbmMenuModel>[
       GbmMenuItemModel(id: GbmActionId.branchNewBranch, label: 'New branch…'),
       GbmMenuItemModel(id: GbmActionId.branchCheckout, label: 'Checkout…'),
       GbmMenuItemModel(
+        // Spec's MENUS table says "Rename branch…", and since the dialog
+        // this now opens can rename a branch named by the 05-B context
+        // menu rather than only HEAD, the shorter label is also the
+        // accurate one. The action id keeps its original name.
         id: GbmActionId.branchRenameCurrentBranch,
-        label: 'Rename current branch…',
+        label: 'Rename branch…',
       ),
       GbmMenuItemModel(
         id: GbmActionId.branchMergeIntoCurrent,

--- a/app_flutter/lib/actions/gbm_shortcuts.dart
+++ b/app_flutter/lib/actions/gbm_shortcuts.dart
@@ -245,6 +245,18 @@ Map<GbmActionId, GbmKeyboardShortcut> gbmActionShortcuts(bool isMacOS) {
       isMacOS,
       shift: true,
     ),
+
+    // Bare-key group (1). The only shortcut in the spec's MENUS table with
+    // no Ctrl/Cmd at all, so it cannot go through _makeShortcut() -- that
+    // helper always sets one or the other. F2 is the platform convention
+    // for rename on Windows and Linux, and spec's 260820 revision
+    // ("Branch → Rename branch… = F2") adopts it on macOS too rather than
+    // splitting the binding per platform.
+    GbmActionId.branchRenameCurrentBranch: const GbmKeyboardShortcut(
+      trigger: LogicalKeyboardKey.f2,
+      control: false,
+      meta: false,
+    ),
   };
 }
 

--- a/app_flutter/lib/actions/gbm_shortcuts.dart
+++ b/app_flutter/lib/actions/gbm_shortcuts.dart
@@ -100,8 +100,11 @@ class GbmKeyboardShortcut {
 
 /// Returns a map of GbmActionId to GbmKeyboardShortcut keyboard shortcuts.
 ///
-/// Exactly 35 of the 52 action IDs have keyboard shortcuts. The remaining 17
+/// Exactly 36 of the 52 action IDs have keyboard shortcuts. The remaining 16
 /// are either intentionally unbound (per spec) or handled specially (e.g., fileExit).
+/// `gbm_shortcuts_test.dart` asserts both numbers, so they cannot drift
+/// silently — but nothing checks the per-group counts in the comments
+/// below, which is how `// Shift group` came to say 14 while holding 15.
 ///
 /// The [isMacOS] parameter controls whether shortcuts use `meta` (macOS) or
 /// `control` (Windows/Linux). This is a pure function for testability; it does
@@ -169,7 +172,7 @@ Map<GbmActionId, GbmKeyboardShortcut> gbmActionShortcuts(bool isMacOS) {
       isMacOS,
     ),
 
-    // Shift group (14)
+    // Shift group (15)
     GbmActionId.fileCloneRepository: _makeShortcut(
       LogicalKeyboardKey.keyN,
       isMacOS,

--- a/app_flutter/lib/data/ffi/gbm_bindings.dart
+++ b/app_flutter/lib/data/ffi/gbm_bindings.dart
@@ -210,6 +210,8 @@ typedef _BranchRenameNative =
       Pointer<Utf8> from,
       Pointer<Utf8> to,
       Int32 force,
+      Int32 renameRemote,
+      Pointer<Utf8> remoteName,
     );
 typedef BranchRenameDart =
     void Function(
@@ -217,6 +219,8 @@ typedef BranchRenameDart =
       Pointer<Utf8> from,
       Pointer<Utf8> to,
       int force,
+      int renameRemote,
+      Pointer<Utf8> remoteName,
     );
 
 typedef _BranchDeleteNative =

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -1391,19 +1391,38 @@ class RepoSessionController extends StateNotifier<RepoSessionState> {
 
   /// `git branch -m <from> <to>` (`-M` when [force]). Async, refreshes refs
   /// on success.
+  ///
+  /// [renameRemote] carries the rename through to [remoteName] afterwards
+  /// (`push --set-upstream` then `push --delete`); leaving it false unsets
+  /// the branch's upstream instead, because `git branch -m` keeps the
+  /// tracking config and would otherwise leave the renamed branch pointing
+  /// at the old remote branch. Either way the remote work happens in core
+  /// as one operation, not as a chain of calls from here -- see
+  /// `gbm_branch_rename`'s doc comment.
   void renameBranch({
     required String from,
     required String to,
     bool force = false,
+    bool renameRemote = false,
+    String remoteName = '',
   }) {
     if (_session == nullptr) return;
     final Pointer<Utf8> fromPtr = from.toNativeUtf8();
     final Pointer<Utf8> toPtr = to.toNativeUtf8();
+    final Pointer<Utf8> remotePtr = remoteName.toNativeUtf8();
     try {
-      _bindings.branchRename(_session, fromPtr, toPtr, force ? 1 : 0);
+      _bindings.branchRename(
+        _session,
+        fromPtr,
+        toPtr,
+        force ? 1 : 0,
+        renameRemote ? 1 : 0,
+        remotePtr,
+      );
     } finally {
       malloc.free(fromPtr);
       malloc.free(toPtr);
+      malloc.free(remotePtr);
     }
   }
 

--- a/app_flutter/lib/features/dialogs/branch_name_validation.dart
+++ b/app_flutter/lib/features/dialogs/branch_name_validation.dart
@@ -1,0 +1,44 @@
+/// Branch-name validation shared by the dialogs that take one.
+///
+/// Git's own ref-name rules, limited to the ones a user hits by accident:
+/// leading/trailing slash or dot, `..`, whitespace, and the characters
+/// `~^:?*[\` plus control codes. Checked here so the button explains itself
+/// before the operation is attempted, not *instead of* git's own validation
+/// -- `check_ref_format` (via `RefStore::isValidBranchName` in core) remains
+/// the authority, and core re-checks before git runs.
+///
+/// Lives as a pure function rather than a private method on one dialog's
+/// State because two dialogs now need exactly these rules (New branch,
+/// Rename branch) and spec page 13's RENAMEVALID table asks for the same
+/// live feedback in both.
+library;
+
+/// Characters git refuses in a ref name, plus control codes and space.
+final RegExp _illegalRefChars = RegExp(r'[\x00-\x20~^:?*\[\\\x7f]');
+
+/// A human-readable reason [name] cannot be used as a branch name, or null
+/// when it is usable.
+///
+/// An empty (or whitespace-only) [name] returns null rather than an error:
+/// the caller disables its confirm button in that case, and nagging about a
+/// field the user has not finished typing is exactly what spec page 13's
+/// "空白或未改動：Rename disabled，不出現錯誤紅字" rules out.
+String? branchNameError(String name, {required List<String> existingNames}) {
+  final String trimmed = name.trim();
+  if (trimmed.isEmpty) return null;
+  if (existingNames.contains(trimmed)) {
+    return 'A branch named "$trimmed" already exists.';
+  }
+  if (_illegalRefChars.hasMatch(trimmed)) {
+    return 'Branch names cannot contain spaces or any of ~^:?*[\\';
+  }
+  if (trimmed.startsWith('/') ||
+      trimmed.endsWith('/') ||
+      trimmed.startsWith('.') ||
+      trimmed.endsWith('.') ||
+      trimmed.contains('..') ||
+      trimmed.endsWith('.lock')) {
+    return 'Not a valid branch name.';
+  }
+  return null;
+}

--- a/app_flutter/lib/features/dialogs/new_branch/new_branch_dialog.dart
+++ b/app_flutter/lib/features/dialogs/new_branch/new_branch_dialog.dart
@@ -9,6 +9,7 @@ import '../../../theme/gbm_theme.dart';
 import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_button.dart';
 import '../../../widgets/gbm_dialog_shell.dart';
+import '../branch_name_validation.dart';
 
 /// The three start-point kinds spec page 06's New branch row lists in its
 /// dropdown: "目前分支 / 指定 commit / tag".
@@ -63,32 +64,8 @@ class _NewBranchDialogContentState
     super.dispose();
   }
 
-  /// Git's own ref-name rules, limited to the ones a user hits by accident:
-  /// leading/trailing slash or dot, `..`, whitespace, and the characters
-  /// `~^:?*[\` plus control codes. Checked here so the button explains
-  /// itself before the create is attempted, not instead of git's own
-  /// validation -- `check_ref_format` remains the authority.
-  static final RegExp _illegalRefChars = RegExp(r'[\x00-\x20~^:?*\[\\\x7f]');
-
-  String? _nameError(List<String> existingNames) {
-    final String name = _nameController.text.trim();
-    if (name.isEmpty) return null; // Button is disabled; no need to nag yet.
-    if (existingNames.contains(name)) {
-      return 'A branch named "$name" already exists.';
-    }
-    if (_illegalRefChars.hasMatch(name)) {
-      return 'Branch names cannot contain spaces or any of ~^:?*[\\';
-    }
-    if (name.startsWith('/') ||
-        name.endsWith('/') ||
-        name.startsWith('.') ||
-        name.endsWith('.') ||
-        name.contains('..') ||
-        name.endsWith('.lock')) {
-      return 'Not a valid branch name.';
-    }
-    return null;
-  }
+  String? _nameError(List<String> existingNames) =>
+      branchNameError(_nameController.text, existingNames: existingNames);
 
   /// The ref the new branch is created at, or `''` for "current branch"
   /// (which `branchCreate` reads as HEAD).

--- a/app_flutter/lib/features/dialogs/rename_branch/rename_branch_dialog.dart
+++ b/app_flutter/lib/features/dialogs/rename_branch/rename_branch_dialog.dart
@@ -149,8 +149,13 @@ class _RenameBranchDialogContentState
     // name (refs/remotes/origin/main), not `%(upstream:short)`. Splitting it
     // on the first slash would yield "refs"; remoteBranchParts() is the
     // helper that already knows that.
-    final bool hasUpstream =
-        branch.hasTrackingInfo && branch.upstream.isNotEmpty;
+    // Keyed on `upstream` alone, deliberately *not* on `hasTrackingInfo`:
+    // the latter mirrors git's `%(upstream:track)`, which is empty for a
+    // branch exactly in sync with its upstream (0 ahead, 0 behind) even
+    // though `%(upstream)` is populated -- see RefStore.cpp's parseTrack().
+    // Conjoining the two hid this whole section for a freshly-pushed
+    // branch, quietly turning every such rename into a local-only one.
+    final bool hasUpstream = branch.upstream.isNotEmpty;
     final (String remote, String remoteBranch) = hasUpstream
         ? remoteBranchParts(branch.upstream)
         : ('', '');

--- a/app_flutter/lib/features/dialogs/rename_branch/rename_branch_dialog.dart
+++ b/app_flutter/lib/features/dialogs/rename_branch/rename_branch_dialog.dart
@@ -1,0 +1,393 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../data/models/ref_snapshot.dart';
+import '../../../data/repositories/repo_identity.dart';
+import '../../../data/repositories/repo_session_repository.dart';
+import '../../../theme/gbm_theme.dart';
+import '../../../theme/tokens.dart';
+import '../../../widgets/gbm_button.dart';
+import '../../../widgets/gbm_dialog_shell.dart';
+import '../../sidebar/branch_tree_builder.dart';
+import '../branch_name_validation.dart';
+
+/// Which of spec page 13's two "遠端連帶處理" options is selected.
+enum RenameRemoteMode {
+  /// Push the new name (with `-u`), then delete the old branch on the remote.
+  alsoRenameRemote,
+
+  /// Leave the remote alone; the renamed branch ends up with no upstream.
+  localOnly,
+}
+
+/// Branch → Rename branch… (F2) and context menu 05-B's "Rename branch".
+///
+/// Spec page 13 section A ("Rename branch — 單一分支"), the design that was
+/// added on 260820 and that issue #45 was waiting for. Four parts, in order:
+/// the current name restated read-only, the new name with live validation,
+/// the remote handling choice, and a warning that spells out what renaming
+/// on the remote actually costs.
+///
+/// The dialog does not wait for the operation: spec page 10's rule is that
+/// progress and failures belong to the background-task row and the error
+/// window, "不留在 dialog 裡轉圈", so the confirm button dispatches and pops
+/// immediately, exactly as every other dialog here does.
+///
+/// Renaming the *current* branch is allowed and needs no checkout first --
+/// git moves HEAD along with the branch.
+///
+/// Routed as `/repo/:repoId/dialogs/rename-branch`.
+class RenameBranchDialogContent extends ConsumerStatefulWidget {
+  const RenameBranchDialogContent({
+    super.key,
+    required this.identity,
+    this.branchName,
+  });
+
+  final RepoIdentity identity;
+
+  /// The branch to rename. Null (Branch → Rename branch…, or F2) means the
+  /// current branch -- the context menu is the entry point that names one.
+  final String? branchName;
+
+  @override
+  ConsumerState<RenameBranchDialogContent> createState() =>
+      _RenameBranchDialogContentState();
+}
+
+class _RenameBranchDialogContentState
+    extends ConsumerState<RenameBranchDialogContent> {
+  final TextEditingController _nameController = TextEditingController();
+  RenameRemoteMode _remoteMode = RenameRemoteMode.alsoRenameRemote;
+
+  /// Whether the name field has been seeded with the branch's current name.
+  /// Done on first build rather than in initState() because the branch is
+  /// only known once the session snapshot is read.
+  bool _seeded = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    final RepoSessionState session = ref.watch(
+      repoSessionProvider(widget.identity),
+    );
+
+    // Spec page 13: "分支正在被 rebase / merge 佔用 -> 整個 dialog 不開啟,
+    // 改出提示「先完成或中止進行中的作業」". Every entry point is already
+    // gated on this (isActionEnabled / BranchTreeItem.conflictActive), so
+    // reaching here mid-conflict means the route was entered directly --
+    // refuse rather than offer a rename that would move HEAD. Same shape as
+    // the discard-changes dialog's malformed-request state: no destructive
+    // button at all, only a way out.
+    if (session.conflictActive) {
+      return GbmDialogShell(
+        title: 'Rename Branch',
+        actions: <Widget>[
+          GbmButton(label: 'Close', onPressed: () => context.pop()),
+        ],
+        child: Text(
+          'Finish or abort the operation in progress before renaming a branch.',
+          style: TextStyle(
+            fontSize: GbmTypography.textSm,
+            color: colors.textPrimary,
+          ),
+        ),
+      );
+    }
+
+    final String targetName = widget.branchName ?? session.refs.head.branchName;
+
+    RefInfo? target;
+    for (final RefInfo b in session.refs.localBranches) {
+      if (b.shortName == targetName) target = b;
+    }
+
+    if (target == null) {
+      return GbmDialogShell(
+        title: 'Rename Branch',
+        actions: <Widget>[
+          GbmButton(label: 'Close', onPressed: () => context.pop()),
+        ],
+        child: Text(
+          targetName.isEmpty
+              ? 'HEAD is detached — there is no branch to rename.'
+              : 'There is no local branch named "$targetName".',
+          style: TextStyle(
+            fontSize: GbmTypography.textSm,
+            color: colors.textPrimary,
+          ),
+        ),
+      );
+    }
+
+    final RefInfo branch = target;
+    if (!_seeded) {
+      _nameController.text = branch.shortName;
+      _seeded = true;
+    }
+
+    // The branch's own name is not a collision -- it is the "未改動" case,
+    // which disables the button without any red text.
+    final List<String> existingNames = session.refs.localBranches
+        .map((RefInfo b) => b.shortName)
+        .where((String name) => name != branch.shortName)
+        .toList(growable: false);
+
+    final String typed = _nameController.text.trim();
+    final String? error = branchNameError(typed, existingNames: existingNames);
+    final bool changed = typed.isNotEmpty && typed != branch.shortName;
+    final bool canRename = changed && error == null;
+
+    // RefInfo.upstream is git's `%(upstream)` -- the tracked ref's *full*
+    // name (refs/remotes/origin/main), not `%(upstream:short)`. Splitting it
+    // on the first slash would yield "refs"; remoteBranchParts() is the
+    // helper that already knows that.
+    final bool hasUpstream =
+        branch.hasTrackingInfo && branch.upstream.isNotEmpty;
+    final (String remote, String remoteBranch) = hasUpstream
+        ? remoteBranchParts(branch.upstream)
+        : ('', '');
+    final bool renameRemote =
+        hasUpstream && _remoteMode == RenameRemoteMode.alsoRenameRemote;
+
+    return GbmDialogShell(
+      title: 'Rename Branch',
+      actions: <Widget>[
+        GbmButton(label: 'Cancel', onPressed: () => context.pop()),
+        const SizedBox(width: GbmSpacing.space2),
+        GbmButton(
+          label: 'Rename',
+          kind: GbmButtonKind.primary,
+          onPressed: canRename
+              ? () {
+                  ref
+                      .read(repoSessionProvider(widget.identity).notifier)
+                      .renameBranch(
+                        from: branch.shortName,
+                        to: typed,
+                        renameRemote: renameRemote,
+                        remoteName: renameRemote ? remote : '',
+                      );
+                  context.pop();
+                }
+              : null,
+        ),
+      ],
+      // GbmDialogShell caps its body's height but does not scroll it, so a
+      // dialog whose content can grow (the remote section and its warning
+      // only appear for a branch with an upstream) scrolls its own body --
+      // the same thing preferences/repository-settings/discard-changes do.
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _Label(text: 'Current name'),
+            const SizedBox(height: GbmSpacing.space1),
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.call_split,
+                  size: GbmTypography.textSm,
+                  color: colors.textSecondary,
+                ),
+                const SizedBox(width: GbmSpacing.space1),
+                Expanded(
+                  child: Text(
+                    branch.shortName,
+                    style: TextStyle(
+                      fontSize: GbmTypography.textSm,
+                      fontFamily: GbmTypography.fontMono,
+                      color: colors.textPrimary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: GbmSpacing.space3),
+            _Label(text: 'New name'),
+            const SizedBox(height: GbmSpacing.space1),
+            TextField(
+              controller: _nameController,
+              autofocus: true,
+              decoration: InputDecoration(
+                hintText: 'New branch name',
+                isDense: true,
+                border: const OutlineInputBorder(),
+                errorText: error,
+              ),
+              // Spec page 13: validation is live, "即時，不等到按 Rename".
+              onChanged: (_) => setState(() {}),
+              onSubmitted: (_) {
+                if (!canRename) return;
+                ref
+                    .read(repoSessionProvider(widget.identity).notifier)
+                    .renameBranch(
+                      from: branch.shortName,
+                      to: typed,
+                      renameRemote: renameRemote,
+                      remoteName: renameRemote ? remote : '',
+                    );
+                context.pop();
+              },
+            ),
+            if (canRename) ...<Widget>[
+              const SizedBox(height: GbmSpacing.space1),
+              Row(
+                children: <Widget>[
+                  Icon(
+                    Icons.check,
+                    size: GbmTypography.textSm,
+                    color: colors.success,
+                  ),
+                  const SizedBox(width: GbmSpacing.space1),
+                  Text(
+                    'Available — no branch by that name.',
+                    style: TextStyle(
+                      fontSize: GbmTypography.textXs,
+                      color: colors.success,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+            if (hasUpstream) ...<Widget>[
+              const SizedBox(height: GbmSpacing.space3),
+              _Label(text: 'Remote handling'),
+              RadioGroup<RenameRemoteMode>(
+                groupValue: _remoteMode,
+                onChanged: (RenameRemoteMode? mode) =>
+                    setState(() => _remoteMode = mode ?? _remoteMode),
+                child: Column(
+                  children: <Widget>[
+                    _RemoteOption(
+                      mode: RenameRemoteMode.alsoRenameRemote,
+                      label: 'Rename the branch on $remote too',
+                      description:
+                          'Pushes the new name, then deletes $remoteBranch on $remote.',
+                    ),
+                    _RemoteOption(
+                      mode: RenameRemoteMode.localOnly,
+                      label: 'Rename locally, keep $remoteBranch on $remote',
+                      description:
+                          'The renamed branch will have no upstream — push it '
+                          'with -u when you want one.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: GbmSpacing.space2),
+              _Warning(
+                text: renameRemote
+                    ? 'Renaming on the remote is a delete plus a push: everyone '
+                          "else's remote-tracking branch for $remoteBranch becomes "
+                          'gone. ${_aheadPhrase(branch)}'
+                    : 'The renamed branch will not have an upstream — you will '
+                          'need to push it with -u again. ${_aheadPhrase(branch)}',
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Ahead is what the refs snapshot actually carries, so it is reported as
+  /// exactly that -- spec page 02 item 11's "永遠顯示實際數字" applies here
+  /// the same way it does in the delete-branch dialog.
+  static String _aheadPhrase(RefInfo branch) => branch.ahead > 0
+      ? 'This branch has ${branch.ahead} commit(s) not yet pushed.'
+      : 'This branch has no unpushed commits.';
+}
+
+class _Label extends StatelessWidget {
+  const _Label({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(
+        fontSize: GbmTypography.textXs,
+        fontWeight: GbmTypography.weightSemibold,
+        color: context.gbmColors.textSecondary,
+      ),
+    );
+  }
+}
+
+class _RemoteOption extends StatelessWidget {
+  const _RemoteOption({
+    required this.mode,
+    required this.label,
+    required this.description,
+  });
+
+  final RenameRemoteMode mode;
+  final String label;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return RadioListTile<RenameRemoteMode>(
+      value: mode,
+      dense: true,
+      contentPadding: EdgeInsets.zero,
+      title: Text(
+        label,
+        style: TextStyle(
+          fontSize: GbmTypography.textSm,
+          color: colors.textPrimary,
+        ),
+      ),
+      subtitle: Text(
+        description,
+        style: TextStyle(
+          fontSize: GbmTypography.textXs,
+          color: colors.textTertiary,
+        ),
+      ),
+    );
+  }
+}
+
+class _Warning extends StatelessWidget {
+  const _Warning({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(
+          Icons.warning_amber_outlined,
+          size: GbmTypography.textSm,
+          color: colors.warning,
+        ),
+        const SizedBox(width: GbmSpacing.space1),
+        Expanded(
+          child: Text(
+            text,
+            style: TextStyle(
+              fontSize: GbmTypography.textXs,
+              color: colors.warning,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -116,17 +116,15 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     );
   }
 
-  Future<void> _renameBranch(RefInfo branch) async {
-    final String? newName = await promptText(
-      context,
-      title: 'Rename Branch',
-      label: 'New name',
-      initialValue: branch.shortName,
+  /// 05-B's "Rename branch". Unlike the Branch menu and F2, this names the
+  /// clicked branch rather than letting the dialog fall back to HEAD.
+  void _renameBranch(RefInfo branch) {
+    context.push(
+      RoutePaths.renameBranchDialogFor(
+        Uri.encodeComponent(widget.identity.workDir),
+        branch: branch.shortName,
+      ),
     );
-    if (newName == null || newName == branch.shortName || !mounted) return;
-    ref
-        .read(repoSessionProvider(widget.identity).notifier)
-        .renameBranch(from: branch.shortName, to: newName);
   }
 
   void _deleteSingle(RefInfo branch) {

--- a/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
@@ -358,10 +358,17 @@ class BranchTreeItem extends StatelessWidget {
           onTap: onNewBranchFromHere!,
         ),
       if (onRename != null)
+        // Spec page 13 keeps rename out of reach mid-sequencer ("分支正在被
+        // rebase / merge 佔用 -> 整個 dialog 不開啟"), and page 07 already
+        // disables every other HEAD-moving action there. Both `enabled` and
+        // `onTap` are set: `enabled` alone is only a visual signal (see
+        // GbmMenuItem's doc comment), `onTap: null` alone would leave a
+        // full-brightness item that silently does nothing.
         GbmMenuItem(
           label: 'Rename branch',
           icon: Icons.edit_outlined,
-          onTap: onRename!,
+          enabled: !conflictActive,
+          onTap: conflictActive ? null : onRename!,
         ),
       if (onMerge != null)
         GbmMenuItem(

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -25,7 +25,6 @@ import '../../theme/gbm_theme.dart';
 import '../../theme/theme_mode_provider.dart';
 import '../../theme/tokens.dart';
 import '../../widgets/gbm_banner.dart';
-import '../../widgets/prompt_text_dialog.dart';
 import '../../widgets/split_pane.dart';
 import '../history_graph/commit_search.dart';
 import '../history_graph/widgets/graph_columns_selector.dart';
@@ -669,9 +668,11 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
           ? () => context.push(RoutePaths.checkoutDialogFor(repoId))
           : null,
       // Detached HEAD (no branch name) or mid-conflict: nothing to rename.
+      // No `branch` query parameter -- the dialog reads HEAD itself, which
+      // is what "the current branch" has to mean for a menu item and F2.
       GbmActionId.branchRenameCurrentBranch:
           isActionEnabled(GbmActionId.branchRenameCurrentBranch, session)
-          ? () => _renameCurrentBranch(context, ref, identity, session)
+          ? () => context.push(RoutePaths.renameBranchDialogFor(repoId))
           : null,
       GbmActionId.branchMergeIntoCurrent:
           isActionEnabled(GbmActionId.branchMergeIntoCurrent, session)
@@ -867,26 +868,6 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
 
   /// Branch → Rename current branch…. Uses the same `promptText` field the
   /// sidebar's own rename uses, so the two entry points behave identically.
-  Future<void> _renameCurrentBranch(
-    BuildContext context,
-    WidgetRef ref,
-    RepoIdentity identity,
-    RepoSessionState session,
-  ) async {
-    final String current = session.refs.head.branchName;
-    if (current.isEmpty) return;
-    final String? newName = await promptText(
-      context,
-      title: 'Rename Branch',
-      label: 'New name',
-      initialValue: current,
-    );
-    if (newName == null || newName == current || !mounted) return;
-    ref
-        .read(repoSessionProvider(identity).notifier)
-        .renameBranch(from: current, to: newName);
-  }
-
   void _handleConflictAbort(
     WidgetRef ref,
     RepoIdentity identity,

--- a/app_flutter/lib/routing/app_router.dart
+++ b/app_flutter/lib/routing/app_router.dart
@@ -37,6 +37,7 @@ import '../features/dialogs/preferences/preferences_dialog.dart';
 import '../features/dialogs/prune_remote_branches/prune_remote_branches_dialog.dart';
 import '../features/dialogs/rebase_onto/rebase_onto_dialog.dart';
 import '../features/dialogs/reflog/reflog_dialog.dart';
+import '../features/dialogs/rename_branch/rename_branch_dialog.dart';
 import '../features/dialogs/repository_settings/repository_settings_dialog.dart';
 import '../features/dialogs/reset_branch/reset_branch_dialog.dart';
 import '../features/dialogs/restore_file/restore_file_dialog.dart';
@@ -409,6 +410,19 @@ final Provider<GoRouter> appRouterProvider = Provider<GoRouter>((ref) {
           );
           final String branch = state.uri.queryParameters['branch'] ?? '';
           return DeleteBranchDialogContent(
+            identity: identity,
+            branchName: branch.isEmpty ? null : branch,
+          );
+        },
+      ),
+      dialogRoute(
+        path: RoutePaths.renameBranchDialog,
+        builder: (context, state) {
+          final RepoIdentity identity = repoIdentityFromRouteParam(
+            state.pathParameters['repoId']!,
+          );
+          final String branch = state.uri.queryParameters['branch'] ?? '';
+          return RenameBranchDialogContent(
             identity: identity,
             branchName: branch.isEmpty ? null : branch,
           );

--- a/app_flutter/lib/routing/route_paths.dart
+++ b/app_flutter/lib/routing/route_paths.dart
@@ -70,6 +70,8 @@ abstract final class RoutePaths {
   static const String checkoutDialog = '/repo/:repoId/dialogs/checkout';
   static const String deleteBranchDialog =
       '/repo/:repoId/dialogs/delete-branch';
+  static const String renameBranchDialog =
+      '/repo/:repoId/dialogs/rename-branch';
   static const String rebaseOntoDialog = '/repo/:repoId/dialogs/rebase-onto';
   static const String forcePushDialog = '/repo/:repoId/dialogs/force-push';
   static const String deleteRemoteBranchDialog =
@@ -171,6 +173,16 @@ abstract final class RoutePaths {
       ).toString();
   static String checkoutDialogFor(String repoId) =>
       '/repo/$repoId/dialogs/checkout';
+
+  /// [branch] empty means "the current branch" -- the Branch menu and F2
+  /// both leave it out; only the 05-B context menu names one.
+  static String renameBranchDialogFor(String repoId, {String branch = ''}) =>
+      Uri(
+        path: '/repo/$repoId/dialogs/rename-branch',
+        queryParameters: branch.isEmpty
+            ? null
+            : <String, String>{'branch': branch},
+      ).toString();
   static String deleteBranchDialogFor(String repoId, {String branch = ''}) =>
       Uri(
         path: '/repo/$repoId/dialogs/delete-branch',

--- a/app_flutter/test/actions/gbm_shortcuts_test.dart
+++ b/app_flutter/test/actions/gbm_shortcuts_test.dart
@@ -5,41 +5,54 @@ import 'package:gbm_flutter/actions/gbm_shortcuts.dart';
 
 void main() {
   group('gbmActionShortcuts', () {
-    test(
-      'macOS shortcuts has exactly 35 entries with meta=true, control=false',
-      () {
-        final shortcuts = gbmActionShortcuts(true);
-        expect(shortcuts.length, 35);
-        for (final shortcut in shortcuts.values) {
-          expect(shortcut.meta, isTrue, reason: 'macOS should use meta=true');
-          expect(
-            shortcut.control,
-            isFalse,
-            reason: 'macOS should use control=false',
-          );
-        }
-      },
-    );
+    // branchRenameCurrentBranch is F2, the MENUS table's only binding with
+    // no Ctrl/Cmd at all, so it is excluded from the "every shortcut carries
+    // the platform modifier" invariant below rather than weakening it for
+    // everything else. Its own modifiers are asserted separately at the end
+    // of this group.
+    const Set<GbmActionId> bareKeyActions = <GbmActionId>{
+      GbmActionId.branchRenameCurrentBranch,
+    };
 
-    test(
-      'non-macOS shortcuts has exactly 35 entries with meta=false, control=true',
-      () {
-        final shortcuts = gbmActionShortcuts(false);
-        expect(shortcuts.length, 35);
-        for (final shortcut in shortcuts.values) {
-          expect(
-            shortcut.meta,
-            isFalse,
-            reason: 'non-macOS should use meta=false',
-          );
-          expect(
-            shortcut.control,
-            isTrue,
-            reason: 'non-macOS should use control=true',
-          );
-        }
-      },
-    );
+    test('macOS shortcuts has exactly 36 entries, and every one but the '
+        'bare-key group uses meta=true, control=false', () {
+      final shortcuts = gbmActionShortcuts(true);
+      expect(shortcuts.length, 36);
+      shortcuts.forEach((id, shortcut) {
+        if (bareKeyActions.contains(id)) return;
+        expect(
+          shortcut.meta,
+          isTrue,
+          reason: '$id: macOS should use meta=true',
+        );
+        expect(
+          shortcut.control,
+          isFalse,
+          reason: '$id: macOS should use control=false',
+        );
+      });
+    });
+
+    test('non-macOS shortcuts has exactly 36 entries, and every one but the '
+        'bare-key group uses meta=false, control=true', () {
+      final shortcuts = gbmActionShortcuts(false);
+      expect(shortcuts.length, 36);
+      for (final MapEntry<GbmActionId, GbmKeyboardShortcut> entry
+          in shortcuts.entries) {
+        if (bareKeyActions.contains(entry.key)) continue;
+        final GbmKeyboardShortcut shortcut = entry.value;
+        expect(
+          shortcut.meta,
+          isFalse,
+          reason: 'non-macOS should use meta=false',
+        );
+        expect(
+          shortcut.control,
+          isTrue,
+          reason: 'non-macOS should use control=true',
+        );
+      }
+    });
 
     test('no two shortcuts produce equal keyboard combinations on macOS', () {
       final shortcuts = gbmActionShortcuts(true);
@@ -91,26 +104,29 @@ void main() {
       expect(shortcutsNonMacOS.containsKey(GbmActionId.fileExit), isFalse);
     });
 
-    test(
-      'branchRenameCurrentBranch is bound to F2, per spec DIALOGS\' Rename '
-      'branch entry (from 05-B -> Rename…) and CTX 05-B\'s own "Rename…" '
-      'key column',
-      () {
-        final shortcuts = gbmActionShortcuts(false);
-        final GbmKeyboardShortcut rename =
-            shortcuts[GbmActionId.branchRenameCurrentBranch]!;
-        expect(rename.trigger, LogicalKeyboardKey.f2);
-      },
-      // Real gap, tracked in docs/reports/spec-conformance-matrix.md
-      // (Page 04, shortcuts table): unlike editFindInFiles and
-      // branchStashChanges (both absent because spec's own MENUS table
-      // double-assigns their key to something else), F2 is not claimed
-      // by any other spec shortcut -- this is a genuine, unexplained
-      // omission, not a spec-internal collision. It also compounds with
-      // the "Rename branch" dialog route being entirely missing (same
-      // matrix page). Remove `skip: true` once F2 is wired to
-      // branchRenameCurrentBranch.
-      skip: true,
-    );
+    test('branchRenameCurrentBranch is bound to F2, per spec DIALOGS\' Rename '
+        'branch entry (from 05-B -> Rename…) and CTX 05-B\'s own "Rename…" '
+        'key column', () {
+      final shortcuts = gbmActionShortcuts(false);
+      final GbmKeyboardShortcut rename =
+          shortcuts[GbmActionId.branchRenameCurrentBranch]!;
+      expect(rename.trigger, LogicalKeyboardKey.f2);
+    });
+
+    test('F2 carries no Ctrl/Cmd on either platform -- the one bare-key '
+        'binding in the MENUS table', () {
+      for (final bool isMacOS in <bool>[true, false]) {
+        final GbmKeyboardShortcut rename = gbmActionShortcuts(
+          isMacOS,
+        )[GbmActionId.branchRenameCurrentBranch]!;
+        expect(rename.control, isFalse, reason: 'isMacOS=$isMacOS');
+        expect(rename.meta, isFalse, reason: 'isMacOS=$isMacOS');
+        expect(rename.shift, isFalse, reason: 'isMacOS=$isMacOS');
+        expect(rename.alt, isFalse, reason: 'isMacOS=$isMacOS');
+        // The shortcuts dialog derives its text from these fields, so a
+        // stray modifier would show up as "Ctrl+F2" there too.
+        expect(rename.displayLabel, 'F2', reason: 'isMacOS=$isMacOS');
+      }
+    });
   });
 }

--- a/app_flutter/test/features/dialogs/branch_name_validation_test.dart
+++ b/app_flutter/test/features/dialogs/branch_name_validation_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/dialogs/branch_name_validation.dart';
+
+/// The rules here are the ones a user hits by accident, not a reimplementation
+/// of `git check-ref-format` -- core still validates before git runs (see
+/// `RefStore::isValidBranchName`). These exist so the button can explain
+/// itself while typing, which is what spec page 13's RENAMEVALID table asks
+/// for ("即時，不等到按 Rename").
+void main() {
+  const List<String> existing = <String>['main', 'feature/lane-allocator'];
+
+  group('branchNameError', () {
+    test('returns null for a name that is free and well-formed', () {
+      expect(branchNameError('feature/new', existingNames: existing), isNull);
+    });
+
+    test('returns null for an empty name so no red text appears while the '
+        'field is still untouched (RENAMEVALID: 空白 -> disabled, 不出現錯誤紅字)', () {
+      expect(branchNameError('', existingNames: existing), isNull);
+      expect(branchNameError('   ', existingNames: existing), isNull);
+    });
+
+    test('names the colliding branch when one already exists', () {
+      final String? error = branchNameError(
+        'feature/lane-allocator',
+        existingNames: existing,
+      );
+      expect(error, isNotNull);
+      expect(error, contains('feature/lane-allocator'));
+    });
+
+    test('trims before comparing, so trailing whitespace still collides', () {
+      expect(branchNameError('main  ', existingNames: existing), isNotNull);
+    });
+
+    test('rejects every character git forbids', () {
+      for (final String name in <String>[
+        'has space',
+        'tilde~',
+        'caret^',
+        'colon:',
+        'question?',
+        'star*',
+        'bracket[',
+        r'backslash\',
+      ]) {
+        expect(
+          branchNameError(name, existingNames: existing),
+          isNotNull,
+          reason: '"$name" should be rejected',
+        );
+      }
+    });
+
+    test('rejects the structural cases git also refuses', () {
+      for (final String name in <String>[
+        '/leading-slash',
+        'trailing-slash/',
+        '.leading-dot',
+        'trailing-dot.',
+        'double..dot',
+        'ends-in.lock',
+      ]) {
+        expect(
+          branchNameError(name, existingNames: existing),
+          isNotNull,
+          reason: '"$name" should be rejected',
+        );
+      }
+    });
+  });
+}

--- a/app_flutter/test/features/dialogs/rename_branch_dialog_test.dart
+++ b/app_flutter/test/features/dialogs/rename_branch_dialog_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/rename_branch/rename_branch_dialog.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+const RepoIdentity _identity = RepoIdentity(
+  workDir: '/tmp/repo',
+  gitDir: '/tmp/repo/.git',
+);
+
+RefInfo _branch(
+  String shortName, {
+  String upstream = '',
+  int ahead = 0,
+  bool isHead = false,
+}) {
+  return RefInfo(
+    fullName: 'refs/heads/$shortName',
+    shortName: shortName,
+    kind: RefKind.localBranch,
+    target: 'a' * 40,
+    upstream: upstream,
+    ahead: ahead,
+    behind: 0,
+    hasTrackingInfo: upstream.isNotEmpty,
+    isGone: false,
+    isHead: isHead,
+    isSymbolic: false,
+    worktreePath: '',
+  );
+}
+
+const WorkingCopyEntry _conflictEntry = WorkingCopyEntry(
+  path: 'lib/main.dart',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+RepoSessionState _sessionWith(
+  List<RefInfo> branches, {
+  String head = 'feature/lane-allocator',
+  bool conflicted = false,
+}) {
+  return RepoSessionState(
+    isOpen: true,
+    refs: RefSnapshot(
+      head: HeadInfo(
+        kind: HeadKind.branch,
+        branchName: head,
+        fullRef: 'refs/heads/$head',
+        target: 'a' * 40,
+      ),
+      refs: branches,
+      refCountGuardTripped: false,
+      totalRefCount: branches.length,
+    ),
+    workingCopyStatus: WorkingCopyStatus(
+      entries: conflicted
+          ? const <WorkingCopyEntry>[_conflictEntry]
+          : const <WorkingCopyEntry>[],
+    ),
+  );
+}
+
+Future<FakeRepoSessionController> _pumpDialog(
+  WidgetTester tester, {
+  required RepoSessionState initialState,
+  String? branchName,
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  final FakeRepoSessionController controller = FakeRepoSessionController(
+    _identity,
+    initialState,
+  );
+
+  // A real router, not a bare `home:` -- the confirm button calls
+  // context.pop(), which only exists once GoRouter is in the tree.
+  final GoRouter router = GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const Scaffold(body: SizedBox.shrink()),
+      ),
+      GoRoute(
+        path: '/dialog',
+        builder: (context, state) => RenameBranchDialogContent(
+          identity: _identity,
+          branchName: branchName,
+        ),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        repoSessionProvider(_identity).overrideWith((ref) => controller),
+      ],
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  router.push('/dialog');
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+/// Finds the Rename button's onPressed, which is null while disabled -- the
+/// signal spec page 13's RENAMEVALID table describes for every invalid case.
+bool _renameEnabled(WidgetTester tester) {
+  final Finder button = find.widgetWithText(InkWell, 'Rename');
+  // Deliberately not defaulting to false when the button cannot be found: a
+  // missing button would otherwise satisfy every `isFalse` assertion below
+  // and turn a real regression into a passing test.
+  expect(button, findsWidgets, reason: 'the Rename button should be rendered');
+  return tester.widget<InkWell>(button.first).onTap != null;
+}
+
+void main() {
+  final List<RefInfo> branches = <RefInfo>[
+    _branch(
+      'feature/lane-allocator',
+      upstream: 'refs/remotes/origin/feature/lane-allocator',
+      ahead: 2,
+      isHead: true,
+    ),
+    _branch('main'),
+  ];
+
+  group('RenameBranchDialogContent', () {
+    testWidgets('seeds the field with the current branch name and shows it '
+        'read-only above (spec P13 A: 目前名稱 / 新名稱)', (tester) async {
+      await _pumpDialog(tester, initialState: _sessionWith(branches));
+
+      expect(find.text('Current name'), findsOneWidget);
+      expect(find.text('New name'), findsOneWidget);
+      final TextField field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'feature/lane-allocator');
+    });
+
+    testWidgets('an unchanged name keeps Rename disabled with no error text '
+        '(RENAMEVALID: 未改動 -> disabled, 不出現錯誤紅字)', (tester) async {
+      await _pumpDialog(tester, initialState: _sessionWith(branches));
+
+      expect(_renameEnabled(tester), isFalse);
+      final TextField field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.decoration!.errorText, isNull);
+    });
+
+    testWidgets('a duplicate name names the branch it collides with and '
+        'disables Rename (RENAMEVALID: 名稱重複)', (tester) async {
+      await _pumpDialog(tester, initialState: _sessionWith(branches));
+
+      await tester.enterText(find.byType(TextField), 'main');
+      await tester.pumpAndSettle();
+
+      final TextField field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.decoration!.errorText, contains('main'));
+      expect(_renameEnabled(tester), isFalse);
+    });
+
+    testWidgets('an illegal character disables Rename '
+        '(RENAMEVALID: 含 git 不允許的字元)', (tester) async {
+      await _pumpDialog(tester, initialState: _sessionWith(branches));
+
+      await tester.enterText(find.byType(TextField), 'has space');
+      await tester.pumpAndSettle();
+
+      final TextField field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.decoration!.errorText, isNotNull);
+      expect(_renameEnabled(tester), isFalse);
+    });
+
+    testWidgets('a valid new name shows the availability line and enables '
+        'Rename', (tester) async {
+      await _pumpDialog(tester, initialState: _sessionWith(branches));
+
+      await tester.enterText(
+        find.byType(TextField),
+        'feature/lane-allocator-v2',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Available'), findsOneWidget);
+      expect(_renameEnabled(tester), isTrue);
+    });
+
+    testWidgets('the default remote choice renames on the remote too, and '
+        'sends the remote name recovered from the full upstream ref', (
+      tester,
+    ) async {
+      final FakeRepoSessionController controller = await _pumpDialog(
+        tester,
+        initialState: _sessionWith(branches),
+      );
+
+      await tester.enterText(
+        find.byType(TextField),
+        'feature/lane-allocator-v2',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand command = controller.commandLog.single;
+      expect(command.name, 'renameBranch');
+      expect(command.args['from'], 'feature/lane-allocator');
+      expect(command.args['to'], 'feature/lane-allocator-v2');
+      expect(command.args['renameRemote'], isTrue);
+      // RefInfo.upstream is `refs/remotes/origin/feature/lane-allocator`;
+      // splitting it on the first slash would send "refs".
+      expect(command.args['remoteName'], 'origin');
+    });
+
+    testWidgets('choosing local-only sends renameRemote false and no remote '
+        'name (spec P13: 只改本地，upstream 會清空)', (tester) async {
+      final FakeRepoSessionController controller = await _pumpDialog(
+        tester,
+        initialState: _sessionWith(branches),
+      );
+
+      await tester.enterText(
+        find.byType(TextField),
+        'feature/lane-allocator-v2',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.textContaining('Rename locally'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand command = controller.commandLog.single;
+      expect(command.args['renameRemote'], isFalse);
+      expect(command.args['remoteName'], '');
+    });
+
+    testWidgets('a branch with no upstream offers no remote choice at all', (
+      tester,
+    ) async {
+      final FakeRepoSessionController controller = await _pumpDialog(
+        tester,
+        initialState: _sessionWith(<RefInfo>[
+          _branch('local-only', isHead: true),
+        ], head: 'local-only'),
+      );
+
+      expect(find.text('Remote handling'), findsNothing);
+
+      await tester.enterText(find.byType(TextField), 'renamed');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+
+      expect(controller.commandLog.single.args['renameRemote'], isFalse);
+    });
+
+    testWidgets('the warning reports the real unpushed commit count', (
+      tester,
+    ) async {
+      await _pumpDialog(tester, initialState: _sessionWith(branches));
+
+      expect(find.textContaining('2 commit(s) not yet pushed'), findsOneWidget);
+    });
+
+    testWidgets('renames the branch named by the route, not the current one', (
+      tester,
+    ) async {
+      final FakeRepoSessionController controller = await _pumpDialog(
+        tester,
+        initialState: _sessionWith(branches),
+        branchName: 'main',
+      );
+
+      final TextField field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'main');
+
+      await tester.enterText(find.byType(TextField), 'trunk');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+
+      expect(controller.commandLog.single.args['from'], 'main');
+    });
+
+    testWidgets('mid-conflict the dialog refuses to offer a rename at all '
+        '(RENAMEVALID: 分支正在被 rebase / merge 佔用)', (tester) async {
+      final FakeRepoSessionController controller = await _pumpDialog(
+        tester,
+        initialState: _sessionWith(branches, conflicted: true),
+      );
+
+      // No name field and no destructive button -- only a way out, the same
+      // shape the discard-changes dialog uses for a request it cannot honour.
+      expect(find.byType(TextField), findsNothing);
+      expect(find.text('Rename'), findsNothing);
+      expect(find.text('Close'), findsOneWidget);
+      expect(controller.commandLog, isEmpty);
+    });
+  });
+}

--- a/app_flutter/test/features/dialogs/rename_branch_dialog_test.dart
+++ b/app_flutter/test/features/dialogs/rename_branch_dialog_test.dart
@@ -19,11 +19,17 @@ const RepoIdentity _identity = RepoIdentity(
   gitDir: '/tmp/repo/.git',
 );
 
+/// [hasTrackingInfo] defaults to "there is an upstream", but the two are
+/// **not** the same thing and a test may need them apart: `hasTrackingInfo`
+/// mirrors git's `%(upstream:track)`, which is *empty* for a branch exactly
+/// in sync with its upstream, while `%(upstream)` is still populated. See
+/// the "synced branch" test below for why that distinction has teeth.
 RefInfo _branch(
   String shortName, {
   String upstream = '',
   int ahead = 0,
   bool isHead = false,
+  bool? hasTrackingInfo,
 }) {
   return RefInfo(
     fullName: 'refs/heads/$shortName',
@@ -33,7 +39,7 @@ RefInfo _branch(
     upstream: upstream,
     ahead: ahead,
     behind: 0,
-    hasTrackingInfo: upstream.isNotEmpty,
+    hasTrackingInfo: hasTrackingInfo ?? upstream.isNotEmpty,
     isGone: false,
     isHead: isHead,
     isSymbolic: false,
@@ -280,6 +286,42 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.commandLog.single.args['renameRemote'], isFalse);
+    });
+
+    testWidgets('a branch in sync with its upstream still offers the remote '
+        'choice -- %(upstream:track) is empty when 0 ahead / 0 behind', (
+      tester,
+    ) async {
+      // Found by the device-tier run (integration_test/
+      // rename_branch_flow_test.dart), not by reading: git reports an
+      // *empty* `%(upstream:track)` for a branch exactly in sync, so
+      // RefInfo.hasTrackingInfo is false while RefInfo.upstream is still
+      // `refs/remotes/origin/feature`. Gating the remote section on
+      // hasTrackingInfo therefore hid it for the single most common case --
+      // a freshly-pushed branch -- and silently downgraded the rename to
+      // local-only with no way for the user to notice.
+      final FakeRepoSessionController controller = await _pumpDialog(
+        tester,
+        initialState: _sessionWith(<RefInfo>[
+          _branch(
+            'synced',
+            upstream: 'refs/remotes/origin/synced',
+            hasTrackingInfo: false,
+            isHead: true,
+          ),
+        ], head: 'synced'),
+      );
+
+      expect(find.text('Remote handling'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'synced-v2');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+
+      final FakeCommand command = controller.commandLog.single;
+      expect(command.args['renameRemote'], isTrue);
+      expect(command.args['remoteName'], 'origin');
     });
 
     testWidgets('the warning reports the real unpushed commit count', (

--- a/app_flutter/test/features/sidebar/branch_context_menu_test.dart
+++ b/app_flutter/test/features/sidebar/branch_context_menu_test.dart
@@ -161,6 +161,54 @@ void main() {
     expect(find.text('Rename branch'), findsNothing);
   });
 
+  group('conflict gate on Rename branch (spec P13: "分支正在被 rebase/merge '
+      '佔用 -> 整個 dialog 不開啟")', () {
+    testWidgets('renders dimmed while a sequencer operation is active', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _branch(),
+          conflictActive: true,
+          onCheckout: () {},
+          onRename: () {},
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      final Text label = tester.widget<Text>(find.text('Rename branch'));
+      expect(
+        label.style?.color,
+        tokensFor(GbmThemeVariant.darkTechnical).textTertiary,
+      );
+    });
+
+    testWidgets('tapping it mid-conflict does not invoke onRename', (
+      tester,
+    ) async {
+      bool renamed = false;
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _branch(),
+          conflictActive: true,
+          onCheckout: () {},
+          onRename: () => renamed = true,
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+      await tester.tap(find.text('Rename branch'));
+      await tester.pumpAndSettle();
+      expect(
+        renamed,
+        isFalse,
+        reason:
+            'onTap must be null too -- `enabled: false` alone would leave a '
+            'dimmed item that still fires.',
+      );
+    });
+  });
+
   group('remote-only row (05-C)', () {
     testWidgets(
       'shows the 05-C remote-only subset, not the 05-B local-branch menu',

--- a/app_flutter/test/integration/workspace_rename_branch_flow_test.dart
+++ b/app_flutter/test/integration/workspace_rename_branch_flow_test.dart
@@ -1,0 +1,233 @@
+// Integration coverage for issue #45's dispatch seam: F2 / Branch → Rename
+// branch… -> the real WorkspaceScreen handler map -> the rename-branch route
+// -> RenameBranchDialogContent -> RepoSessionController.renameBranch().
+//
+// The widget-tier test (test/features/dialogs/rename_branch_dialog_test.dart)
+// pumps the dialog directly, so it cannot see whether anything actually
+// reaches it -- which is exactly the shape of bug CLAUDE.md's "Intent /
+// Action layer" section documents (a handler wired to null in
+// _buildActionHandlers() while the in-window menu still appeared to work).
+// F2 is the most exposed of the three entry points: it has no visible
+// affordance at all, so a broken binding is silent.
+//
+// The dialog is registered via `topLevelRoutes`, not `extraRoutes`: dialog
+// routes are siblings of the workspace ShellRoute, not children of it.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/models/repo_state.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/rename_branch/rename_branch_dialog.dart';
+import 'package:gbm_flutter/routing/dialog_route.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:go_router/go_router.dart';
+
+import '../support/fake_repo_session.dart';
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/repo',
+  gitDir: '/test/repo/.git',
+);
+
+RepoState _mergeState() => const RepoState(
+  flags: RepoStateFlags.merge,
+  isClean: false,
+  isSequencerOperation: true,
+  rebaseStep: 0,
+  rebaseTotal: 0,
+  rebaseOntoLabel: '',
+  indexLocked: false,
+  indexLockAgeSeconds: null,
+  describe: '',
+);
+
+const WorkingCopyEntry _conflictEntry = WorkingCopyEntry(
+  path: 'conflict.txt',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+const RefInfo _mainBranch = RefInfo(
+  fullName: 'refs/heads/main',
+  shortName: 'main',
+  kind: RefKind.localBranch,
+  target: 'deadbeef',
+  upstream: 'refs/remotes/origin/main',
+  ahead: 1,
+  behind: 0,
+  hasTrackingInfo: true,
+  isGone: false,
+  isHead: true,
+  isSymbolic: false,
+  worktreePath: '',
+);
+
+final RefSnapshot _refs = const RefSnapshot(
+  head: HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: 'deadbeef',
+  ),
+  refs: <RefInfo>[_mainBranch],
+  refCountGuardTripped: false,
+  totalRefCount: 1,
+);
+
+RepoSessionState _cleanSession() => RepoSessionState(isOpen: true, refs: _refs);
+
+RepoSessionState _conflictSession() => RepoSessionState(
+  isOpen: true,
+  refs: _refs,
+  repoState: _mergeState(),
+  workingCopyStatus: const WorkingCopyStatus(
+    entries: <WorkingCopyEntry>[_conflictEntry],
+  ),
+);
+
+/// The real dialog behind the real route, not a placeholder: the point of
+/// this tier is that the whole chain works, and a placeholder would not
+/// prove the route's `branch` query parameter reaches the dialog.
+List<RouteBase> _renameDialogRoute() => <RouteBase>[
+  dialogRoute(
+    path: RoutePaths.renameBranchDialog,
+    builder: (context, state) => RenameBranchDialogContent(
+      identity: _identity,
+      branchName: state.uri.queryParameters['branch']?.isEmpty ?? true
+          ? null
+          : state.uri.queryParameters['branch'],
+    ),
+  ),
+];
+
+Future<void> _pressF2(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.f2);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.f2);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('rename branch flow', () {
+    testWidgets('F2 opens the rename dialog seeded with the current branch', (
+      tester,
+    ) async {
+      await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _cleanSession(),
+        topLevelRoutes: _renameDialogRoute(),
+      );
+
+      expect(find.byType(RenameBranchDialogContent), findsNothing);
+
+      await _pressF2(tester);
+
+      expect(find.byType(RenameBranchDialogContent), findsOneWidget);
+      // The dialog is a non-opaque overlay, so the workspace (and its own
+      // sidebar filter TextField) stays mounted underneath -- scope the
+      // field lookup to the dialog rather than using find.byType(TextField).
+      final Finder nameField = find.descendant(
+        of: find.byType(RenameBranchDialogContent),
+        matching: find.byType(TextField),
+      );
+      expect(tester.widget<TextField>(nameField).controller!.text, 'main');
+    });
+
+    testWidgets('confirming in the dialog reaches renameBranch on the real '
+        'controller', (tester) async {
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _cleanSession(),
+        topLevelRoutes: _renameDialogRoute(),
+      );
+
+      await _pressF2(tester);
+
+      final Finder nameField = find.descendant(
+        of: find.byType(RenameBranchDialogContent),
+        matching: find.byType(TextField),
+      );
+      await tester.enterText(nameField, 'trunk');
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(RenameBranchDialogContent),
+          matching: find.text('Rename'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final Iterable<FakeCommand> renames = pumped.controller.commandLog.where(
+        (FakeCommand c) => c.name == 'renameBranch',
+      );
+      expect(renames, hasLength(1));
+      expect(renames.single.args['from'], 'main');
+      expect(renames.single.args['to'], 'trunk');
+      // main tracks refs/remotes/origin/main, so the default choice carries
+      // the rename to the remote.
+      expect(renames.single.args['renameRemote'], isTrue);
+      expect(renames.single.args['remoteName'], 'origin');
+
+      // The dialog dispatches and pops rather than waiting (spec page 10:
+      // progress belongs to the background-task row, "不留在 dialog 裡轉圈").
+      expect(find.byType(RenameBranchDialogContent), findsNothing);
+    });
+
+    testWidgets('mid-conflict F2 opens nothing at all', (tester) async {
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflictSession(),
+        topLevelRoutes: _renameDialogRoute(),
+      );
+
+      await _pressF2(tester);
+
+      expect(find.byType(RenameBranchDialogContent), findsNothing);
+      expect(
+        pumped.controller.commandLog.where(
+          (FakeCommand c) => c.name == 'renameBranch',
+        ),
+        isEmpty,
+      );
+    });
+
+    testWidgets('conflict -> clean round-trip: F2 works again once the '
+        'conflict is resolved, with no residue from the blocked attempt', (
+      tester,
+    ) async {
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflictSession(),
+        topLevelRoutes: _renameDialogRoute(),
+      );
+
+      await _pressF2(tester);
+      expect(find.byType(RenameBranchDialogContent), findsNothing);
+
+      pumped.controller.emit(_cleanSession());
+      await tester.pumpAndSettle();
+
+      await _pressF2(tester);
+      expect(find.byType(RenameBranchDialogContent), findsOneWidget);
+    });
+  });
+}

--- a/app_flutter/test/integration/workspace_rename_branch_flow_test.dart
+++ b/app_flutter/test/integration/workspace_rename_branch_flow_test.dart
@@ -12,6 +12,7 @@
 //
 // The dialog is registered via `topLevelRoutes`, not `extraRoutes`: dialog
 // routes are siblings of the workspace ShellRoute, not children of it.
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,6 +22,7 @@ import 'package:gbm_flutter/data/models/working_copy_status.dart';
 import 'package:gbm_flutter/data/repositories/repo_identity.dart';
 import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
 import 'package:gbm_flutter/features/dialogs/rename_branch/rename_branch_dialog.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/branch_tree_item.dart';
 import 'package:gbm_flutter/routing/dialog_route.dart';
 import 'package:gbm_flutter/routing/route_paths.dart';
 import 'package:go_router/go_router.dart';
@@ -118,6 +120,20 @@ List<RouteBase> _renameDialogRoute() => <RouteBase>[
 Future<void> _pressF2(WidgetTester tester) async {
   await tester.sendKeyDownEvent(LogicalKeyboardKey.f2);
   await tester.sendKeyUpEvent(LogicalKeyboardKey.f2);
+  await tester.pumpAndSettle();
+}
+
+/// The sidebar's own entry point (05-B "Rename branch"). Right-click is not
+/// reachable through `tester.tap`, so this mirrors
+/// branch_context_menu_test.dart's `_rightClick`.
+Future<void> _openBranchMenu(WidgetTester tester) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(find.byType(BranchTreeItem).first));
+  await gesture.up();
   await tester.pumpAndSettle();
 }
 
@@ -227,6 +243,64 @@ void main() {
       await tester.pumpAndSettle();
 
       await _pressF2(tester);
+      expect(find.byType(RenameBranchDialogContent), findsOneWidget);
+    });
+
+    // The sidebar entry is the one of the three that dispatches by
+    // *navigation* rather than by a session command, so
+    // FakeRepoSessionController.commandLog cannot see it regress -- these
+    // assert on the dialog's presence instead. Its conflict gate is also the
+    // only one not routed through isActionEnabled(): BranchTreeItem takes a
+    // plain `conflictActive` param, so it needs its own transition coverage
+    // per CLAUDE.md's rule at the end of "Action availability state machine".
+    testWidgets('the sidebar\'s 05-B Rename branch opens the dialog seeded '
+        'with the clicked branch', (tester) async {
+      await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _cleanSession(),
+        topLevelRoutes: _renameDialogRoute(),
+      );
+
+      await _openBranchMenu(tester);
+      await tester.tap(find.text('Rename branch'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RenameBranchDialogContent), findsOneWidget);
+      final Finder nameField = find.descendant(
+        of: find.byType(RenameBranchDialogContent),
+        matching: find.byType(TextField),
+      );
+      expect(tester.widget<TextField>(nameField).controller!.text, 'main');
+    });
+
+    testWidgets('mid-conflict the sidebar\'s Rename branch is inert, and '
+        'recovers on the round trip back to clean', (tester) async {
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflictSession(),
+        topLevelRoutes: _renameDialogRoute(),
+      );
+
+      await _openBranchMenu(tester);
+      await tester.tap(find.text('Rename branch'));
+      await tester.pumpAndSettle();
+      expect(
+        find.byType(RenameBranchDialogContent),
+        findsNothing,
+        reason:
+            'SidebarPanel must pass conflictActive down so BranchTreeItem '
+            'nulls the Rename onTap, matching the menu and F2 paths that go '
+            'through isActionEnabled().',
+      );
+
+      pumped.controller.emit(_cleanSession());
+      await tester.pumpAndSettle();
+
+      await _openBranchMenu(tester);
+      await tester.tap(find.text('Rename branch'));
+      await tester.pumpAndSettle();
       expect(find.byType(RenameBranchDialogContent), findsOneWidget);
     });
   });

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -402,9 +402,17 @@ class FakeRepoSessionController extends RepoSessionController {
     required String from,
     required String to,
     bool force = false,
+    bool renameRemote = false,
+    String remoteName = '',
   }) {
     commandLog.add(
-      FakeCommand('renameBranch', <String, Object?>{'from': from, 'to': to}),
+      FakeCommand('renameBranch', <String, Object?>{
+        'from': from,
+        'to': to,
+        'force': force,
+        'renameRemote': renameRemote,
+        'remoteName': remoteName,
+      }),
     );
   }
 

--- a/docs/reports/spec-conformance-matrix.md
+++ b/docs/reports/spec-conformance-matrix.md
@@ -60,7 +60,7 @@ audit time**. P16's `REVISIONS` changes two things about this paragraph:
   單", so binding it before the multi-select work (#54) lands would give
   it nothing to select. Sequence it after, not before.
 
-**Keyboard shortcuts (`gbmActionShortcuts()`, 35/52 ids bound):**
+**Keyboard shortcuts (`gbmActionShortcuts()`, 36/52 ids bound — 35/52 at audit time; F2 is the one added since, see the rename row below):**
 
 | Spec item | Verdict | Evidence | Reason |
 |---|---|---|---|

--- a/docs/reports/spec-conformance-matrix.md
+++ b/docs/reports/spec-conformance-matrix.md
@@ -34,14 +34,31 @@ This report is descriptive only — no fixes are applied here. See
 
 ## Page 04 — Menu bar & shortcuts (`gbm_menu_model.dart`, `gbm_shortcuts.dart`)
 
-**Menu bar (`gbmMenus`, 7 menus, 52 items):** matches spec's MENUS table
-verbatim across all 7 menus (File 8 / Edit 8 / View 11 / Repository 10 /
-Branch 7 / Remote 4 / Help 4). The one addition —
-`repositoryStageSelectedLines` ("Stage selected lines") — is not in the
-page-04 MENUS table, but the spec's own page-03 prose (SCOPES row 7 / P3
-item 5) names `Repository → Stage selected lines`, so this is the spec's
-own table missing a row it documents elsewhere, not an app-side addition.
-**符合** (spec-internal inconsistency, code sides with the prose).
+**Menu bar (`gbmMenus`, 7 menus, 52 items) (260820 修訂):** matches spec's
+MENUS table verbatim across all 7 menus (File 8 / Edit 8 / View 11 /
+Repository 10 / Branch 7 / Remote 4 / Help 4) **as that table stood at
+audit time**. P16's `REVISIONS` changes two things about this paragraph:
+
+- **`Stage selected lines` is no longer an app-side addition.** It was
+  logged here as "the spec's own table missing a row it documents
+  elsewhere" (page-03 prose, SCOPES row 7 / P3 item 5), with the verdict
+  **符合** on the grounds that the code sided with the prose. REVISIONS
+  now puts it *in* the MENUS table — "已加入 Repository 選單" — so the
+  spec-internal inconsistency is resolved in the code's favour and the
+  item itself stays 符合. But the same revision assigns it
+  **`Ctrl/Cmd+Alt+S`**, and `gbm_shortcuts.dart` binds it to
+  `Ctrl/Cmd+Shift+Enter` (the shift group's `LogicalKeyboardKey.enter`
+  entry). That is a **real shortcut mismatch** that did not exist when
+  this row was written — the audit had no shortcut to compare against.
+  **措辭不符** on the binding. Not fixed in the Tier 0c PR; needs its own
+  issue alongside the other two shortcut rows below.
+- **`Edit → Select all` is missing entirely.** REVISIONS adds it with
+  `Ctrl/Cmd+A` ("搭 P13 多選"), so the Edit menu should now have 9 items
+  and the app-wide total 53, not 52. `gbmMenus`' Edit menu has 8 and no
+  `editSelectAll` id exists in `GbmActionId`. **缺少** — and note it is
+  not independent of P13: `Ctrl/Cmd+A` is also `MULTIKEYS`' "全選當前清
+  單", so binding it before the multi-select work (#54) lands would give
+  it nothing to select. Sequence it after, not before.
 
 **Keyboard shortcuts (`gbmActionShortcuts()`, 35/52 ids bound):**
 
@@ -203,14 +220,25 @@ tab when opened — nothing else. The actual `TabRow` widget also renders:
 Per this audit's scope rule, this is the single largest source of
 "functionality beyond spec, but through a non-conforming entry point."
 
-### F-B. Log panel has two competing implementations
+### F-B. Log panel has two competing implementations (260820 修訂 — verdict hardened)
 
 Spec page 10 defines Log as a bottom drawer (`main.log` splitter,
 draggable height, zero space when collapsed). The code has both
 `lib/features/log_drawer/` (matches the spec) and a separate
 `operationLogDialog` modal route, reachable only from `_MoreMenu`. Same
-concept, two surfaces — full detail pending the page-10 discovery pass
-below.
+concept, two surfaces — full detail in the page-10 pass below.
+
+**P16's REVISIONS settles which one is wrong.** At audit time this was
+logged as an ambiguity: the spec described a drawer, the app had both, and
+nothing said the dialog was forbidden. REVISIONS now states it outright —
+「只留抽屜；**operation-log dialog 從規格中刪除**（LOGRULES 新增「只有一
+套」一列）」. So this is no longer "two implementations of one concept,
+pick a winner" but a **named removal**: `operationLogDialog`, its route
+constant, its `_MoreMenu` entry and `features/operation_log/` are now
+非規格內容 and should go, with the drawer keeping the feature. That also
+answers the open question tracked on **#61**, which was waiting for
+exactly this ruling. Not acted on in the Tier 0c PR (scoped to rename);
+deleting a live route is its own change with its own tests.
 
 ---
 
@@ -414,7 +442,9 @@ independent problems:
 3. **F-A**: `tab_row.dart`'s 18-item overflow menu is a spec-unsanctioned
    third entry surface for otherwise-legitimate features.
 4. **F-B**: the Log drawer and Operation Log dialog are two competing
-   implementations of the same spec concept.
+   implementations of the same spec concept — and as of 260820 this is no
+   longer a judgement call: P16's REVISIONS deletes the dialog from the
+   spec by name and keeps the drawer (see F-B above, and #61).
 5. Preferences (page 11) has 5 gaps that are all "field exists in the
    data model / backing repository, but no UI surfaces it yet" — the
    cheapest category to close.

--- a/docs/reports/spec-conformance-matrix.md
+++ b/docs/reports/spec-conformance-matrix.md
@@ -18,6 +18,18 @@ already-documented absence (see CLAUDE.md's Known gaps).
 This report is descriptive only — no fixes are applied here. See
 `docs/reports/code-review-2026-08.md` for the accompanying code review.
 
+> **Audit baseline moved on 260820 (commit `fc3bfb3`).** The spec this
+> matrix was written against had 12 pages; it now has 16. Four pages were
+> added — **P13** Branch rename dialog + branch/commit multi-select, **P14**
+> entry-point IA for the 24 already-shipped advanced screens, **P15** empty
+> states and error windows, **P16** the revision log itself — and P16's
+> `REVISIONS` table also *changes* rules the rows below were judged against.
+> Rows affected by that table are corrected in place and marked
+> "(260820 修訂)"; the four new pages are **not** audited here. Anything
+> below without that marker was judged against the original 12 pages and
+> may have drifted. See the Tier 0c PR for the rename rows, which are the
+> only ones this round implemented.
+
 ---
 
 ## Page 04 — Menu bar & shortcuts (`gbm_menu_model.dart`, `gbm_shortcuts.dart`)
@@ -35,9 +47,9 @@ own table missing a row it documents elsewhere, not an app-side addition.
 
 | Spec item | Verdict | Evidence | Reason |
 |---|---|---|---|
-| Edit → Find in files, `Ctrl/Cmd+Shift+F` | 缺少 (spec-internal collision) | `gbm_shortcuts.dart` has no `editFindInFiles` entry | Spec's own MENUS table assigns `Ctrl/Cmd+Shift+F` to BOTH "Find in files" and "Repository → Fetch". Code kept `repositoryFetch`'s binding and left `editFindInFiles` unbound. Classification: spec defect, not a code bug — but flag for spec authors. |
-| Branch → Stash changes, `Ctrl/Cmd+Shift+T` | 缺少 (spec-internal collision) | `gbm_shortcuts.dart` has no `branchStashChanges` entry | Same pattern: spec's MENUS table assigns `Ctrl/Cmd+Shift+T` to BOTH "View → File list as tree" and "Branch → Stash changes". Code kept `viewFileListAsTree`. |
-| Branch → Rename current branch…, `F2` (from DIALOGS table + CTX 05-B) | **缺少 (real gap)** | `gbm_shortcuts.dart` has no `branchRenameCurrentBranch` entry; `F2` is otherwise unused — no collision excuse | Compounds with the missing dialog route below (page 06). This is the one shortcut gap that is NOT explained by a spec-internal collision. Classification **(i)** — action id and presumably a rename capi call already exist; only wiring is missing. |
+| Edit → Find in files, `Ctrl/Cmd+Shift+H` (260820 修訂) | **缺少** | `gbm_shortcuts.dart` has no `editFindInFiles` entry | Originally logged as a spec defect: the 12-page MENUS table assigned `Ctrl/Cmd+Shift+F` to BOTH "Find in files" and "Repository → Fetch", so the code kept `repositoryFetch` and left this unbound. **P16's REVISIONS resolves it** — Fetch keeps `Shift+F` ("工具列 F / P / P 三顆同組，不能拆") and Find in files moves to `Ctrl/Cmd+Shift+H`. The collision excuse is therefore gone; this is now an ordinary unbound shortcut. Not fixed in the Tier 0c PR (which scoped itself to rename) — needs its own issue. |
+| Branch → Stash changes, `Ctrl/Cmd+Shift+S` (260820 修訂) | **缺少** | `gbm_shortcuts.dart` has no `branchStashChanges` entry | Same story: the original table double-assigned `Ctrl/Cmd+Shift+T` to both this and "View → File list as tree", and the code kept the latter. **P16's REVISIONS moves Stash changes to `Ctrl/Cmd+Shift+S`** and keeps `Shift+T` for the tree toggle. Note `Ctrl/Cmd+Shift+S` is currently bound to `repositoryStageAll` here, so honouring the revision means re-deciding that binding, not just adding one. Needs its own issue. |
+| Branch → Rename branch…, `F2` (from DIALOGS table + CTX 05-B) | **符合** (fixed, Tier 0c) | `gbm_shortcuts.dart`'s bare-key group | Was the one shortcut gap not explained by a spec-internal collision, and it compounded with the missing dialog route below. Now bound, as the only entry in the map with no Ctrl/Cmd at all — it is constructed directly rather than through `_makeShortcut()`, which always adds one. P16's REVISIONS confirms the binding ("Branch → Rename branch… = F2"). Label also corrected from `Rename current branch…` to spec's `Rename branch…`. |
 | File → Exit, `Alt+F4 / Cmd+Q` | 符合 (by design) | `gbm_shortcuts.dart:103-104` doc comment; no `fileExit` entry | Correctly left out of the app's `Shortcuts`/`Actions` binding — these are OS-native window-close accelerators, not something the Flutter shortcut layer should intercept. |
 | Context-menu-scoped keys (Space/F2/Ctrl+Enter for file actions; Alt+Left/Right/↓, Ctrl/Cmd+↑/↓/Z for the conflict window) | 待查 | — | These are architecturally separate from the global 52-id map (bound locally at the widget that owns that context). Verification folded into pages 03/08 below. |
 
@@ -119,7 +131,7 @@ audit's plan flagged going in.
 | Switch repository | 符合 | `repo_switcher_popover.dart` | Correctly a popover, not a modal dialog — matches spec's own note that this is deliberately lightweight, not one of the 33 modal dialog routes. |
 | Clone repository | 符合 (documented gap, iii) | — | Already recorded in CLAUDE.md: no `git init`/clone capi entry point exists; File → Clone repository… stays disabled by design. |
 | New branch | 符合 | `route_paths.dart: newBranchDialog` | Route exists. |
-| **Rename branch** | **缺少 (real gap)** | `route_paths.dart` has no rename-branch route among its ~36 dialog constants | Spec's DIALOGS table names this dialog explicitly (from 05-B → Rename…, key F2). `GbmActionId.branchRenameCurrentBranch` exists as an action id but has no dialog to open and no shortcut (see page 04 above) — the whole feature has zero conforming entry points despite the enum id existing. Classification **(i)** — `gbm_branch_rename` exists in capi; only the Flutter dialog + route are missing. |
+| **Rename branch** | **符合** (fixed, Tier 0c) | `RoutePaths.renameBranchDialog`, `features/dialogs/rename_branch/` | Built against **P13 section A**, the design added on 260820 — which is why this was deliberately deferred in Tier 0 rather than built blind (see issue #45's history). All three spec entry points now reach it: 05-B context menu (naming the clicked branch), Branch menu, and F2 (both falling back to HEAD). The classification was optimistic: `gbm_branch_rename` did exist, but P13's "遠端連帶處理" needed it extended with `renameRemote`/`remoteName`/`askpassDir` plus a `--unset-upstream` step, since `git branch -m` carries tracking config across. |
 | Delete branch | 符合 | `deleteBranchDialog` | — |
 | Checkout | 符合 | `checkoutDialog` | — |
 | Merge | 符合 | `mergeDialog` | — |
@@ -133,7 +145,8 @@ audit's plan flagged going in.
 | Repository settings | 符合 | `repositorySettingsDialog` | — |
 | Preferences | 符合 | `preferencesDialog` | — |
 
-**14/16 present, 1 real gap (Rename branch), 1 documented absence (Clone).**
+**15/16 present, 1 documented absence (Clone).** Rename branch was the one
+real gap and is fixed (Tier 0c).
 
 ### Dialogs beyond the spec's 16 — entry-point audit
 
@@ -310,7 +323,7 @@ confirmed in `tokens.dart:543-544`. **11/11 符合.**
 | 4 | Log drawer (draggable height, zero when collapsed, filter/copy/save) | 符合 | `log_drawer.dart:20-70` | — |
 | 5 | Error DIALOG window (Esc closes, next-action button, duplicate→counter) | **缺少 — confirmed** | `workspace_screen.dart:297-316` | Errors surface as an inline, persistent `GbmWarningBanner` (`if (session.lastError case final error? when error.codeName != 'Conflict')`), not a modal dialog window. This does satisfy the spec's *intent* ("no auto-dismissing toast — must stay until the user has seen it") but not the *mechanism* — there is no dialog with a "what failed / why / raw git output (collapsed, monospace)" 3-section layout, no primary-button-as-next-action, and no repeated-error counter (searched for and found no such field). Classification **(i)** — the underlying `GitError` model already carries the needed fields (per `git_error.dart`); this is a missing dialog widget, not a missing data path. |
 
-**Additional finding — LOGRULES retention number:** spec says "記憶體中保留最近 2,000 筆" (in-memory keeps last 2,000 entries). Code caps `operationLog` at `_kMaxOperationLogEntries = 500` (`repo_session_repository.dart:243`). **措辭不符/缺少** — the retention mechanism (cap + sublist eviction) is correctly implemented, but the number is 500, not 2,000.
+**Additional finding — LOGRULES retention number (260820 修訂):** originally logged as a mismatch — spec said "記憶體中保留最近 2,000 筆" while the code capped `operationLog` at 500. **P16's REVISIONS reverses the direction**: the default is now 500 with Preferences able to raise it to 2,000 ("預設 500，Preferences 可調到 2,000"), which is what Tier 0h already built (the cap reads `AppPreferences.logMemoryLimit`). **符合** — no longer a gap; the spec moved to the code, not the other way round.
 
 ---
 

--- a/src/capi/Branches.cpp
+++ b/src/capi/Branches.cpp
@@ -63,11 +63,15 @@ GBM_API void gbm_branch_create(GbmSessionHandle session,
 GBM_API void gbm_branch_rename(GbmSessionHandle session,
                                const char* from,
                                const char* to,
-                               int32_t force) {
+                               int32_t force,
+                               int32_t renameRemote,
+                               const char* remoteName) {
     RenameBranchRequest request;
     request.from = from != nullptr ? from : "";
     request.to = to != nullptr ? to : "";
     request.force = force != 0;
+    request.renameRemote = renameRemote != 0;
+    request.remoteName = remoteName != nullptr ? remoteName : "";
 
     toSession(session)->renameBranch(std::move(request));
 }

--- a/src/capi/Session.cpp
+++ b/src/capi/Session.cpp
@@ -284,8 +284,17 @@ void Session::createBranch(CreateBranchRequest request) {
 }
 
 void Session::renameBranch(RenameBranchRequest request) {
-    submitOperation(makeRenameBranchOperation(std::move(request)),
-                    /*refreshHistoryOnSuccess=*/true);
+    // Only the remote half can prompt for credentials, so only it needs the
+    // askpass watch -- same conditional as deleteTag() below.
+    const bool needsAskpass = request.renameRemote;
+    if (needsAskpass) {
+        request.askpassDir = beginAskpass();
+    }
+    submitOperation(
+        makeRenameBranchOperation(std::move(request)),
+        /*refreshHistoryOnSuccess=*/true,
+        /*onSuccess=*/nullptr,
+        /*onAlways=*/needsAskpass ? std::function<void()>([this]() { endAskpass(); }) : nullptr);
 }
 
 void Session::deleteBranch(DeleteBranchRequest request) {

--- a/src/capi/Session.cpp
+++ b/src/capi/Session.cpp
@@ -429,14 +429,20 @@ void Session::commitChanges(CommitRequest request) {
 
 void Session::submitOperation(std::unique_ptr<Operation> operation,
                               bool refreshHistoryOnSuccess,
-                              std::function<void()> onSuccess) {
+                              std::function<void()> onSuccess,
+                              std::function<void()> onAlways) {
     operations_->submit(std::move(operation),
-                        [this, refreshHistoryOnSuccess, onSuccess = std::move(onSuccess)](
-                            OperationOutcome outcome) {
+                        [this,
+                         refreshHistoryOnSuccess,
+                         onSuccess = std::move(onSuccess),
+                         onAlways = std::move(onAlways)](OperationOutcome outcome) {
                             const bool succeeded = outcome.succeeded;
                             refreshUndoJournalCache();
                             callbacks_.emit(GBM_EVENT_OPERATION_FINISHED, toJson(outcome));
                             refreshWorkingCopy();
+                            if (onAlways) {
+                                onAlways();
+                            }
                             if (succeeded && refreshHistoryOnSuccess) {
                                 refreshHistory();
                             }

--- a/src/capi/Session.h
+++ b/src/capi/Session.h
@@ -513,12 +513,17 @@ private:
     /// the OperationOutcome sense -- see mergeBranch()'s doc comment above).
     /// Refreshes history too, but only when `refreshHistoryOnSuccess` and
     /// the operation actually succeeded, since a conflicting/aborted
-    /// operation has not moved any ref. `onSuccess`, if given, runs after
-    /// that -- e.g. bisect operations use it to also refresh their own
-    /// status snapshot, which nothing else here knows to do.
+    /// operation has not moved any ref. `onAlways`, if given, runs
+    /// unconditionally right after the event is emitted -- the hook
+    /// beginAskpass() requires, since a credential watch has to be stopped
+    /// whether the operation succeeded or not. `onSuccess`, if given, runs
+    /// last and only on success -- e.g. bisect operations use it to also
+    /// refresh their own status snapshot, which nothing else here knows to
+    /// do. Same two-callback shape as submitWorkingCopyOperation() above.
     void submitOperation(std::unique_ptr<Operation> operation,
                          bool refreshHistoryOnSuccess,
-                         std::function<void()> onSuccess = nullptr);
+                         std::function<void()> onSuccess = nullptr,
+                         std::function<void()> onAlways = nullptr);
 
     GitInstallation installation_;
     RepoPaths paths_;

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -392,12 +392,30 @@ GBM_API void gbm_branch_create(GbmSessionHandle session,
                                int32_t setUpstream,
                                const char* upstream);
 
-/// `git branch -m <from> <to>` (`-M` when `force`). Async: fires
-/// GBM_EVENT_OPERATION_FINISHED, and on success refreshes refs.
+/// `git branch -m <from> <to>` (`-M` when `force`).
+///
+/// When `renameRemote` is set, the rename is carried through to
+/// `remoteName` afterwards: `git push --set-upstream <remoteName> <to>`,
+/// then `git push <remoteName> --delete <from>`. git has no atomic remote
+/// rename, so it really is push-then-delete -- everyone else's
+/// remote-tracking ref for the old name goes `gone`. A failure in either
+/// remote step is reported as a failed operation whose summary states that
+/// the *local* rename did land, since the caller otherwise cannot tell
+/// which half happened.
+///
+/// When `renameRemote` is not set, the branch's upstream is unset instead:
+/// `git branch -m` carries the tracking config across, which would leave
+/// the renamed branch tracking the old remote branch.
+///
+/// Async: fires GBM_EVENT_OPERATION_FINISHED, and on success refreshes
+/// refs. May fire GBM_EVENT_CREDENTIAL_REQUESTED while `renameRemote` is
+/// contacting the remote.
 GBM_API void gbm_branch_rename(GbmSessionHandle session,
                                const char* from,
                                const char* to,
-                               int32_t force);
+                               int32_t force,
+                               int32_t renameRemote,
+                               const char* remoteName);
 
 /// `git branch -d/-D <names...>` (multiple names in one call, matching
 /// `git branch`'s own multi-name support -- a multi-select delete is one

--- a/src/core/git/ops/BranchOps.cpp
+++ b/src/core/git/ops/BranchOps.cpp
@@ -1,8 +1,10 @@
 #include "core/git/ops/BranchOps.h"
 
 #include "core/base/FsUtil.h"
+#include "core/git/AskpassHelper.h"
 #include "core/git/RefStore.h"
 
+#include <chrono>
 #include <sstream>
 #include <string_view>
 #include <utility>
@@ -204,9 +206,7 @@ public:
                     "The branch is currently named " + temporary + "; rename it manually to finish";
                 return outcome;
             }
-            outcome.succeeded = true;
-            outcome.summary = "Renamed to " + request_.to;
-            return outcome;
+            return finishLocalRename(runner, paths, token);
         }
 
         std::vector<std::string> args{
@@ -220,12 +220,75 @@ public:
             outcome.summary = outcome.error->message;
             return outcome;
         }
-        outcome.succeeded = true;
-        outcome.summary = "Renamed to " + request_.to;
-        return outcome;
+        return finishLocalRename(runner, paths, token);
     }
 
 private:
+    /// Everything after the local rename has landed. Either carries the
+    /// rename through to the remote -- push the new name, then delete the
+    /// old one, in that order -- or, when the branch is staying local-only,
+    /// drops the tracking config `git branch -m` would otherwise have left
+    /// pointing at the old remote branch.
+    ///
+    /// A failure here is reported as a failure with the local rename spelled
+    /// out in the summary, the same shape DeleteTagOperation uses: the branch
+    /// really has been renamed, and saying only "push failed" would leave the
+    /// user unable to tell which half happened.
+    OperationOutcome finishLocalRename(IProcessRunner& runner,
+                                       const RepoPaths& paths,
+                                       CancellationToken token) {
+        OperationOutcome outcome;
+        outcome.succeeded = true;
+        outcome.summary = "Renamed to " + request_.to;
+
+        if (!request_.renameRemote) {
+            // `git branch -m` carries branch.<name>.remote/.merge across with
+            // the rename, so without this the renamed branch would still
+            // track the *old* remote branch. Its exit code is deliberately
+            // ignored rather than swallowed: --unset-upstream fails when
+            // there was no upstream to begin with, which is the common case
+            // and not an error -- either way the branch ends up with no
+            // upstream, which is the whole point.
+            GitCommand unsetUpstream(paths.commandDir(),
+                                     {"branch", "--unset-upstream", request_.to});
+            unsetUpstream.timeout = std::chrono::seconds(60);
+            (void)runner.run(unsetUpstream, token);
+            return outcome;
+        }
+
+        // No local timeout on either remote step: the budget belongs to the
+        // network, exactly as PushTagOperation/DeleteTagOperation do it.
+        GitCommand push(paths.commandDir(),
+                        {"push", "--set-upstream", request_.remoteName, request_.to});
+        push.timeout = std::chrono::milliseconds(0);
+        askpass::wire(push, request_.askpassDir);
+        auto pushed = runner.run(push, token);
+        if (!pushed) {
+            outcome.succeeded = false;
+            outcome.error = std::move(pushed).error();
+            outcome.summary = "Renamed locally to " + request_.to + ", but could not push it to " +
+                              request_.remoteName + ": " + outcome.error->message;
+            return outcome;
+        }
+
+        GitCommand deleteOld(paths.commandDir(),
+                             {"push", request_.remoteName, "--delete", request_.from});
+        deleteOld.timeout = std::chrono::milliseconds(0);
+        askpass::wire(deleteOld, request_.askpassDir);
+        auto deleted = runner.run(deleteOld, token);
+        if (!deleted) {
+            outcome.succeeded = false;
+            outcome.error = std::move(deleted).error();
+            outcome.summary = "Renamed to " + request_.to +
+                              " and pushed it, but could not delete " + request_.from + " on " +
+                              request_.remoteName + ": " + outcome.error->message;
+            return outcome;
+        }
+
+        outcome.summary = "Renamed to " + request_.to + " locally and on " + request_.remoteName;
+        return outcome;
+    }
+
     RenameBranchRequest request_;
 };
 

--- a/src/core/git/ops/BranchOps.h
+++ b/src/core/git/ops/BranchOps.h
@@ -2,6 +2,7 @@
 
 #include "core/git/OperationRunner.h"
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -20,6 +21,25 @@ struct RenameBranchRequest {
     std::string from;
     std::string to;
     bool force = false;
+    /// Carries the rename through to `remoteName` after the local rename
+    /// succeeds: pushes the branch under its new name (with `-u`, so the
+    /// renamed branch tracks it), then deletes the old branch on the remote.
+    /// git has no atomic remote rename, so this really is push-then-delete,
+    /// and everyone else's remote-tracking ref for the old name goes `gone`.
+    /// Push comes first deliberately -- reversing the two would leave the
+    /// branch unpublished if the second step failed.
+    ///
+    /// When this is false and the branch had an upstream, the upstream is
+    /// unset instead: `git branch -m` *keeps* the tracking config, which
+    /// would otherwise leave the renamed branch still tracking the old
+    /// remote branch. That is not configurable -- it is what "rename
+    /// locally only" means.
+    bool renameRemote = false;
+    std::string remoteName;
+    /// Set by the app layer to a directory made with askpass::makeRequestDir();
+    /// only the `renameRemote` steps need it, since they are the only ones
+    /// that talk to a remote.
+    std::filesystem::path askpassDir;
 };
 
 struct DeleteBranchRequest {

--- a/tests/capi/BranchApiTest.cpp
+++ b/tests/capi/BranchApiTest.cpp
@@ -81,6 +81,68 @@ protected:
         }
         std::error_code ec;
         std::filesystem::remove_all(repo_, ec);
+        if (!remote_.empty()) {
+            std::filesystem::remove_all(remote_, ec);
+        }
+    }
+
+    /// Adds a local bare repository as `origin` and publishes `branch` to it
+    /// with `-u`, so the rename tests have a real upstream to carry across.
+    /// Deliberately not in SetUp(): only the remote-rename tests need it, and
+    /// an extra init+push on every test in this file is pure overhead.
+    /// Same fixture shape as RemoteApiTest's -- no network involved.
+    void setUpRemoteWithBranch(const std::string& branch) {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        remote_ = std::filesystem::temp_directory_path() /
+                  ("gbm-capi-branch-remote-" + std::string(info->name()));
+        std::filesystem::remove_all(remote_);
+        ASSERT_EQ(runIn(remote_.parent_path(), {"init", "--quiet", "--bare", remote_.string()}), 0);
+        ASSERT_EQ(runGit({"remote", "add", "origin", remote_.string()}), 0);
+        ASSERT_EQ(runGit({"branch", branch}), 0);
+        ASSERT_EQ(runGit({"push", "--quiet", "-u", "origin", branch}), 0);
+    }
+
+    int runIn(const std::filesystem::path& dir, std::vector<std::string> args) {
+        std::string command = "git -C \"" + dir.string() + "\"";
+        for (const auto& arg : args) {
+            command += " \"" + arg + "\"";
+        }
+#ifdef _WIN32
+        command += " >NUL 2>&1";
+#else
+        command += " >/dev/null 2>&1";
+#endif
+        return std::system(command.c_str());
+    }
+
+    /// Branch names present in the bare remote, read from the remote itself
+    /// rather than from any remote-tracking ref -- a stale local ref would
+    /// otherwise make a failed delete look like it worked.
+    std::vector<std::string> remoteBranches() {
+        const std::string outFile = (repo_ / "..gbm_remote_branch_list.txt").string();
+        const std::string command = "git -C \"" + remote_.string() +
+                                    "\" branch --format=\"%(refname:short)\" > \"" + outFile + "\"";
+        [[maybe_unused]] const int rc = std::system(command.c_str());
+        std::ifstream in(outFile);
+        std::vector<std::string> names;
+        std::string line;
+        while (std::getline(in, line)) {
+            if (!line.empty()) names.push_back(line);
+        }
+        return names;
+    }
+
+    /// `branch`'s configured upstream, or empty when it has none.
+    std::string upstreamOf(const std::string& branch) {
+        const std::string outFile = (repo_ / "..gbm_upstream.txt").string();
+        const std::string command = "git -C \"" + repo_.string() + "\" for-each-ref " +
+                                    "--format=\"%(upstream:short)\" \"refs/heads/" + branch +
+                                    "\" > \"" + outFile + "\"";
+        [[maybe_unused]] const int rc = std::system(command.c_str());
+        std::ifstream in(outFile);
+        std::string line;
+        std::getline(in, line);
+        return line;
     }
 
     int runGit(std::vector<std::string> args) {
@@ -139,6 +201,7 @@ protected:
     }
 
     std::filesystem::path repo_;
+    std::filesystem::path remote_;
     GbmSessionHandle session_ = nullptr;
     EventLog log_;
 };
@@ -182,12 +245,72 @@ TEST_F(BranchApiTest, CreateBranchWithCheckoutAfterMovesHead) {
 TEST_F(BranchApiTest, RenameBranchChangesTheLocalBranchName) {
     ASSERT_EQ(runGit({"branch", "old-name"}), 0);
 
-    gbm_branch_rename(session_, "old-name", "new-name", /*force=*/0);
+    gbm_branch_rename(
+        session_, "old-name", "new-name", /*force=*/0, /*renameRemote=*/0, /*remoteName=*/"");
     ASSERT_TRUE(waitForOperationFinished());
 
     const auto branches = localBranches();
     EXPECT_EQ(std::find(branches.begin(), branches.end(), "old-name"), branches.end());
     EXPECT_NE(std::find(branches.begin(), branches.end(), "new-name"), branches.end());
+}
+
+TEST_F(BranchApiTest, RenameBranchWithRenameRemotePushesTheNewNameAndDeletesTheOldOne) {
+    setUpRemoteWithBranch("old-name");
+    const auto before = remoteBranches();
+    ASSERT_NE(std::find(before.begin(), before.end(), "old-name"), before.end());
+
+    gbm_branch_rename(
+        session_, "old-name", "new-name", /*force=*/0, /*renameRemote=*/1, /*remoteName=*/"origin");
+    ASSERT_TRUE(waitForOperationFinished());
+
+    const auto branches = localBranches();
+    EXPECT_NE(std::find(branches.begin(), branches.end(), "new-name"), branches.end());
+
+    const auto onRemote = remoteBranches();
+    EXPECT_NE(std::find(onRemote.begin(), onRemote.end(), "new-name"), onRemote.end());
+    EXPECT_EQ(std::find(onRemote.begin(), onRemote.end(), "old-name"), onRemote.end());
+
+    // --set-upstream on the push is what re-points tracking at the new name;
+    // without it the renamed branch would still track origin/old-name.
+    EXPECT_EQ(upstreamOf("new-name"), "origin/new-name");
+}
+
+TEST_F(BranchApiTest, RenameBranchWithoutRenameRemoteClearsTheUpstreamAndLeavesTheRemoteAlone) {
+    setUpRemoteWithBranch("old-name");
+    ASSERT_EQ(upstreamOf("old-name"), "origin/old-name");
+
+    gbm_branch_rename(
+        session_, "old-name", "new-name", /*force=*/0, /*renameRemote=*/0, /*remoteName=*/"");
+    ASSERT_TRUE(waitForOperationFinished());
+
+    // `git branch -m` keeps branch.<name>.remote/.merge, so this is the one
+    // assertion that proves the --unset-upstream step ran: without it the
+    // renamed branch silently still tracks origin/old-name.
+    EXPECT_EQ(upstreamOf("new-name"), "");
+
+    const auto onRemote = remoteBranches();
+    EXPECT_NE(std::find(onRemote.begin(), onRemote.end(), "old-name"), onRemote.end());
+}
+
+TEST_F(BranchApiTest, RenameBranchReportsTheLocalRenameWhenTheRemoteStepFails) {
+    ASSERT_EQ(runGit({"branch", "old-name"}), 0);
+
+    // No such remote, so the push fails while the local rename has already
+    // landed -- the half-done case the summary exists to describe.
+    gbm_branch_rename(session_,
+                      "old-name",
+                      "new-name",
+                      /*force=*/0,
+                      /*renameRemote=*/1,
+                      /*remoteName=*/"no-such-remote");
+    ASSERT_TRUE(waitForOperationFinished());
+
+    const auto branches = localBranches();
+    EXPECT_NE(std::find(branches.begin(), branches.end(), "new-name"), branches.end());
+
+    const std::string payload = lastOperationFinishedPayload();
+    EXPECT_NE(payload.find("\"succeeded\":false"), std::string::npos) << payload;
+    EXPECT_NE(payload.find("Renamed locally to new-name"), std::string::npos) << payload;
 }
 
 TEST_F(BranchApiTest, DeleteBranchRemovesASingleLocalBranch) {


### PR DESCRIPTION
Fixes #45

依 spec **P13 A 區**補上 Rename branch 專屬 dialog、`/repo/:repoId/dialogs/rename-branch` route，以及 **F2** 綁定；三個 spec 指定的入口（05-B 右鍵、Branch 選單、F2）全部改接同一個 dialog。

## 為什麼現在做：延後理由已解除

Tier 0（#64）刻意跳過這條，理由寫在 issue 留言：「等專屬 rename 對話框設計稿完成後再開新一輪處理」。**那個條件在 260820 成立了** — 規格於 `fc3bfb3` 新增四頁，其中 P13 A 區就是等的那份設計稿（版面、兩個遠端選項、五條 `RENAMEVALID` 即時驗證規則），P16 的 `REVISIONS` 也直接補上當初缺的 `Branch → Rename branch… = F2`。

延後的判斷本身沒有錯，只是它指名的條件到了。

## issue 前提的兩處修正

issue 內文已就地更正（沿用 #60 / #50 的慣例：前提不成立就把證據寫進 issue，不默默改標題）。

| issue 原文 | 實際狀況 |
|---|---|
| 標題讀起來像「rename 不能用」 | 兩個入口一直都能用，共用一個陽春的 `promptText` 輸入框；缺的是專屬 dialog、route、快捷鍵 |
| 「`gbm_branch_rename` 已存在，只差接線」 | P13 的「遠端連帶處理」讓這句話不成立，見下 |

## capi 擴充：遠端連帶更名

`gbm_branch_rename` 增加 `renameRemote` / `remoteName`（與內部的 `askpassDir`）。遠端更名是 push 後 delete（git 沒有原子遠端更名），而且做在 `RenameBranchOperation::run()` 裡，不是從 Dart 串三個 capi 呼叫 — 那會產生三個 `OPERATION_FINISHED` 事件與三個錯誤出口，違反 spec P10「一個背景作業、一個錯誤視窗」。`run()` 本來就是多步驟的（case-only rename 走 `.gbm-rename-tmp` 兩段式）。

樣式全程比照 `TagOps.cpp` 的 `DeleteTagOperation`：本地步驟先跑、遠端步驟在旗標後面帶 `askpass::wire()` 且不設本地 timeout、部分失敗時 summary 明講哪一半完成了。

## 兩件靠實測而非閱讀才發現的事

**`git branch -m` 會保留 upstream。** spec 說本地-only 更名後分支沒有 upstream，直覺會以為更名本來就會斷開 tracking。並不會 — `branch -m` 會把 `branch.<name>.remote/.merge` 一併帶走，更名後的分支仍然無聲地追蹤**舊的**遠端分支。因此多了一步 `git branch --unset-upstream`。這點是先在暫存 repo 實測確認才寫測試的，否則那條測試會空過。

**`Session::submitOperation` 沒有無條件回呼。** `beginAskpass()` 的 doc 要求 `endAskpass()` 必須無條件配對，但只有 `submitWorkingCopyOperation` 有 `onAlways`；`submitOperation` 只有 `onSuccess`，失敗路徑會讓 credential watch 停不掉。rename 必須留在 `submitOperation`（它發 `OPERATION_FINISHED`，是既有 capi 契約），所以 `onAlways` 以獨立 commit 補上。

## 順手發現、刻意不在本輪修的缺陷

**`delete_branch_dialog.dart` 的 `_remoteOf()` 是壞的。** `RefInfo.upstream` 是 `%(upstream)` 的完整 ref（`refs/remotes/origin/main`），不是 `origin/main`；用第一個斜線切會得到 `refs`。該 dialog 的「一併刪除遠端」因此會對一個叫 `refs` 的 remote 送出請求。本 PR 的 dialog 改用 `remoteBranchParts()` 避開，但沒有動 delete 那邊 — 不同功能、需要自己的測試，另開 issue 追蹤。

**05-B 選單另外三項仍未加 conflict gate。** `New branch from here` / `Merge into current branch` / `Delete branch` 依 spec P07 都應該在 conflict 時停用，目前沒有。本輪只加了 Rename 的（#45 範圍內）。

## 刻意的取捨

**F2 指向目前分支，不是 sidebar 選取項。** spec 寫「sidebar 選中後按 F2」，sidebar 確實有選取狀態，但 `_selected` 是 `SidebarPanel` 的 local `State`，`WorkspaceScreen._buildActionHandlers()` 讀不到；把它提升成 provider 是 #54 多選那輪本來就要做的事。所以 F2 與 Branch 選單回落到 HEAD（與 action id 名稱一致），由 05-B 右鍵透過 route 的 `branch` 參數指定分支。

**不動 05-C catalog。** P13 內文說純遠端分支的 Rename 應 disabled 並附 tooltip，但 05-C 的項目清單裡根本沒有 Rename。catalog 是 parity 測試的驗收基準，改它等於改被驗證的對象（同 #71 的形狀）。記錄這個規格內部矛盾，不修。

## Commit 結構

八個依序、每個都可獨立 build 與回退：

| # | 內容 |
|---|---|
| `3754bc3` | `refactor`：`submitOperation` 加 `onAlways` |
| `96b32ee` | `feat`：core + capi 遠端連帶更名與 `--unset-upstream` |
| `ddf7f0f` | `feat`：Flutter FFI 對接 |
| `ddb2e1e` | `refactor`：抽出 `branchNameError()` 共用 |
| `715bd81` | `feat`：dialog + route |
| `c466110` | `feat`：三個入口 + F2 + conflict gate + 標籤 |
| `cc54c33` | `test`：integration 覆蓋 |
| `47c7ce2` | `chore`：docs |
| `43989d7` | `test`：sidebar 右鍵 Rename 的 conflict gate 覆蓋 |
| `1ce19e9` | `chore`：補齊 REVISIONS 影響的其餘 matrix 列 |
| `1eb9dca` | `fix`：已同步分支被誤判為沒有 upstream |
| `5ef6205` | `test`：device-tier e2e |
| `f3b88ce` | `chore`：記錄兩項實測發現 |

C++ 側的簽章變更會讓「只有測試」的 commit 編不過，所以簽章 + 實作 + 測試落在同一個 commit，以保住每個 commit 都是綠的。

## Test plan

- [x] `ctest -j4` — 517/517 通過（含三條新的 `BranchApiTest`：遠端更名成功、本地-only 清 upstream、遠端失敗時的部分完成訊息，借 `RemoteApiTest` 的 local bare origin fixture，不需網路）
- [x] `flutter analyze` — 0 issues
- [x] `dart format --set-exit-if-changed .` — 無變更
- [x] `flutter test` — 1030 passed / 2 skipped（原本 3 skipped，`gbm_shortcuts_test.dart` 的 F2 skip 已解除）
- [x] `clang-format` 與 core-不得依賴-Qt 的分層檢查
- [x] **反向驗證**：移除 F2 綁定後，`workspace_rename_branch_flow_test.dart` 四條中有三條失敗（第四條「conflict 時 F2 不開任何東西」正確地仍然通過）——確認測試驗的是綁定本身，不是空過
- [x] **device-tier e2e 取代原訂的手測**：`integration_test/rename_branch_flow_test.dart` 對真實 `gbm_capi` 與真實 bare origin 跑完兩種遠端選項，斷言直接讀 `for-each-ref`。`flutter test integration_test/rename_branch_flow_test.dart -d macos` 2/2 通過
- [x] **mutation test**：移除 `branch_tree_item.dart` 的 conflict gate 後，新增的三條測試全部轉紅

### 這一輪驗證抓到的缺陷（已在本 PR 修掉）

`RefInfo.hasTrackingInfo` **不等於「有 upstream」**。它對應 git 的 `%(upstream:track)`，而該欄位在分支與 upstream 完全同步（0 ahead / 0 behind）時是**空字串**，`%(upstream)` 卻仍然填滿。dialog 原本寫 `hasTrackingInfo && upstream.isNotEmpty`，等於對「剛 push 完的分支」這個最常見情境**整段隱藏遠端連帶處理區塊**，把使用者以為的遠端更名靜默降級成只改本地。

值得記一筆的是**既有的 widget 測試從頭到尾都是綠的**——因為 fixture 寫死 `hasTrackingInfo: upstream.isNotEmpty`，把同一個錯誤假設寫了第二次，測試因此無從反駁程式。是 device-tier 實跑才看見的。修法（`1eb9dca`）：只看 `upstream`，fixture 改為兩個欄位可獨立指定，並補上同步分支的案例。

### 為什麼一定要有 device-tier 這一層

本 PR 同時改了 `gbm_branch_rename` 的 C 匯出簽章與 `dart:ffi` 的 typedef，而**整套測試沒有任何一層跨越這個接縫**：`test/**` 全走 `FakeGbmBindings`，`tests/capi/**` 直接呼叫 C++。`lookupFunction` 只比對符號名稱、不比對簽章，所以 arity 不合會一路編譯、analyze、單元測試全綠，然後在真實使用者第一次更名時破壞堆疊。

順帶再次踩到 `integration_test/README.md` 已記載的陷阱：`build/native/libgbm_capi.dylib` 是**複本**，跑之前那份比重新編譯的小了 21KB，仍然照常載入。兩件事都寫進 `CLAUDE.md` 的 Tier 0c addendum。

## 文件

`spec-conformance-matrix.md` 加上基準說明（稽核當時 12 頁、現為 16 頁），rename 兩列改為已修復，並依 P16 `REVISIONS` 就地更正受影響的其他列 —— 其中兩條快捷鍵原本以「spec 自己撞鍵」免責，**那個理由已經失效**（Find in files → `Ctrl/Cmd+Shift+H`、Stash changes → `Ctrl/Cmd+Shift+S`），另外兩條同表落差在補齊時才發現：`Stage selected lines` 現已入表並指定 `Ctrl/Cmd+Alt+S`（程式綁 `Ctrl/Cmd+Shift+Enter`），`Edit → Select all`（`Ctrl/Cmd+A`）整條缺少。`operation-log dialog` 則被規格具名刪除，只留抽屜——這正是 #61 在等的裁決。P14/P15/P16 未稽核，`lib/` 也未為它們做任何改動。

### CI 上打到的偶發失敗（與本 PR 無關，已隔離並開 issue）

`WorkingCopyApiTest.UnstageHunkReversesAFullyStagedSingleHunkFile` 在一次 macOS capi job 轉紅。判定為既有偶發失敗，依據不是推測：

- 本 PR 後六個 commit **未觸及任何 `src/` 或 `tests/` 檔案**
- 同分支前一次 CI run 在**完全相同的 `src/` 樹**上 macOS 通過，同一次 run 的 Linux 與 Windows 也都通過
- 本機重現不需要本分支的任何改動

進一步抓到實際錯誤訊息（不是「重跑就好」）：失敗是 `LockHeld`，鎖的是測試**自己**的 temp repo `.git/index.lock`——前一個 working-copy 操作被回報完成時，git 還沒放掉下一個要用的鎖。

這與 #70 記錄的形狀**不同**，不可併案：#70 是 `waitForRefreshesToSettle` 的 10 秒逾時、假設輸給平行負載；這條在**單獨執行、無平行負載**下 12 次中 1 次失敗（另一輪在第 30/40 次），每次只跑 0.36 秒，遠不到任何逾時門檻。因此 #70 的「調高 timeout」對它無效。已開 **#77** 記錄逐字錯誤訊息與這項區別，並在 `CLAUDE.md` 註明兩者分流方式不同。

### 開出的 follow-up

- #74 — `delete_branch_dialog._remoteOf()` 把 `refs/remotes/origin/x` 切成 `"refs"`（同一個 `upstream` 欄位的誤用，順手發現、刻意不在本 PR 修）
- #75 — REVISIONS 造成的四項快捷鍵/選單落差
- #76 — P13 B 區多選與 P14/P15/P16 尚未稽核
- #77 — `WorkingCopyApiTest` 的 `index.lock` 自我競爭（既有偶發失敗，與本 PR 無關）
- 已在 #61（operation-log dialog 的裁決）與 #54（多選規則已補完，且 `Ctrl/Cmd+A` 應排在其後）留言

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rmvbFxrWxj9MMzVbmdKJX


