### PR TITLE
perf: readHead 由兩次 git 呼叫併成一次以降低 Windows 行程成本

### DIFF
--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -23,9 +23,22 @@ spread on GitHub's Windows runners is the first thing to notice:
 | `32387290916` | tier-0c | 511 | 251.54 s | 0.4923 |
 | `32389479399` | `--no-optional-locks` (#78) | 509 | 203.71 s | 0.4002 |
 
-mean 0.4371, stdev 0.0387 — a **±9 % band**, min to max a 22 % spread, on runs
-whose `src/` differences cannot plausibly account for it. Any claim about a
-Windows speed-up smaller than that band is unfalsifiable from CI alone.
+mean 0.4309, stdev 0.0378 — a **±9 % band**, min to max a 23 % spread, on runs
+whose `src/` differences cannot plausibly account for it.
+
+The sharpest demonstration is not that table but a same-code pair. The branch
+carrying this report's own change was run twice, the second time with two extra
+tests and no behavioural difference:
+
+| Run | tests | ctest total | s/test |
+|---|---|---|---|
+| `32393264652` | 517 | 226.47 s | 0.4380 |
+| `32394639008` | 519 | 191.29 s | **0.3686** |
+
+**19 % apart, on effectively identical code.** The second is faster than every
+run in the table above, including the ones without the change. Any claim about
+a Windows speed-up needs either an effect well outside that spread or several
+runs per side; a single pair proves nothing in either direction.
 
 For scale, the same suite on Linux (`ubuntu-22.04`, run `32387290916`) is
 **22.89 s** against Windows' ~220 s — roughly **11×**, and not one pathological
@@ -134,13 +147,14 @@ once in the refresh's `load()`), so that is ~11 ms per operation on macOS and,
 extrapolating from Windows' higher per-process cost, plausibly 60–120 ms there.
 The extrapolation is not a measurement.
 
-**CI cannot confirm this, and does not.** The Windows run carrying the change
-(`32393264652`, 517 tests, 226.47 s) lands at **0.4380 s/test** — z = +0.02
-against the six-run population above, i.e. dead on its mean. Quoting it against
-the 0.4923 s/test baseline alone would manufacture a −11 % "improvement" that
-the rest of the population does not support; that baseline simply happened to
-be the slowest run in the set. The defensible claims here are the deterministic
-ones — 89 fewer processes, 5.5 ms per call — not a CI delta.
+**CI cannot confirm this, and does not.** The two runs carrying the change land
+at 0.4380 (z = +0.02, dead on the population mean) and 0.3686 (z = −1.65,
+faster than anything without the change) — 19 % apart from each other, which is
+larger than any effect a 89-process saving could produce. Quoting either one
+alone would manufacture a result: against the 0.4923 s/test baseline the first
+looks like −11 %, and that baseline simply happened to be the slowest run in
+the set. The defensible claims here are the deterministic ones — 89 fewer
+processes, 5.5 ms per call — not a CI delta.
 
 ## What this does *not* fix
 

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -9,19 +9,29 @@ optimises the wrong layer.
 
 ## The gap
 
-From one CI run (PR #73, run `32387290916`, identical `src/` tree on every
-platform, `cmake --workflow --preset capi-only`):
+Windows ctest totals from six CI runs of the same suite, oldest first. All are
+`cmake --workflow --preset capi-only`; the test count drifts because branches
+added tests. **Per-test time is the only comparable number**, and the run-to-run
+spread on GitHub's Windows runners is the first thing to notice:
 
-| Platform | ctest total | Job wall clock |
-|---|---|---|
-| Linux (`ubuntu-22.04`) | **22.89 s** | 3 m 31 s |
-| macOS (`macos-26`, arm64) | — | 2 m 18 s |
-| Windows (`windows-latest`) | **251.54 s** | 9 m 25 s |
+| Run | branch | tests | ctest total | s/test |
+|---|---|---|---|---|
+| `32365698665` | tier-5 | 502 | 202.71 s | 0.4038 |
+| `32367844938` | tier-5 | 502 | 204.81 s | 0.4080 |
+| `32374888281` | tier-4 | 508 | 212.61 s | 0.4185 |
+| `32382971897` | tier-0c | 511 | 236.51 s | 0.4628 |
+| `32387290916` | tier-0c | 511 | 251.54 s | 0.4923 |
+| `32389479399` | `--no-optional-locks` (#78) | 509 | 203.71 s | 0.4002 |
 
-**11×**, and it is not one pathological test. Linux's slowest single test is
-1.77 s; Windows has a dozen in the 2–9 s range and a long flat tail. A broad
-per-test constant, not an outlier, is the signature of **per-process
-overhead** — every one of these tests spawns git repeatedly.
+mean 0.4371, stdev 0.0387 — a **±9 % band**, min to max a 22 % spread, on runs
+whose `src/` differences cannot plausibly account for it. Any claim about a
+Windows speed-up smaller than that band is unfalsifiable from CI alone.
+
+For scale, the same suite on Linux (`ubuntu-22.04`, run `32387290916`) is
+**22.89 s** against Windows' ~220 s — roughly **11×**, and not one pathological
+test: Linux's slowest single case is 1.77 s while Windows has a dozen in the
+2–9 s range and a long flat tail. A broad per-test constant is the signature of
+**per-process overhead**, since every one of these tests spawns git repeatedly.
 
 ## Method
 
@@ -117,6 +127,21 @@ Same shim, same binary, after the change:
 calls take the unborn fallback and some `rev-parse` calls come from other
 sites (`RefStore::resolveRevision`, `BisectOps`).
 
+Per call, on macOS, 60 iterations against a real repository: the two-process
+form costs **11.3 ms** and the one-process form **5.9 ms** — 5.5 ms saved, or
+48 %. A user operation runs `readHead()` twice (once in `recordUndoPoint()`,
+once in the refresh's `load()`), so that is ~11 ms per operation on macOS and,
+extrapolating from Windows' higher per-process cost, plausibly 60–120 ms there.
+The extrapolation is not a measurement.
+
+**CI cannot confirm this, and does not.** The Windows run carrying the change
+(`32393264652`, 517 tests, 226.47 s) lands at **0.4380 s/test** — z = +0.02
+against the six-run population above, i.e. dead on its mean. Quoting it against
+the 0.4923 s/test baseline alone would manufacture a −11 % "improvement" that
+the rest of the population does not support; that baseline simply happened to
+be the slowest run in the set. The defensible claims here are the deterministic
+ones — 89 fewer processes, 5.5 ms per call — not a CI delta.
+
 ## What this does *not* fix
 
 Stated plainly so the CI number is not mistaken for the target:
@@ -143,7 +168,6 @@ Stated plainly so the CI number is not mistaken for the target:
 
 `--no-optional-locks` (issue #77) was checked for a Windows regression, since
 skipping the index stat-cache refresh could in principle cost later `status`
-calls. It did not: the Windows job ran **8 m 52 s** with it against a
-**9 m 25 s** baseline on the same tree without it — inside the noise, and if
-anything faster, which is consistent with fewer index writes for Defender to
-scan.
+calls. Its run is the fastest of the six above (0.4002 s/test) — but that is
+z = −0.95, still inside the band, so the honest reading is "no regression
+detected", not "measurably faster".

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -1,0 +1,149 @@
+# Windows process-spawn cost, measured (2026-08)
+
+Why the C++ suite takes four minutes on Windows and twenty seconds on Linux,
+what part of that gap the *application* is responsible for, and what was
+actually changed. Written because the ratio is large enough that "Windows is
+just slow" is not a useful answer, and because two of the three contributing
+costs are **not** in `src/` at all — a fact worth recording before someone
+optimises the wrong layer.
+
+## The gap
+
+From one CI run (PR #73, run `32387290916`, identical `src/` tree on every
+platform, `cmake --workflow --preset capi-only`):
+
+| Platform | ctest total | Job wall clock |
+|---|---|---|
+| Linux (`ubuntu-22.04`) | **22.89 s** | 3 m 31 s |
+| macOS (`macos-26`, arm64) | — | 2 m 18 s |
+| Windows (`windows-latest`) | **251.54 s** | 9 m 25 s |
+
+**11×**, and it is not one pathological test. Linux's slowest single test is
+1.77 s; Windows has a dozen in the 2–9 s range and a long flat tail. A broad
+per-test constant, not an outlier, is the signature of **per-process
+overhead** — every one of these tests spawns git repeatedly.
+
+## Method
+
+Two independent counters, run against the same binary so they cross-check:
+
+1. **In-process**: a temporary atomic counter in `ProcessRunner`'s `execute()`
+   funnel, keyed by `command.args[0]`. Counts what the *app* spawns.
+2. **PATH shim**: a `git` shim script earlier on `PATH` than the real binary,
+   appending `$1` to a log and `exec`-ing through. Counts what *anything*
+   spawns — app and test fixtures alike, since `GitExecutable::detect()`
+   searches `PATH` and `std::system()` inherits it.
+
+Both were run over the whole `gbm_capi_tests` binary on macOS. Platform does
+not matter for a *count*; only the per-spawn cost is platform-specific.
+
+## What the counts showed
+
+`gbm_capi_tests`, before any change:
+
+| Source | git invocations | Share |
+|---|---|---|
+| Test fixtures (`std::system`) | 903 | 65 % |
+| Application (`ProcessRunner`) | 475 + 35 `--version` probes | 35 % |
+| **Total** | **1378** | |
+
+And within the application's own 510, the distribution was lopsided:
+
+| git subcommand | count |
+|---|---|
+| `rev-parse` | 115 |
+| `symbolic-ref` | 111 |
+| `status` | 53 |
+| `--version` (`GitExecutable::probe`) | 35 |
+| `for-each-ref` | 33 |
+| everything else | ≤ 22 each |
+
+**`rev-parse` + `symbolic-ref` = 226 of 510 — 44 % of every git process the
+app started was spent reading HEAD.** That is the finding this report exists
+for.
+
+## Why HEAD was costing two processes
+
+`RefStore::readHead()` issued `symbolic-ref --quiet HEAD` for the branch name
+and then `rev-parse --verify --quiet HEAD` for the oid, unconditionally. It
+sits on two hot paths at once:
+
+- `RefStore::load()` — every refs refresh.
+- `OperationRunner::recordUndoPoint()` — before **every** undoable write.
+
+So on Windows each write operation paid roughly two spawns of pure overhead
+before it began, and the refresh that followed paid two more.
+
+### The fix
+
+One command supplies both facts:
+
+```
+git rev-parse --revs-only HEAD --symbolic-full-name HEAD
+```
+
+| HEAD state | exit | stdout |
+|---|---|---|
+| On a branch | 0 | `<oid>` then `refs/heads/<name>` |
+| Detached | 0 | `<oid>` then the literal `HEAD` |
+| Unborn (no commits) | 0 | *empty* |
+
+`--revs-only` is load bearing rather than decoration. Without it the same
+argument list exits 128 on an unborn repository and writes `fatal: ambiguous
+argument 'HEAD'` to stderr — and `ProcessRunner::recordOperation()` records
+*every* invocation, stderr included, into the operation log the user can
+read. A freshly-initialised repository is a normal state, and it would have
+been described there as a fatal error.
+
+Unborn is the one case that still costs a second process: the combined
+command cannot name the branch HEAD is parked on, so it falls back to the old
+`symbolic-ref`. That is 2 spawns, exactly as before — no regression, and the
+common cases drop to 1.
+
+Detached is recognised by the literal string `HEAD` on line two. That is
+unambiguous, not merely convenient: a real branch always comes back fully
+qualified as `refs/heads/…`.
+
+### Measured effect
+
+Same shim, same binary, after the change:
+
+| | before | after | delta |
+|---|---|---|---|
+| App git spawns | 475 | **386** | **−89 (−18.7 %)** |
+| All git invocations | 1378 | 1289 | −89 (−6.5 %) |
+
+89 rather than the 113 a naive halving predicts, because some `readHead()`
+calls take the unborn fallback and some `rev-parse` calls come from other
+sites (`RefStore::resolveRevision`, `BisectOps`).
+
+## What this does *not* fix
+
+Stated plainly so the CI number is not mistaken for the target:
+
+1. **Test fixtures dominate, and they are not app code.** 903 of 1378
+   invocations come from `runGit()` helpers built on `std::system()`. On
+   Windows that spawns **`cmd.exe` *and* `git.exe`** per call — roughly 1806
+   processes for the fixtures against 386 for the app. No change under `src/`
+   can touch this. Replacing `std::system()` with a direct spawn would be the
+   single largest win available for the *test job*.
+2. **ctest runs serially in CI.** `CMakePresets.json`'s `tbase` test preset
+   sets no `execution.jobs`, so all 511 cases run one at a time on every
+   platform. Parallelising would compress Windows' 251 s substantially — but
+   see **#70**: `UndoApiTest`/`MergeApiTest` (and, observed while writing
+   this, `BisectApiTest.BisectResetEndsTheSessionAndRestoresTheOriginalBranch`)
+   already fail intermittently under parallel load with a fixed 10 s
+   `waitFor` budget. Turning on `-j` in CI without settling #70 first would
+   trade wall clock for flakes. Deliberately not done here.
+3. **The remaining app spawns are mostly irreducible.** `status`, `diff` and
+   `for-each-ref` each answer a distinct question; `--version` is one probe
+   per `Session`.
+
+## Sundry
+
+`--no-optional-locks` (issue #77) was checked for a Windows regression, since
+skipping the index stat-cache refresh could in principle cost later `status`
+calls. It did not: the Windows job ran **8 m 52 s** with it against a
+**9 m 25 s** baseline on the same tree without it — inside the noise, and if
+anything faster, which is consistent with fewer index writes for Defender to
+scan.

--- a/src/core/git/RefStore.cpp
+++ b/src/core/git/RefStore.cpp
@@ -146,28 +146,62 @@ GitResult<HeadInfo> RefStore::readHead(CancellationToken token) {
     GBM_ASSERT_NOT_UI_THREAD();
 
     HeadInfo head;
-    GitCommand command(paths_.commandDir(), {"symbolic-ref", "--quiet", "HEAD"});
+
+    // Both facts about HEAD -- which ref it points at and which commit that
+    // resolves to -- come from one git process, not two. This used to be a
+    // `symbolic-ref` followed by a `rev-parse`, and it sits on two hot paths at
+    // once: RefStore::load() runs it on every refs refresh, and
+    // OperationRunner::recordUndoPoint() runs it before every undoable write.
+    // Process creation costs roughly two orders of magnitude more on Windows
+    // than on Linux, so the spare spawn was a measurable share of the work
+    // there rather than a rounding error.
+    //
+    // `--revs-only` is load bearing. Without it this argument list exits 128 on
+    // a repository with no commits yet and writes "fatal: ambiguous argument
+    // 'HEAD'" to stderr -- and ProcessRunner records every invocation, stderr
+    // included, into the operation log the user can read. With it, an
+    // unresolvable HEAD is simply empty output and exit 0, which is the right
+    // shape for what is a normal state rather than an error.
+    GitCommand command(paths_.commandDir(),
+                       {"rev-parse", "--revs-only", "HEAD", "--symbolic-full-name", "HEAD"});
     command.timeout = std::chrono::seconds(15);
-    auto symbolic = runner_.run(command, token);
+    auto resolved = runner_.run(command, token);
 
-    if (symbolic && !symbolic->out.empty()) {
-        head.kind = HeadInfo::Kind::Branch;
-        head.fullRef = symbolic->out;
-        head.branchName = shortNameFor(head.fullRef, RefKind::LocalBranch);
-    } else {
-        head.kind = HeadInfo::Kind::Detached;
-    }
+    if (resolved && !resolved->out.empty()) {
+        // "<oid>\n<symbolic name>" -- run() joins records with '\n' and trims
+        // the trailing one.
+        const std::size_t split = resolved->out.find('\n');
+        const std::string oid = resolved->out.substr(0, split);
+        const std::string symbolic =
+            split == std::string::npos ? std::string() : resolved->out.substr(split + 1);
 
-    GitCommand revParse(paths_.commandDir(), {"rev-parse", "--verify", "--quiet", "HEAD"});
-    revParse.timeout = std::chrono::seconds(15);
-    auto resolved = runner_.run(revParse, token);
-    if (!resolved || resolved->out.empty()) {
-        // No commits yet. A fresh repository must still open cleanly rather than
-        // reporting an error, so this is a normal state, not a failure.
-        head.kind = HeadInfo::Kind::Unborn;
+        // git prints the literal string "HEAD" for a detached head. A branch
+        // always comes back fully qualified as `refs/heads/...`, so this cannot
+        // collide with a real branch name.
+        if (symbolic.empty() || symbolic == "HEAD") {
+            head.kind = HeadInfo::Kind::Detached;
+        } else {
+            head.kind = HeadInfo::Kind::Branch;
+            head.fullRef = symbolic;
+            head.branchName = shortNameFor(head.fullRef, RefKind::LocalBranch);
+        }
+        head.target = ObjectId::fromHex(oid);
         return head;
     }
-    head.target = ObjectId::fromHex(resolved->out);
+
+    // No commits yet. A fresh repository must still open cleanly rather than
+    // reporting an error, so this is a normal state, not a failure -- and the
+    // branch HEAD is parked on is still worth showing. The command above cannot
+    // supply that name (an unresolvable HEAD yields no output at all), so this
+    // one case still costs a second process, exactly as it did before.
+    head.kind = HeadInfo::Kind::Unborn;
+    GitCommand symbolicRef(paths_.commandDir(), {"symbolic-ref", "--quiet", "HEAD"});
+    symbolicRef.timeout = std::chrono::seconds(15);
+    auto symbolic = runner_.run(symbolicRef, token);
+    if (symbolic && !symbolic->out.empty()) {
+        head.fullRef = symbolic->out;
+        head.branchName = shortNameFor(head.fullRef, RefKind::LocalBranch);
+    }
     return head;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(gbm_core_tests
     unit/OriginalOperationMessageTest.cpp
     unit/PreparedCommitMessageTest.cpp
     unit/ProcessRunnerTest.cpp
+    unit/RefStoreHeadTest.cpp
     unit/RemoteOpsTest.cpp
     unit/RepoStateTest.cpp
     unit/SideBySideDiffTest.cpp

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -903,6 +903,47 @@ TEST_F(RealRepoTest, HonoursAMaxCountLimit) {
     EXPECT_EQ((*snapshot)->rowCount(), 4u);
 }
 
+// readHead() reads HEAD's oid and its symbolic name out of a single
+// `git rev-parse --revs-only HEAD --symbolic-full-name HEAD`, and tells the two
+// apart by whether the second line is the literal string "HEAD". That is a
+// detail of git's own output, so these two cases are asserted against a real
+// git rather than only against FakeProcessRunner -- RefStoreHeadTest.cpp pins
+// the parsing and the invocation count, but a fake cannot notice if a future
+// git prints something else. The unborn third case is
+// HandlesAnEmptyRepositoryWithoutError, below.
+TEST_F(RealRepoTest, ReadsABranchHeadFromRealGit) {
+    commitFile("a.txt", "one\n", "first");
+
+    RefStore store(*runner_, paths_);
+    auto head = store.readHead(CancellationToken{});
+    ASSERT_TRUE(head) << head.error().message;
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Branch);
+    EXPECT_EQ(head->fullRef, "refs/heads/main");
+    EXPECT_EQ(head->branchName, "main");
+
+    auto expected = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(expected);
+    EXPECT_EQ(head->target.hex(), expected->out);
+}
+
+TEST_F(RealRepoTest, ReadsADetachedHeadFromRealGit) {
+    commitFile("a.txt", "one\n", "first");
+    ASSERT_TRUE(run({"checkout", "--quiet", "--detach"}));
+
+    RefStore store(*runner_, paths_);
+    auto head = store.readHead(CancellationToken{});
+    ASSERT_TRUE(head) << head.error().message;
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Detached);
+    EXPECT_TRUE(head->branchName.empty());
+    EXPECT_TRUE(head->fullRef.empty());
+
+    // The oid still has to be right: detaching must not cost the caller the
+    // commit HEAD is sitting on.
+    auto expected = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(expected);
+    EXPECT_EQ(head->target.hex(), expected->out);
+}
+
 TEST_F(RealRepoTest, HandlesAnEmptyRepositoryWithoutError) {
     // No commits at all. A fresh `git init` must open cleanly rather than
     // reporting a failure the user cannot act on.

--- a/tests/unit/ProcessRunnerTest.cpp
+++ b/tests/unit/ProcessRunnerTest.cpp
@@ -233,12 +233,10 @@ TEST(HistoryProvider, SurvivesAChildKilledMidStream) {
 TEST(RefStore, ParsesForEachRefOutputIncludingTrackingInfo) {
     FakeProcessRunner runner;
 
-    FakeProcessRunner::Response symbolic;
-    symbolic.out = "refs/heads/main";
-    runner.whenArgsContain({"symbolic-ref"}, symbolic);
-
+    // readHead() resolves HEAD's oid and its symbolic name in one rev-parse,
+    // so the scripted reply is both lines: "<oid>\n<symbolic full name>".
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a') + "\nrefs/heads/main";
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     // Fields are separated by the ASCII unit separator, which cannot appear in a
@@ -283,7 +281,7 @@ TEST(RefStore, TreatsAnUnbornHeadAsANormalState) {
     runner.whenArgsContain({"symbolic-ref"}, symbolic);
 
     FakeProcessRunner::Response revParse;
-    revParse.exitCode = 1;  // --verify --quiet finds nothing
+    revParse.exitCode = 1;  // HEAD does not resolve: no commits yet
     runner.whenArgsContain({"rev-parse"}, revParse);
     runner.whenArgsContain({"for-each-ref"}, FakeProcessRunner::Response{});
 
@@ -297,9 +295,8 @@ TEST(RefStore, TreatsAnUnbornHeadAsANormalState) {
 
 TEST(RefStore, TripsTheRefCountGuardOnAHugeRefSet) {
     FakeProcessRunner runner;
-    runner.whenArgsContain({"symbolic-ref"}, FakeProcessRunner::Response{});
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a');  // an oid with no symbolic name: detached
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     const char sep = '\x1f';
@@ -382,12 +379,10 @@ TEST(RefStore, ExcludesAGoneUpstreamFromHistorySeeds) {
 
 TEST(RefStore, ParsesGoneTrackFieldWithoutCountingAsAheadOrBehind) {
     FakeProcessRunner runner;
-    FakeProcessRunner::Response symbolic;
-    symbolic.out = "refs/heads/feature";
-    runner.whenArgsContain({"symbolic-ref"}, symbolic);
-
+    // readHead() resolves HEAD's oid and its symbolic name in one rev-parse,
+    // so the scripted reply is both lines: "<oid>\n<symbolic full name>".
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a') + "\nrefs/heads/feature";
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     const char sep = '\x1f';
@@ -419,12 +414,10 @@ TEST(RefStore, LoadsEveryRefWithASingleForEachRefInvocation) {
     // minutes. Every parsed field would still be correct if someone did that,
     // so the process count is the only thing that can catch it.
     FakeProcessRunner runner;
-    FakeProcessRunner::Response symbolic;
-    symbolic.out = "refs/heads/main";
-    runner.whenArgsContain({"symbolic-ref"}, symbolic);
-
+    // readHead() resolves HEAD's oid and its symbolic name in one rev-parse,
+    // so the scripted reply is both lines: "<oid>\n<symbolic full name>".
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a') + "\nrefs/heads/main";
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     // Enough refs, each with tracking info, that a per-ref process would be
@@ -457,11 +450,12 @@ TEST(RefStore, LoadsEveryRefWithASingleForEachRefInvocation) {
     EXPECT_EQ(forEachRefCalls, 1u)
         << "one load() must cost exactly one for-each-ref, not one per ref";
 
-    // Three processes in total: symbolic-ref and rev-parse for HEAD
-    // (readHead), then the single for-each-ref. Pinned so that adding "just
-    // one more quick git call" to load() has to be a deliberate edit to this
-    // number.
-    EXPECT_EQ(runner.invocationCount(), 3u);
+    // Two processes in total: one rev-parse resolving HEAD's oid and symbolic
+    // name together (readHead), then the single for-each-ref. This was three
+    // until readHead() stopped issuing a separate symbolic-ref -- see
+    // RefStoreHeadTest.cpp. Pinned so that adding "just one more quick git
+    // call" to load() has to be a deliberate edit to this number.
+    EXPECT_EQ(runner.invocationCount(), 2u);
 }
 
 }  // namespace

--- a/tests/unit/RefStoreHeadTest.cpp
+++ b/tests/unit/RefStoreHeadTest.cpp
@@ -1,0 +1,138 @@
+// RefStore::readHead()'s command shape, asserted through FakeProcessRunner.
+//
+// The point of these tests is the *invocation count* as much as the parsed
+// result. readHead() used to issue two git processes unconditionally -- a
+// `symbolic-ref` for the branch name followed by a `rev-parse` for the oid --
+// and it is on two hot paths at once: RefStore::load() runs it on every refs
+// refresh, and OperationRunner::recordUndoPoint() runs it before every
+// undoable write. Process creation is roughly two orders of magnitude more
+// expensive on Windows than on Linux, so a spare spawn there is not a
+// rounding error; see docs/reports/windows-process-cost.md.
+//
+// A behaviour-only test would stay green if someone reverted the merge back to
+// two commands, so every case below pins invocationCount() explicitly.
+#include "core/git/RefStore.h"
+#include "support/FakeProcessRunner.h"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace gbm {
+namespace {
+
+using testing::FakeProcessRunner;
+
+RepoPaths testPaths() {
+    return RepoPaths("/repo", "/repo/.git", "/repo/.git");
+}
+
+constexpr const char* kOid = "8de891509a719cf9c23b3b6e9baebb9ad30f5878";
+
+/// `run()` reassembles stdout from the line splitter and trims the trailing
+/// separator, so a two-line git result reaches the caller as "a\nb" with no
+/// final newline. The fake passes `out` through verbatim, so the scripted
+/// responses here must already be in that shape.
+FakeProcessRunner::Response combinedReply(const std::string& oid, const std::string& symbolic) {
+    FakeProcessRunner::Response reply;
+    reply.out = oid + "\n" + symbolic;
+    return reply;
+}
+
+TEST(RefStoreReadHead, OnABranchResolvesNameAndOidInASingleInvocation) {
+    FakeProcessRunner runner;
+    runner.whenArgsContain({"rev-parse", "--symbolic-full-name"},
+                           combinedReply(kOid, "refs/heads/main"));
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Branch);
+    EXPECT_EQ(head->fullRef, "refs/heads/main");
+    EXPECT_EQ(head->branchName, "main");
+    EXPECT_EQ(head->target.hex(), kOid);
+
+    EXPECT_EQ(runner.invocationCount(), 1u);
+}
+
+TEST(RefStoreReadHead, DetachedIsRecognisedFromTheLiteralHeadSymbolicName) {
+    // `--symbolic-full-name HEAD` prints the literal string "HEAD" when HEAD is
+    // detached. That is unambiguous rather than merely convenient: a real
+    // branch always comes back fully qualified as `refs/heads/...`, so a bare
+    // "HEAD" cannot be a branch name reaching this code by accident.
+    FakeProcessRunner runner;
+    runner.whenArgsContain({"rev-parse", "--symbolic-full-name"}, combinedReply(kOid, "HEAD"));
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Detached);
+    EXPECT_TRUE(head->branchName.empty());
+    EXPECT_EQ(head->target.hex(), kOid);
+
+    EXPECT_EQ(runner.invocationCount(), 1u);
+}
+
+TEST(RefStoreReadHead, UnbornFallsBackToSymbolicRefAndKeepsTheBranchName) {
+    // A repository with no commits yet is a normal state, not a failure, and
+    // the branch HEAD points at is still worth showing. The combined command
+    // cannot supply it -- with `--revs-only` an unresolvable HEAD yields empty
+    // output -- so this is the one case that still costs a second process.
+    // It is also the case most likely to be dropped by a later refactor, hence
+    // asserting the name and not just the kind.
+    FakeProcessRunner runner;
+    runner.whenArgsContain({"rev-parse", "--symbolic-full-name"}, FakeProcessRunner::Response{});
+    FakeProcessRunner::Response symbolic;
+    symbolic.out = "refs/heads/dev";
+    runner.whenArgsContain({"symbolic-ref", "--quiet", "HEAD"}, symbolic);
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Unborn);
+    EXPECT_EQ(head->fullRef, "refs/heads/dev");
+    EXPECT_EQ(head->branchName, "dev");
+
+    EXPECT_EQ(runner.invocationCount(), 2u);
+}
+
+TEST(RefStoreReadHead, UsesRevsOnlySoAnUnbornHeadIsNotReportedAsAFatalError) {
+    // Without `--revs-only`, `git rev-parse HEAD --symbolic-full-name HEAD`
+    // exits 128 and writes "fatal: ambiguous argument 'HEAD'" to stderr on an
+    // unborn repository. ProcessRunner records *every* invocation into
+    // Log::instance(), stderr included, so that wording would surface in the
+    // user's operation log every time a freshly-initialised repository is
+    // opened -- describing a normal state as a fatal error. The flag is load
+    // bearing, not decoration.
+    FakeProcessRunner runner;
+    RefStore store(runner, testPaths());
+    (void)store.readHead(CancellationToken{});
+
+    ASSERT_GE(runner.invocationCount(), 1u);
+    const std::vector<std::string> args = runner.invokedArgs(0);
+    EXPECT_NE(std::find(args.begin(), args.end(), "--revs-only"), args.end());
+}
+
+TEST(RefStoreReadHead, AFailedGitStillLeavesAUsableUnbornHead) {
+    // Parity with the previous implementation: a rev-parse that errors outright
+    // (not a repository, git missing) must not propagate as a failed
+    // GitResult -- a repository that cannot answer still has to open.
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 128;
+    failure.err = "fatal: not a git repository";
+    runner.setDefaultResponse(failure);
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Unborn);
+}
+
+}  // namespace
+}  // namespace gbm


### PR DESCRIPTION
> **更正（合併前請讀）**：本文原先引用單一次 Windows run 的 251.54 s 當基準。取六次 run 的母體後，Windows ctest 的 run-to-run 變異是 **±9%**（0.4038–0.4923 s/test，mean 0.4371、stdev 0.0387）。**帶著本修改的 run 是 0.4380 s/test，z = +0.02，正好落在平均值上——CI 偵測不到這個改動。** 下面保留的是可確定的數字（行程數、單次延遲），不是 CI 差值。詳見 `docs/reports/windows-process-cost.md`。

Windows 上 C++ 測試比 Linux 慢 11 倍（ctest 約 220 s vs 22.89 s，同一份 `src/`）。這個 PR 針對其中**應用程式自己**該負責的那一份，把最貴的一條路徑從兩個 git 行程減成一個。完整量測與方法寫在 `docs/reports/windows-process-cost.md`。

## 先講結論：44% 的 git 行程只是在讀 HEAD

用兩個互相印證的計數器量 `gbm_capi_tests`（`ProcessRunner::execute()` 裡的行程內計數器，加上一個掛在 `PATH` 前面的 `git` shim）：

| 來源 | git 呼叫次數 | 佔比 |
|---|---|---|
| 測試 fixture（`std::system`） | 903 | 65% |
| 應用程式（`ProcessRunner`） | 475 + 35 次 `--version` | 35% |

而應用程式那 510 次裡：`rev-parse` 115 + `symbolic-ref` 111 = **226 次，44%**，全都來自同一個函式。

`RefStore::readHead()` 無條件發兩個行程：`symbolic-ref --quiet HEAD` 拿分支名，`rev-parse --verify --quiet HEAD` 拿 oid。它同時在兩條熱路徑上——`RefStore::load()` 每次 refs 重新整理跑一次，`OperationRunner::recordUndoPoint()` **每個可 undo 的寫入前**跑一次。所以在 Windows，每個寫入操作開始前先付兩個行程，後面的重新整理再付兩個。

## 修法

一個指令同時給出兩個事實：

```
git rev-parse --revs-only HEAD --symbolic-full-name HEAD
```

| HEAD 狀態 | exit | stdout |
|---|---|---|
| 在分支上 | 0 | `<oid>` 換行 `refs/heads/<name>` |
| detached | 0 | `<oid>` 換行 字面值 `HEAD` |
| unborn（無 commit） | 0 | 空 |

**`--revs-only` 是必要的，不是裝飾。** 少了它，同一組參數在 unborn repo 會 exit 128 並把 `fatal: ambiguous argument 'HEAD'` 寫進 stderr——而 `ProcessRunner::recordOperation()` 會把**每一次**呼叫連同 stderr 記進使用者讀得到的 operation log。剛 `git init` 的 repo 是正常狀態，不該在那裡被描述成 fatal error。

- **unborn** 是唯一還要第二個行程的情況：組合式指令無法給出 HEAD 停在哪個分支，所以 fallback 回 `symbolic-ref`。**2 個行程，與修改前完全相同**，沒有退步。
- **detached** 用第二行的字面值 `HEAD` 判定。這是明確的而非湊巧：真實分支永遠是完整的 `refs/heads/…`，不可能撞名。

## 實測效果

同一個 shim、同一個 binary：

| | 修改前 | 修改後 | 差 |
|---|---|---|---|
| app 端 git 行程 | 475 | **386** | **−89（−18.7%）** |
| 全部 git 呼叫 | 1378 | 1289 | −89（−6.5%） |

是 89 不是「砍半」的 113，因為部分 `readHead()` 走 unborn fallback，且部分 `rev-parse` 來自其他呼叫點（`RefStore::resolveRevision`、`BisectOps`）。

## 測試

新增 `tests/unit/RefStoreHeadTest.cpp`，五條測試**除了行為以外一律釘住 `invocationCount()`**（born 1 次、unborn 2 次）——只驗行為的測試在有人改回兩次呼叫時仍然會綠，那就等於沒鎖住這次優化。先寫測試確認 RED（5 條中 3 條紅），實作後 GREEN。

`ProcessRunnerTest.cpp` 五處 fake 腳本改成新的組合式回覆；`LoadsEveryRefWithASingleForEachRefInvocation` 釘住的行程數由 3 改為 2，並在註解寫明為什麼變。

- `ctest -j4`：**519 中 518 通過**
- `./scripts/format-check.sh`：乾淨（174 檔，clang-format 18.1.8）
- `src/core/` 無 Qt header

### 那一條失敗是 #70，已做對照組確認

`UndoApiTest.UndoRefusesAfterSwitchingBranches` 是 **#70 點名的既有 flake**（`waitForRefreshesToSettle` 的 10 秒逾時，記載頻率約 5 次 2 次）。不是推測——實際跑了對照組，各 8 次：

| | 失敗次數 |
|---|---|
| 本分支（已修改） | 3 / 8 |
| **`main`（未修改，對照組）** | **4 / 8** |

修改後**沒有變差**（若有差異是略好），與 #70 記載的頻率一致。**#70 維持開啟**，本 PR 不主張修好它。

## 這個 PR 明確**沒有**處理的事

寫清楚，免得把 CI 數字誤當成目標：

1. **測試 fixture 才是大宗，而且不是 app 程式碼。** 1378 次裡有 903 次來自建在 `std::system()` 上的 `runGit()` helper。在 Windows 那是每次生 **`cmd.exe` 加 `git.exe` 兩個行程**——fixture 約 1806 個行程，對上 app 的 386 個。**任何 `src/` 底下的改動都碰不到這塊**；把 `std::system()` 換成直接 spawn 會是測試 job 單項最大的收益。
2. **CI 的 ctest 是序列執行的。** `CMakePresets.json` 的 `tbase` test preset 沒有設 `execution.jobs`，511 個 case 在每個平台都一個一個跑。開平行會大幅壓縮 Windows 那 251 秒——但那正是 #70 的觸發條件，在 #70 定案前開 `-j` 等於拿 wall clock 換 flake。**刻意不做。**
3. 其餘 app 端呼叫大致無法再減：`status` / `diff` / `for-each-ref` 各自回答不同問題，`--version` 是每個 `Session` 一次探測。

## 單次延遲實測（這是可確定的部分）

macOS、真 repo、60 次迭代：舊的兩行程式 **11.3 ms**，新的一行程式 **5.9 ms**，**每次省 5.5 ms（−48%）**。一個使用者操作跑兩次 `readHead()`（`recordUndoPoint()` 一次、refresh 的 `load()` 一次），所以 macOS 約省 11 ms/操作；Windows 依其較高的每行程成本外推約 60–120 ms/操作——**外推，不是量測**。

## 附帶查核

`--no-optional-locks`（#77 / PR #78）有沒有拖慢 Windows？其 run 是六次母體裡最快的一次（0.4002 s/test），但 z = −0.95 仍在帶寬內，所以誠實的說法是「**未偵測到退步**」，而不是「較快」。
