### PR TITLE
fix: 背景讀取不再取得 git 的 optional index lock

### DIFF
--- a/src/core/git/GitCommand.h
+++ b/src/core/git/GitCommand.h
@@ -44,6 +44,31 @@ struct GitCommand {
     /// UTF-8 filenames survive round-tripping. The pager and terminal prompt are
     /// disabled because there is no terminal to drive them, and a prompt would
     /// hang the child forever instead of returning an auth error we can report.
+    ///
+    /// `--no-optional-locks` is the fix for issue #77, and it is here rather
+    /// than on individual read commands on purpose. Reads and writes run on
+    /// *different* thread pools: writes are serialised by OperationRunner's
+    /// single worker, but Session::refreshWorkingCopy() and every other
+    /// background read post to sharedReadPool(), which is not serialised
+    /// against it. A plain `git status` or `git diff` rewrites the index
+    /// whenever its cached stat info has gone stale, and rewriting means
+    /// taking `.git/index.lock` -- so a background refresh could take the
+    /// lock out from under a real user operation, which then failed with
+    /// GitError::Code::LockHeld ("Another Git process appears to be running
+    /// in this repository"). This flag is git's own answer for GUI clients
+    /// in exactly that position (git 2.15+, equivalent to
+    /// GIT_OPTIONAL_LOCKS=0): it suppresses only *opportunistic* locking, so
+    /// commands that genuinely must write the index -- add, apply --cached,
+    /// commit, checkout -- still take their required lock and behave
+    /// identically.
+    ///
+    /// Applying it to every invocation rather than tagging the ~28
+    /// sharedReadPool() call sites individually is deliberate: a new read
+    /// command added later cannot forget to opt in, which is the drift this
+    /// repo's audits keep finding. The cost is that the index's stat cache is
+    /// no longer refreshed as a side effect of a status read, so a later
+    /// status may re-stat more files; that is the documented trade-off git
+    /// itself names for this flag.
     static std::vector<std::string> globalFlags() {
         return {
             "-c",
@@ -53,6 +78,7 @@ struct GitCommand {
             "-c",
             "advice.detachedHead=false",
             "--no-pager",
+            "--no-optional-locks",
         };
     }
 };

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -39,11 +39,13 @@
 #include "core/git/ops/WorktreeOps.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -974,6 +976,58 @@ TEST_F(RealRepoTest, WorkingCopyStatusReportsStagedUnstagedAndUntracked) {
     ASSERT_EQ(untracked.size(), 1u);
     EXPECT_EQ(untracked[0]->path, "new.txt");
     EXPECT_TRUE(untracked[0]->untracked);
+}
+
+/// Regression for #77: a background status read must not take git's
+/// *optional* index lock.
+///
+/// Writes go through OperationRunner's single serial thread, so two writes
+/// can never collide -- but Session::refreshWorkingCopy() posts to
+/// sharedReadPool(), a different pool entirely, and
+/// submitWorkingCopyOperation() emits its FINISHED event *before* kicking
+/// that refresh off. So a caller that reacts to the event by starting the
+/// next operation races the refresh, and a plain `git status` rewrites the
+/// index (taking .git/index.lock) whenever stat info has gone stale. The
+/// loser gets GitError::Code::LockHeld, "Another Git process appears to be
+/// running in this repository".
+///
+/// Asserted on the index's *bytes* rather than its mtime: filesystem
+/// timestamp granularity varies (HFS+ is 1s), so an mtime comparison can
+/// pass on a fast machine for the wrong reason.
+TEST_F(RealRepoTest, StatusReadDoesNotRewriteTheIndex) {
+    // Enough files that git has real stat work to do, and a back-dated mtime
+    // on each so the cached stat info is guaranteed stale -- without this git
+    // has no reason to want to rewrite the index and the test would pass
+    // vacuously, before *and* after the fix.
+    for (int i = 0; i < 40; ++i) {
+        const std::string name = "f" + std::to_string(i) + ".txt";
+        std::ofstream(repo_ / name) << "content " << i << "\n";
+    }
+    ASSERT_TRUE(run({"add", "-A"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "many files"}));
+    for (int i = 0; i < 40; ++i) {
+        const std::string name = "f" + std::to_string(i) + ".txt";
+        std::filesystem::last_write_time(
+            repo_ / name,
+            std::filesystem::file_time_type::clock::now() - std::chrono::hours(24 * 365));
+    }
+
+    const auto readIndexBytes = [this]() {
+        std::ifstream in(repo_ / ".git" / "index", std::ios::binary);
+        return std::string((std::istreambuf_iterator<char>(in)),
+                           std::istreambuf_iterator<char>());
+    };
+    const std::string before = readIndexBytes();
+    ASSERT_FALSE(before.empty());
+
+    WorkingCopyStatusReader reader(*runner_, paths_);
+    auto status = reader.read(CancellationToken{});
+    ASSERT_TRUE(status) << status.error().message;
+
+    EXPECT_EQ(readIndexBytes(), before)
+        << "a status read rewrote .git/index, which means it took the index "
+           "lock -- any concurrent write operation would have failed with "
+           "LockHeld. See GitCommand::globalFlags()'s --no-optional-locks.";
 }
 
 TEST_F(RealRepoTest, WorkingCopyStatusDetectsARenameStagedForCommit) {


### PR DESCRIPTION
Fixes #77

## 前提修正：這不只是 flaky test，是真的產品 race

#77 原文的「建議調查方向」猜測是**操作本身的 git process 還沒放掉 lock，`FINISHED` 事件就先發出去了**。調查結果**推翻了這個假設**：操作的 lock 早就釋放了，搶鎖的是**後續在 `sharedReadPool()` 上跑的背景 status/diff**——一個 issue 完全沒點名的、不同的 process。

因果鏈（每一環都在原始碼裡可查）：

1. `src/capi/Session.cpp:350` — `submitWorkingCopyOperation` 在呼叫 `onAlways` / `onSuccess`（也就是 `refreshWorkingCopy()`）**之前**就發出 `GBM_EVENT_WORKING_COPY_OPERATION_FINISHED`。測試收到事件後立刻發下一個寫入操作。
2. `src/capi/Session.cpp:309` — `refreshWorkingCopy()` 丟到 `sharedReadPool()`，這是**跟 `operations_` 不同的 thread pool**。
3. `src/core/git/OperationRunner.h` — `OperationRunner` 是單一序列 worker，「一次一個操作」。所以**寫入之間永遠不會互撞**，唯一可能互撞的是「背景讀取 vs 操作寫入」。
4. 實測確認：普通的 `git status --porcelain=v2` 會**改寫 `.git/index`**（更新 stat cache），過程中要拿 `.git/index.lock`；`git --no-optional-locks status` 則不會。

所以 `LockHeld: Unable to create '.../.git/index.lock': File exists` 是一個背景讀取跟緊接著的寫入操作搶同一把鎖，不是測試寫壞。

## 修法：`--no-optional-locks` 加在 `GitCommand::globalFlags()`

`--no-optional-locks`（git 2.15+，等同 `GIT_OPTIONAL_LOCKS=0`）只壓抑**機會性**的鎖；真正必要的鎖（`add` / `apply --cached` / `commit` / `checkout`）完全不受影響。

**為什麼放全域而不是只加在讀取端**：`src/core` 裡有約 28 個唯讀 git 呼叫點，逐一加旗標保證會漂移——新增一個讀取路徑而忘了加，race 就默默回來了。全域套用讓「讀取不拿 optional lock」變成無法繞過的不變式。代價已寫進 doc comment：唯讀操作不再更新 index 的 stat cache，極大 repo 的後續 status 可能稍慢一點；換來的是背景讀取永遠不會擋住使用者的寫入。

git 版本下限**不是新增的限制**：`GitInstallation::minimumSupported()`（`src/core/git/GitExecutable.h:49`）已經是 2.30.0，遠高於 2.15。

## 證據與其限制（請照實讀，不要當成 A/B 已證明）

**確定性的機制測試（RED → GREEN）**：新增 `RealRepoTest.StatusReadDoesNotRewriteTheIndex`。它建 40 個檔案、commit、再把 mtime 往回撥 365 天——**這一步是必要的**，否則 git 根本不想改寫 index，測試在修好前後都會 vacuously 通過。接著跑 `WorkingCopyStatusReader::read`，斷言 `.git/index` 的**位元組內容**沒變（不是 mtime——HFS+ 只有 1 秒精度）。修好前紅、修好後綠。

**壓力測試無法證明什麼，這點必須講清楚**：修好後把原本會 flake 的測試連跑 60 次全過，但**把修正拿掉的對照組也是 60/60 全過**，平行 ctest 負載下 40/40 也全過。每個測試用自己的 temp repo，所以這個 race 是 process 內的 thread 排程，不是 process 間的競爭——這個壓力方法無法按需重現 flake。**所以本 PR 的證據建立在上面那條確定性機制測試加因果鏈上，不是端對端 A/B。**

## 明確不主張的事

**這不修 #70。** #70 是不同形狀的失敗（平行負載下 `waitForRefreshesToSettle` 的 10 秒預算逾時），跟 `LockHeld` 無關，#70 維持開啟。

## 驗證

- `ctest --test-dir build/dev -j4` — **515/515 通過**
- `./scripts/format-check.sh` — 乾淨（174 檔，clang-format 18.1.8）
- `src/core/` 無 Qt header

## 合併後的待辦（跨分支文件相依）

PR #73 的 `CLAUDE.md` 有一段把 #77 記成「未解決的 flake」。本分支從 `main` 切出，不含那段文字。**兩個 PR 都合併後，要回頭更新 PR #73 那段 flake 說明**，否則 `CLAUDE.md` 會把一個已修好的問題描述成開啟中。
