### PR TITLE
test: fixture 不再經 shell 呼叫 git，行程數減少 41%

### DIFF
--- a/.github/workflows/cq.yml
+++ b/.github/workflows/cq.yml
@@ -66,6 +66,26 @@ jobs:
           fi
           echo "core is Qt-free"
 
+      # Fixture git commands go through tests/support/GitCli.h, never a shell.
+      # std::system() runs `/bin/sh -c` on POSIX and `cmd.exe /c` on Windows, so
+      # every call costs a second process -- and the capi suite issued ~900 of
+      # them, which is most of why that suite takes ten times longer on Windows
+      # than on Linux (docs/reports/windows-process-cost.md). Building a command
+      # *string* is also a real quoting hazard rather than a theoretical one:
+      # BranchApiTest carried a five-line comment about single quotes surviving
+      # cmd.exe and unquoted parentheses breaking dash. Both problems return the
+      # moment someone adds one std::system() call back, and nothing else in CI
+      # would notice -- the tests would still pass, just slower and more
+      # fragile. Comment lines are allowed so the helper can explain itself.
+      - name: tests must not shell out with std::system
+        run: |
+          if grep -rn 'std::system' tests --include='*.cpp' --include='*.h' \
+              | grep -vE ':[[:space:]]*(//|\*)'; then
+            echo "::error::tests must call gbm::testing::GitCli, not std::system - see tests/support/GitCli.h"
+            exit 1
+          fi
+          echo "tests are shell-free"
+
       # subosito/flutter-action's `channel: stable` floats to whatever build
       # is current that day. dart format's output is not stable across Dart
       # SDK versions (CLAUDE.md's "Known gaps": a local Dart 3.12.2 and a CI

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -156,27 +156,75 @@ looks like −11 %, and that baseline simply happened to be the slowest run in
 the set. The defensible claims here are the deterministic ones — 89 fewer
 processes, 5.5 ms per call — not a CI delta.
 
-## What this does *not* fix
+## The fixture shell, since removed
 
-Stated plainly so the CI number is not mistaken for the target:
+The largest single item in the earlier version of this report was listed under
+"what this does not fix": 903 of the 1378 git invocations came from `runGit()`
+helpers built on `std::system()`, copy-pasted into 26 capi fixtures. On Windows
+each of those spawns **`cmd.exe` *and* `git.exe`**, so the fixtures alone cost
+~1806 processes against the app's 386.
 
-1. **Test fixtures dominate, and they are not app code.** 903 of 1378
-   invocations come from `runGit()` helpers built on `std::system()`. On
-   Windows that spawns **`cmd.exe` *and* `git.exe`** per call — roughly 1806
-   processes for the fixtures against 386 for the app. No change under `src/`
-   can touch this. Replacing `std::system()` with a direct spawn would be the
-   single largest win available for the *test job*.
-2. **ctest runs serially in CI.** `CMakePresets.json`'s `tbase` test preset
-   sets no `execution.jobs`, so all 511 cases run one at a time on every
-   platform. Parallelising would compress Windows' 251 s substantially — but
-   see **#70**: `UndoApiTest`/`MergeApiTest` (and, observed while writing
-   this, `BisectApiTest.BisectResetEndsTheSessionAndRestoresTheOriginalBranch`)
-   already fail intermittently under parallel load with a fixed 10 s
-   `waitFor` budget. Turning on `-j` in CI without settling #70 first would
-   trade wall clock for flakes. Deliberately not done here.
-3. **The remaining app spawns are mostly irreducible.** `status`, `diff` and
-   `for-each-ref` each answer a distinct question; `--version` is one probe
-   per `Session`.
+That is now fixed. `tests/support/GitCli.h` runs git through the existing
+`makeProcessRunner()` — `gbm_capi_tests` already linked `gbm_core`, so no new
+dependency — and every fixture call site goes through it.
+
+| | before | after |
+|---|---|---|
+| git processes | 1378 | 1348 |
+| shell processes | 903 | **0** |
+| **total** | **2281** | **1348** |
+
+**933 fewer processes, −41 %**, which is what the per-process model predicted.
+The 30 git processes that also went are `GitExecutable::detect()`: 29 fixtures
+each ran their own `git --version` probe purely to decide whether to skip, and
+`GitCli` detects once per test binary.
+
+Wall clock, `gbm_capi_tests` run end to end on macOS, three runs per side:
+
+| | samples | median |
+|---|---|---|
+| before | 64.19 / 54.95 / 45.49 | 54.95 s |
+| after | 38.43 / 40.97 / 52.49 | **40.97 s** |
+
+−25 % by median, **but the ranges overlap** (the fastest "before" run beats the
+slowest "after" one), so on macOS this is directional rather than conclusive at
+n=3. That is expected: `/bin/sh` is cheap. The deterministic process count is
+the number to trust here, and Windows — where the removed process is `cmd.exe`
+— is where the effect should be large enough to see. A controlled measurement
+on a single file was cleaner: `WorkingCopyApiTest --gtest_repeat=10` (800
+fixture calls) went from a median of **33.72 s** to **30.56 s**, non-overlapping
+ranges, 3.95 ms saved per call against a 4.39 ms prediction.
+
+Two correctness problems went with the shell, and they matter more than the
+seconds:
+
+- **Quoting.** `BranchApiTest` carried a five-line comment explaining that
+  single quotes are POSIX-shell syntax `cmd.exe` passes through literally, so
+  git received them as part of a `--format` string, while leaving
+  `%(refname:short)` unquoted made dash treat the parentheses as a syntax
+  error. An argv vector has no such failure mode.
+- **Stray files in the repository under test.** `CommitFilesApiTest` and
+  `CommitMetaApiTest` redirected `rev-parse HEAD` into `head-oid.txt` *inside*
+  the fixture repository, leaving an untracked file for every later status read
+  to trip over. `GitCli::capture()` returns stdout directly.
+
+A `cq.yml` guard now fails the build if `std::system` reappears under `tests/`,
+on the same reasoning as the "core must not depend on Qt" grep next to it: the
+tests would still pass, just slower and more fragile, so nothing else in CI
+would notice.
+
+## What this still does *not* fix
+
+1. **ctest runs serially in CI.** `CMakePresets.json`'s `tbase` test preset
+   sets no `execution.jobs`, so all cases run one at a time on every platform.
+   Parallelising would compress Windows further — but see **#70**:
+   `UndoApiTest`/`MergeApiTest` (and, observed while writing this,
+   `BisectApiTest.BisectResetEndsTheSessionAndRestoresTheOriginalBranch`)
+   already fail intermittently under parallel load with a fixed 10 s `waitFor`
+   budget. Turning on `-j` in CI without settling #70 first would trade wall
+   clock for flakes. Deliberately not done here.
+2. **The remaining app spawns are mostly irreducible.** `status`, `diff` and
+   `for-each-ref` each answer a distinct question.
 
 ## Sundry
 

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -23,9 +23,22 @@ spread on GitHub's Windows runners is the first thing to notice:
 | `32387290916` | tier-0c | 511 | 251.54 s | 0.4923 |
 | `32389479399` | `--no-optional-locks` (#78) | 509 | 203.71 s | 0.4002 |
 
-mean 0.4371, stdev 0.0387 — a **±9 % band**, min to max a 22 % spread, on runs
-whose `src/` differences cannot plausibly account for it. Any claim about a
-Windows speed-up smaller than that band is unfalsifiable from CI alone.
+mean 0.4309, stdev 0.0378 — a **±9 % band**, min to max a 23 % spread, on runs
+whose `src/` differences cannot plausibly account for it.
+
+The sharpest demonstration is not that table but a same-code pair. The branch
+carrying this report's own change was run twice, the second time with two extra
+tests and no behavioural difference:
+
+| Run | tests | ctest total | s/test |
+|---|---|---|---|
+| `32393264652` | 517 | 226.47 s | 0.4380 |
+| `32394639008` | 519 | 191.29 s | **0.3686** |
+
+**19 % apart, on effectively identical code.** The second is faster than every
+run in the table above, including the ones without the change. Any claim about
+a Windows speed-up needs either an effect well outside that spread or several
+runs per side; a single pair proves nothing in either direction.
 
 For scale, the same suite on Linux (`ubuntu-22.04`, run `32387290916`) is
 **22.89 s** against Windows' ~220 s — roughly **11×**, and not one pathological
@@ -134,13 +147,14 @@ once in the refresh's `load()`), so that is ~11 ms per operation on macOS and,
 extrapolating from Windows' higher per-process cost, plausibly 60–120 ms there.
 The extrapolation is not a measurement.
 
-**CI cannot confirm this, and does not.** The Windows run carrying the change
-(`32393264652`, 517 tests, 226.47 s) lands at **0.4380 s/test** — z = +0.02
-against the six-run population above, i.e. dead on its mean. Quoting it against
-the 0.4923 s/test baseline alone would manufacture a −11 % "improvement" that
-the rest of the population does not support; that baseline simply happened to
-be the slowest run in the set. The defensible claims here are the deterministic
-ones — 89 fewer processes, 5.5 ms per call — not a CI delta.
+**CI cannot confirm this, and does not.** The two runs carrying the change land
+at 0.4380 (z = +0.02, dead on the population mean) and 0.3686 (z = −1.65,
+faster than anything without the change) — 19 % apart from each other, which is
+larger than any effect a 89-process saving could produce. Quoting either one
+alone would manufacture a result: against the 0.4923 s/test baseline the first
+looks like −11 %, and that baseline simply happened to be the slowest run in
+the set. The defensible claims here are the deterministic ones — 89 fewer
+processes, 5.5 ms per call — not a CI delta.
 
 ## What this does *not* fix
 

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -213,6 +213,41 @@ on the same reasoning as the "core must not depend on Qt" grep next to it: the
 tests would still pass, just slower and more fragile, so nothing else in CI
 would notice.
 
+## The prediction failed on Windows CI
+
+The acceptance criterion was written before the run and is not being moved
+afterwards. Removing 933 of 2281 processes was predicted to take Windows'
+ctest phase from ~0.43 s/test to ~0.26; anything landing in 0.37–0.49 was
+declared a failure in advance.
+
+| Run | tests | ctest | s/test |
+|---|---|---|---|
+| six-run population *without* either change | 502–511 | — | 0.4002–0.4923 (mean 0.4309) |
+| readHead only | 519 | 184.2 s | 0.3549 |
+| readHead **+ no fixture shell** | 523 | 211.9 s | **0.4052** |
+
+**0.4052 is squarely in the failure band** — the population mean, essentially.
+And the branch with *fewer* changes came out faster than the branch with more,
+which is not a coherent causal signal in either direction. The honest reading
+is **no detectable effect on Windows CI**.
+
+The model was wrong in a specific, identifiable way: it assumed
+cost(`cmd.exe`) ≈ cost(`git.exe`). The data says otherwise. `cmd.exe` is a
+small, already-resident system binary; `git.exe` on Windows drags in the MSYS2
+runtime and is far more expensive to start. Removing 903 shell processes
+therefore removed 903 of the *cheap* processes and left all 1348 expensive ones
+in place. The `−41 % of processes` figure is still true and still deterministic;
+it just does not convert into `−41 % of time`.
+
+What survives is not the speed claim:
+
+- the quoting hazard is structurally gone (an argv vector has no shell to
+  misparse it),
+- the two redirect files written *inside* the repository under test are gone,
+- and a guard stops the pattern coming back.
+
+Those were always the better half of the argument. The seconds were not there.
+
 ## What this still does *not* fix
 
 1. **ctest runs serially in CI.** `CMakePresets.json`'s `tbase` test preset
@@ -225,6 +260,30 @@ would notice.
    clock for flakes. Deliberately not done here.
 2. **The remaining app spawns are mostly irreducible.** `status`, `diff` and
    `for-each-ref` each answer a distinct question.
+
+## The compile phase is the larger half, and nothing here touches it
+
+Splitting the Windows job by phase makes the priority obvious, and it is not
+the one this report spent its effort on:
+
+| Platform | compile | test | compile share |
+|---|---|---|---|
+| **Windows** | **297–310 s** | 184–212 s | **~61 %** |
+| Linux | 129 s | 17 s | 88 % |
+| macOS | 97 s | 52 s | 65 % |
+
+Windows compiles 2.3× slower than Linux and 3.1× slower than macOS, and that
+phase alone is bigger than the whole test phase. Meanwhile there is **no
+`ccache`/`sccache`, no `CMAKE_*_COMPILER_LAUNCHER`, no precompiled header, no
+`UNITY_BUILD`, and no `actions/cache` anywhere in `ci.yml`** — every run
+recompiles everything, on every platform, including the `FetchContent` copy of
+GoogleTest. The generator is Ninja, so build parallelism is already the default
+and is *not* the missing piece.
+
+A compiler cache is the obvious next lever and is deliberately left undone
+here. One caveat found while scoping it, worth checking before anyone starts:
+sccache does not cache MSVC objects built with `/Zi` (separate PDB), only
+`/Z7`. That is the most likely reason such an attempt would quietly not work.
 
 ## Sundry
 

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -9,19 +9,29 @@ optimises the wrong layer.
 
 ## The gap
 
-From one CI run (PR #73, run `32387290916`, identical `src/` tree on every
-platform, `cmake --workflow --preset capi-only`):
+Windows ctest totals from six CI runs of the same suite, oldest first. All are
+`cmake --workflow --preset capi-only`; the test count drifts because branches
+added tests. **Per-test time is the only comparable number**, and the run-to-run
+spread on GitHub's Windows runners is the first thing to notice:
 
-| Platform | ctest total | Job wall clock |
-|---|---|---|
-| Linux (`ubuntu-22.04`) | **22.89 s** | 3 m 31 s |
-| macOS (`macos-26`, arm64) | — | 2 m 18 s |
-| Windows (`windows-latest`) | **251.54 s** | 9 m 25 s |
+| Run | branch | tests | ctest total | s/test |
+|---|---|---|---|---|
+| `32365698665` | tier-5 | 502 | 202.71 s | 0.4038 |
+| `32367844938` | tier-5 | 502 | 204.81 s | 0.4080 |
+| `32374888281` | tier-4 | 508 | 212.61 s | 0.4185 |
+| `32382971897` | tier-0c | 511 | 236.51 s | 0.4628 |
+| `32387290916` | tier-0c | 511 | 251.54 s | 0.4923 |
+| `32389479399` | `--no-optional-locks` (#78) | 509 | 203.71 s | 0.4002 |
 
-**11×**, and it is not one pathological test. Linux's slowest single test is
-1.77 s; Windows has a dozen in the 2–9 s range and a long flat tail. A broad
-per-test constant, not an outlier, is the signature of **per-process
-overhead** — every one of these tests spawns git repeatedly.
+mean 0.4371, stdev 0.0387 — a **±9 % band**, min to max a 22 % spread, on runs
+whose `src/` differences cannot plausibly account for it. Any claim about a
+Windows speed-up smaller than that band is unfalsifiable from CI alone.
+
+For scale, the same suite on Linux (`ubuntu-22.04`, run `32387290916`) is
+**22.89 s** against Windows' ~220 s — roughly **11×**, and not one pathological
+test: Linux's slowest single case is 1.77 s while Windows has a dozen in the
+2–9 s range and a long flat tail. A broad per-test constant is the signature of
+**per-process overhead**, since every one of these tests spawns git repeatedly.
 
 ## Method
 
@@ -117,6 +127,21 @@ Same shim, same binary, after the change:
 calls take the unborn fallback and some `rev-parse` calls come from other
 sites (`RefStore::resolveRevision`, `BisectOps`).
 
+Per call, on macOS, 60 iterations against a real repository: the two-process
+form costs **11.3 ms** and the one-process form **5.9 ms** — 5.5 ms saved, or
+48 %. A user operation runs `readHead()` twice (once in `recordUndoPoint()`,
+once in the refresh's `load()`), so that is ~11 ms per operation on macOS and,
+extrapolating from Windows' higher per-process cost, plausibly 60–120 ms there.
+The extrapolation is not a measurement.
+
+**CI cannot confirm this, and does not.** The Windows run carrying the change
+(`32393264652`, 517 tests, 226.47 s) lands at **0.4380 s/test** — z = +0.02
+against the six-run population above, i.e. dead on its mean. Quoting it against
+the 0.4923 s/test baseline alone would manufacture a −11 % "improvement" that
+the rest of the population does not support; that baseline simply happened to
+be the slowest run in the set. The defensible claims here are the deterministic
+ones — 89 fewer processes, 5.5 ms per call — not a CI delta.
+
 ## What this does *not* fix
 
 Stated plainly so the CI number is not mistaken for the target:
@@ -143,7 +168,6 @@ Stated plainly so the CI number is not mistaken for the target:
 
 `--no-optional-locks` (issue #77) was checked for a Windows regression, since
 skipping the index stat-cache refresh could in principle cost later `status`
-calls. It did not: the Windows job ran **8 m 52 s** with it against a
-**9 m 25 s** baseline on the same tree without it — inside the noise, and if
-anything faster, which is consistent with fewer index writes for Defender to
-scan.
+calls. Its run is the fastest of the six above (0.4002 s/test) — but that is
+z = −0.95, still inside the band, so the honest reading is "no regression
+detected", not "measurably faster".

--- a/docs/reports/windows-process-cost.md
+++ b/docs/reports/windows-process-cost.md
@@ -1,0 +1,149 @@
+# Windows process-spawn cost, measured (2026-08)
+
+Why the C++ suite takes four minutes on Windows and twenty seconds on Linux,
+what part of that gap the *application* is responsible for, and what was
+actually changed. Written because the ratio is large enough that "Windows is
+just slow" is not a useful answer, and because two of the three contributing
+costs are **not** in `src/` at all — a fact worth recording before someone
+optimises the wrong layer.
+
+## The gap
+
+From one CI run (PR #73, run `32387290916`, identical `src/` tree on every
+platform, `cmake --workflow --preset capi-only`):
+
+| Platform | ctest total | Job wall clock |
+|---|---|---|
+| Linux (`ubuntu-22.04`) | **22.89 s** | 3 m 31 s |
+| macOS (`macos-26`, arm64) | — | 2 m 18 s |
+| Windows (`windows-latest`) | **251.54 s** | 9 m 25 s |
+
+**11×**, and it is not one pathological test. Linux's slowest single test is
+1.77 s; Windows has a dozen in the 2–9 s range and a long flat tail. A broad
+per-test constant, not an outlier, is the signature of **per-process
+overhead** — every one of these tests spawns git repeatedly.
+
+## Method
+
+Two independent counters, run against the same binary so they cross-check:
+
+1. **In-process**: a temporary atomic counter in `ProcessRunner`'s `execute()`
+   funnel, keyed by `command.args[0]`. Counts what the *app* spawns.
+2. **PATH shim**: a `git` shim script earlier on `PATH` than the real binary,
+   appending `$1` to a log and `exec`-ing through. Counts what *anything*
+   spawns — app and test fixtures alike, since `GitExecutable::detect()`
+   searches `PATH` and `std::system()` inherits it.
+
+Both were run over the whole `gbm_capi_tests` binary on macOS. Platform does
+not matter for a *count*; only the per-spawn cost is platform-specific.
+
+## What the counts showed
+
+`gbm_capi_tests`, before any change:
+
+| Source | git invocations | Share |
+|---|---|---|
+| Test fixtures (`std::system`) | 903 | 65 % |
+| Application (`ProcessRunner`) | 475 + 35 `--version` probes | 35 % |
+| **Total** | **1378** | |
+
+And within the application's own 510, the distribution was lopsided:
+
+| git subcommand | count |
+|---|---|
+| `rev-parse` | 115 |
+| `symbolic-ref` | 111 |
+| `status` | 53 |
+| `--version` (`GitExecutable::probe`) | 35 |
+| `for-each-ref` | 33 |
+| everything else | ≤ 22 each |
+
+**`rev-parse` + `symbolic-ref` = 226 of 510 — 44 % of every git process the
+app started was spent reading HEAD.** That is the finding this report exists
+for.
+
+## Why HEAD was costing two processes
+
+`RefStore::readHead()` issued `symbolic-ref --quiet HEAD` for the branch name
+and then `rev-parse --verify --quiet HEAD` for the oid, unconditionally. It
+sits on two hot paths at once:
+
+- `RefStore::load()` — every refs refresh.
+- `OperationRunner::recordUndoPoint()` — before **every** undoable write.
+
+So on Windows each write operation paid roughly two spawns of pure overhead
+before it began, and the refresh that followed paid two more.
+
+### The fix
+
+One command supplies both facts:
+
+```
+git rev-parse --revs-only HEAD --symbolic-full-name HEAD
+```
+
+| HEAD state | exit | stdout |
+|---|---|---|
+| On a branch | 0 | `<oid>` then `refs/heads/<name>` |
+| Detached | 0 | `<oid>` then the literal `HEAD` |
+| Unborn (no commits) | 0 | *empty* |
+
+`--revs-only` is load bearing rather than decoration. Without it the same
+argument list exits 128 on an unborn repository and writes `fatal: ambiguous
+argument 'HEAD'` to stderr — and `ProcessRunner::recordOperation()` records
+*every* invocation, stderr included, into the operation log the user can
+read. A freshly-initialised repository is a normal state, and it would have
+been described there as a fatal error.
+
+Unborn is the one case that still costs a second process: the combined
+command cannot name the branch HEAD is parked on, so it falls back to the old
+`symbolic-ref`. That is 2 spawns, exactly as before — no regression, and the
+common cases drop to 1.
+
+Detached is recognised by the literal string `HEAD` on line two. That is
+unambiguous, not merely convenient: a real branch always comes back fully
+qualified as `refs/heads/…`.
+
+### Measured effect
+
+Same shim, same binary, after the change:
+
+| | before | after | delta |
+|---|---|---|---|
+| App git spawns | 475 | **386** | **−89 (−18.7 %)** |
+| All git invocations | 1378 | 1289 | −89 (−6.5 %) |
+
+89 rather than the 113 a naive halving predicts, because some `readHead()`
+calls take the unborn fallback and some `rev-parse` calls come from other
+sites (`RefStore::resolveRevision`, `BisectOps`).
+
+## What this does *not* fix
+
+Stated plainly so the CI number is not mistaken for the target:
+
+1. **Test fixtures dominate, and they are not app code.** 903 of 1378
+   invocations come from `runGit()` helpers built on `std::system()`. On
+   Windows that spawns **`cmd.exe` *and* `git.exe`** per call — roughly 1806
+   processes for the fixtures against 386 for the app. No change under `src/`
+   can touch this. Replacing `std::system()` with a direct spawn would be the
+   single largest win available for the *test job*.
+2. **ctest runs serially in CI.** `CMakePresets.json`'s `tbase` test preset
+   sets no `execution.jobs`, so all 511 cases run one at a time on every
+   platform. Parallelising would compress Windows' 251 s substantially — but
+   see **#70**: `UndoApiTest`/`MergeApiTest` (and, observed while writing
+   this, `BisectApiTest.BisectResetEndsTheSessionAndRestoresTheOriginalBranch`)
+   already fail intermittently under parallel load with a fixed 10 s
+   `waitFor` budget. Turning on `-j` in CI without settling #70 first would
+   trade wall clock for flakes. Deliberately not done here.
+3. **The remaining app spawns are mostly irreducible.** `status`, `diff` and
+   `for-each-ref` each answer a distinct question; `--version` is one probe
+   per `Session`.
+
+## Sundry
+
+`--no-optional-locks` (issue #77) was checked for a Windows regression, since
+skipping the index stat-cache refresh could in principle cost later `status`
+calls. It did not: the Windows job ran **8 m 52 s** with it against a
+**9 m 25 s** baseline on the same tree without it — inside the noise, and if
+anything faster, which is consistent with fewer index writes for Defender to
+scan.

--- a/src/core/git/RefStore.cpp
+++ b/src/core/git/RefStore.cpp
@@ -146,28 +146,62 @@ GitResult<HeadInfo> RefStore::readHead(CancellationToken token) {
     GBM_ASSERT_NOT_UI_THREAD();
 
     HeadInfo head;
-    GitCommand command(paths_.commandDir(), {"symbolic-ref", "--quiet", "HEAD"});
+
+    // Both facts about HEAD -- which ref it points at and which commit that
+    // resolves to -- come from one git process, not two. This used to be a
+    // `symbolic-ref` followed by a `rev-parse`, and it sits on two hot paths at
+    // once: RefStore::load() runs it on every refs refresh, and
+    // OperationRunner::recordUndoPoint() runs it before every undoable write.
+    // Process creation costs roughly two orders of magnitude more on Windows
+    // than on Linux, so the spare spawn was a measurable share of the work
+    // there rather than a rounding error.
+    //
+    // `--revs-only` is load bearing. Without it this argument list exits 128 on
+    // a repository with no commits yet and writes "fatal: ambiguous argument
+    // 'HEAD'" to stderr -- and ProcessRunner records every invocation, stderr
+    // included, into the operation log the user can read. With it, an
+    // unresolvable HEAD is simply empty output and exit 0, which is the right
+    // shape for what is a normal state rather than an error.
+    GitCommand command(paths_.commandDir(),
+                       {"rev-parse", "--revs-only", "HEAD", "--symbolic-full-name", "HEAD"});
     command.timeout = std::chrono::seconds(15);
-    auto symbolic = runner_.run(command, token);
+    auto resolved = runner_.run(command, token);
 
-    if (symbolic && !symbolic->out.empty()) {
-        head.kind = HeadInfo::Kind::Branch;
-        head.fullRef = symbolic->out;
-        head.branchName = shortNameFor(head.fullRef, RefKind::LocalBranch);
-    } else {
-        head.kind = HeadInfo::Kind::Detached;
-    }
+    if (resolved && !resolved->out.empty()) {
+        // "<oid>\n<symbolic name>" -- run() joins records with '\n' and trims
+        // the trailing one.
+        const std::size_t split = resolved->out.find('\n');
+        const std::string oid = resolved->out.substr(0, split);
+        const std::string symbolic =
+            split == std::string::npos ? std::string() : resolved->out.substr(split + 1);
 
-    GitCommand revParse(paths_.commandDir(), {"rev-parse", "--verify", "--quiet", "HEAD"});
-    revParse.timeout = std::chrono::seconds(15);
-    auto resolved = runner_.run(revParse, token);
-    if (!resolved || resolved->out.empty()) {
-        // No commits yet. A fresh repository must still open cleanly rather than
-        // reporting an error, so this is a normal state, not a failure.
-        head.kind = HeadInfo::Kind::Unborn;
+        // git prints the literal string "HEAD" for a detached head. A branch
+        // always comes back fully qualified as `refs/heads/...`, so this cannot
+        // collide with a real branch name.
+        if (symbolic.empty() || symbolic == "HEAD") {
+            head.kind = HeadInfo::Kind::Detached;
+        } else {
+            head.kind = HeadInfo::Kind::Branch;
+            head.fullRef = symbolic;
+            head.branchName = shortNameFor(head.fullRef, RefKind::LocalBranch);
+        }
+        head.target = ObjectId::fromHex(oid);
         return head;
     }
-    head.target = ObjectId::fromHex(resolved->out);
+
+    // No commits yet. A fresh repository must still open cleanly rather than
+    // reporting an error, so this is a normal state, not a failure -- and the
+    // branch HEAD is parked on is still worth showing. The command above cannot
+    // supply that name (an unresolvable HEAD yields no output at all), so this
+    // one case still costs a second process, exactly as it did before.
+    head.kind = HeadInfo::Kind::Unborn;
+    GitCommand symbolicRef(paths_.commandDir(), {"symbolic-ref", "--quiet", "HEAD"});
+    symbolicRef.timeout = std::chrono::seconds(15);
+    auto symbolic = runner_.run(symbolicRef, token);
+    if (symbolic && !symbolic->out.empty()) {
+        head.fullRef = symbolic->out;
+        head.branchName = shortNameFor(head.fullRef, RefKind::LocalBranch);
+    }
     return head;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(gbm_core_tests
     unit/OriginalOperationMessageTest.cpp
     unit/PreparedCommitMessageTest.cpp
     unit/ProcessRunnerTest.cpp
+    unit/RefStoreHeadTest.cpp
     unit/RemoteOpsTest.cpp
     unit/RepoStateTest.cpp
     unit/SideBySideDiffTest.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GoogleTest)
 
 # Test doubles live here rather than in the shipped library.
-add_library(gbm_test_support STATIC support/FakeProcessRunner.cpp)
+add_library(gbm_test_support STATIC support/FakeProcessRunner.cpp support/GitCli.cpp)
 target_include_directories(gbm_test_support PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(gbm_test_support PUBLIC gbm_core PRIVATE gbm_warnings)
 
@@ -13,6 +13,7 @@ add_executable(gbm_core_tests
     unit/ConflictMarkerParserTest.cpp
     unit/CoreBasicsTest.cpp
     unit/DiscoveryTest.cpp
+    unit/GitCliTest.cpp
     unit/GitExecutableTest.cpp
     unit/GitIntegrationTest.cpp
     unit/GraphBuilderTest.cpp
@@ -147,7 +148,7 @@ if(GBM_BUILD_CAPI)
         capi/WorktreeApiTest.cpp
     )
     target_link_libraries(gbm_capi_tests
-        PRIVATE gbm_capi gbm_core GTest::gtest GTest::gtest_main gbm_warnings gbm_sanitizers)
+        PRIVATE gbm_capi gbm_core gbm_test_support GTest::gtest GTest::gtest_main gbm_warnings gbm_sanitizers)
 
     # gbm_capi is SHARED, so on Windows (no RPATH like Linux/macOS) the
     # loader can't find gbm_capi.dll unless it sits next to the .exe --

--- a/tests/capi/BisectApiTest.cpp
+++ b/tests/capi/BisectApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -104,17 +105,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {

--- a/tests/capi/BisectApiTest.cpp
+++ b/tests/capi/BisectApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -109,27 +111,16 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {
-        const std::string outFile = (repo_ / "..gbm_rev.txt").string();
-        std::string command = "git -C \"" + repo_.string() + "\" rev-parse " + revision + " > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(repo_, {"rev-parse", revision}).firstLine();
     }
 
     std::string currentBranch() {
-        const std::string outFile = (repo_ / "..gbm_branch.txt").string();
-        std::string command = "git -C \"" + repo_.string() + "\" symbolic-ref --short -q HEAD > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(repo_, {"symbolic-ref", "--short", "-q", "HEAD"})
+            .firstLine();
     }
 
     std::string bisectStatusJson() {

--- a/tests/capi/BisectApiTest.cpp
+++ b/tests/capi/BisectApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class BisectApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/BlameApiTest.cpp
+++ b/tests/capi/BlameApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -95,17 +96,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/BlameApiTest.cpp
+++ b/tests/capi/BlameApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -100,7 +102,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/BlameApiTest.cpp
+++ b/tests/capi/BlameApiTest.cpp
@@ -60,9 +60,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class BlameApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/BranchApiTest.cpp
+++ b/tests/capi/BranchApiTest.cpp
@@ -2,6 +2,7 @@
 // repo with two commits and a couple of extra local branches.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <algorithm>
 #include <chrono>
@@ -145,17 +146,11 @@ protected:
         return line;
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::vector<std::string> localBranches() {

--- a/tests/capi/BranchApiTest.cpp
+++ b/tests/capi/BranchApiTest.cpp
@@ -19,6 +19,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -150,29 +152,20 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::vector<std::string> localBranches() {
         const std::string outFile = (repo_ / "..gbm_branch_test_list.txt").string();
-        // Double quotes, not single: single quotes are POSIX-shell syntax
-        // that cmd.exe passes through literally to git.exe on Windows
-        // instead of stripping, so git received them as part of the format
-        // string and the branch names never came back bare. Unquoted
-        // doesn't work either -- dash (Debian/Ubuntu's /bin/sh, which
-        // std::system() invokes) treats the embedded parens in
-        // %(refname:short) as a syntax error even mid-word. Double quotes
-        // are stripped correctly by both dash and Windows' argv parsing.
-        std::string command =
-            "git -C \"" + repo_.string() + "\" branch --format=\"%(refname:short)\" > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::vector<std::string> names;
-        std::string line;
-        while (std::getline(in, line)) {
-            if (!line.empty()) names.push_back(line);
-        }
-        return names;
+        // This used to build a command string, and the quoting was a genuine
+        // hazard rather than a theoretical one: single quotes are POSIX-shell
+        // syntax that cmd.exe passes through literally to git.exe on Windows,
+        // so git got them as part of the format string and the branch names
+        // never came back bare -- while leaving %(refname:short) unquoted made
+        // dash treat the parentheses as a syntax error. An argv vector has
+        // neither problem, because no shell ever sees it.
+        return GitCli::capture(repo_, {"branch", "--format=%(refname:short)"})
+            .lines();
     }
 
     bool waitForOperationFinished() {
@@ -215,26 +208,16 @@ TEST_F(BranchApiTest, CreateBranchAddsALocalBranchWithoutMovingHead) {
     const auto branches = localBranches();
     EXPECT_NE(std::find(branches.begin(), branches.end(), "feature-1"), branches.end());
 
-    const std::string outFile = (repo_ / "..gbm_branch_test_head.txt").string();
-    std::string command = "git -C \"" + repo_.string() + "\" symbolic-ref --short HEAD > \"" + outFile + "\"";
-    [[maybe_unused]] const int rc = std::system(command.c_str());
-    std::ifstream in(outFile);
-    std::string head;
-    std::getline(in, head);
-    EXPECT_EQ(head, "main");
+    EXPECT_EQ(GitCli::capture(repo_, {"symbolic-ref", "--short", "HEAD"}).firstLine(),
+              "main");
 }
 
 TEST_F(BranchApiTest, CreateBranchWithCheckoutAfterMovesHead) {
     gbm_branch_create(session_, "feature-2", "", /*checkoutAfter=*/1, /*setUpstream=*/0, "");
     ASSERT_TRUE(waitForOperationFinished());
 
-    const std::string outFile = (repo_ / "..gbm_branch_test_head2.txt").string();
-    std::string command = "git -C \"" + repo_.string() + "\" symbolic-ref --short HEAD > \"" + outFile + "\"";
-    [[maybe_unused]] const int rc = std::system(command.c_str());
-    std::ifstream in(outFile);
-    std::string head;
-    std::getline(in, head);
-    EXPECT_EQ(head, "feature-2");
+    EXPECT_EQ(GitCli::capture(repo_, {"symbolic-ref", "--short", "HEAD"}).firstLine(),
+              "feature-2");
 }
 
 TEST_F(BranchApiTest, RenameBranchChangesTheLocalBranchName) {

--- a/tests/capi/BranchApiTest.cpp
+++ b/tests/capi/BranchApiTest.cpp
@@ -52,9 +52,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class BranchApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/BranchApiTest.cpp
+++ b/tests/capi/BranchApiTest.cpp
@@ -108,46 +108,21 @@ protected:
     }
 
     int runIn(const std::filesystem::path& dir, std::vector<std::string> args) {
-        std::string command = "git -C \"" + dir.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return GitCli::run(dir, std::move(args));
     }
 
     /// Branch names present in the bare remote, read from the remote itself
     /// rather than from any remote-tracking ref -- a stale local ref would
     /// otherwise make a failed delete look like it worked.
     std::vector<std::string> remoteBranches() {
-        const std::string outFile = (repo_ / "..gbm_remote_branch_list.txt").string();
-        const std::string command = "git -C \"" + remote_.string() +
-                                    "\" branch --format=\"%(refname:short)\" > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::vector<std::string> names;
-        std::string line;
-        while (std::getline(in, line)) {
-            if (!line.empty()) names.push_back(line);
-        }
-        return names;
+        return GitCli::capture(remote_, {"branch", "--format=%(refname:short)"}).lines();
     }
 
     /// `branch`'s configured upstream, or empty when it has none.
     std::string upstreamOf(const std::string& branch) {
-        const std::string outFile = (repo_ / "..gbm_upstream.txt").string();
-        const std::string command = "git -C \"" + repo_.string() + "\" for-each-ref " +
-                                    "--format=\"%(upstream:short)\" \"refs/heads/" + branch +
-                                    "\" > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(
+                   repo_, {"for-each-ref", "--format=%(upstream:short)", "refs/heads/" + branch})
+            .firstLine();
     }
 
     /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h

--- a/tests/capi/CherryPickRevertApiTest.cpp
+++ b/tests/capi/CherryPickRevertApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -124,17 +126,11 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {
-        const std::string outFile = (repo_ / "..gbm_rev.txt").string();
-        std::string command = "git -C \"" + repo_.string() + "\" rev-parse " + revision + " > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(repo_, {"rev-parse", revision}).firstLine();
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/CherryPickRevertApiTest.cpp
+++ b/tests/capi/CherryPickRevertApiTest.cpp
@@ -2,6 +2,7 @@
 // surface (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -119,17 +120,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {

--- a/tests/capi/CherryPickRevertApiTest.cpp
+++ b/tests/capi/CherryPickRevertApiTest.cpp
@@ -69,9 +69,11 @@ bool waitForOperationFinished(EventLog& log) {
 class CherryPickRevertApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/CommitFilesApiTest.cpp
+++ b/tests/capi/CommitFilesApiTest.cpp
@@ -19,6 +19,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -99,17 +101,15 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string revParseHead() {
-        const std::filesystem::path out = repo_ / "head-oid.txt";
-        std::string command = "git -C \"" + repo_.string() + "\" rev-parse HEAD > \"" + out.string() + "\"";
-        if (std::system(command.c_str()) != 0) return "";
-        std::ifstream in(out);
-        std::string oid;
-        std::getline(in, oid);
-        return oid;
+        // The redirect this replaces wrote head-oid.txt *inside* the
+        // repository under test, leaving an untracked file behind for every
+        // later status read to trip over.
+        const auto result = GitCli::capture(repo_, {"rev-parse", "HEAD"});
+        return result.exitCode == 0 ? result.firstLine() : std::string();
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/CommitFilesApiTest.cpp
+++ b/tests/capi/CommitFilesApiTest.cpp
@@ -3,6 +3,7 @@
 // gbm_request_commit_file_diff()/GBM_EVENT_COMMIT_FILE_DIFF_READY.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -94,17 +95,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string revParseHead() {

--- a/tests/capi/CommitFilesApiTest.cpp
+++ b/tests/capi/CommitFilesApiTest.cpp
@@ -61,9 +61,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class CommitFilesApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/CommitMetaApiTest.cpp
+++ b/tests/capi/CommitMetaApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -98,17 +100,15 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string revParseHead() {
-        const std::filesystem::path out = repo_ / "head-oid.txt";
-        std::string command = "git -C \"" + repo_.string() + "\" rev-parse HEAD > \"" + out.string() + "\"";
-        if (std::system(command.c_str()) != 0) return "";
-        std::ifstream in(out);
-        std::string oid;
-        std::getline(in, oid);
-        return oid;
+        // The redirect this replaces wrote head-oid.txt *inside* the
+        // repository under test, leaving an untracked file behind for every
+        // later status read to trip over.
+        const auto result = GitCli::capture(repo_, {"rev-parse", "HEAD"});
+        return result.exitCode == 0 ? result.firstLine() : std::string();
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/CommitMetaApiTest.cpp
+++ b/tests/capi/CommitMetaApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h): gbm_request_commit_meta()/GBM_EVENT_COMMIT_META_READY.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -93,17 +94,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string revParseHead() {

--- a/tests/capi/CommitMetaApiTest.cpp
+++ b/tests/capi/CommitMetaApiTest.cpp
@@ -60,9 +60,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class CommitMetaApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/CompareApiTest.cpp
+++ b/tests/capi/CompareApiTest.cpp
@@ -69,9 +69,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class CompareApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/CompareApiTest.cpp
+++ b/tests/capi/CompareApiTest.cpp
@@ -5,6 +5,7 @@
 // needed, just two branches in one repo.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -110,17 +111,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/CompareApiTest.cpp
+++ b/tests/capi/CompareApiTest.cpp
@@ -20,6 +20,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -115,7 +117,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/ConflictMarkerApiTest.cpp
+++ b/tests/capi/ConflictMarkerApiTest.cpp
@@ -21,6 +21,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -110,7 +112,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/ConflictMarkerApiTest.cpp
+++ b/tests/capi/ConflictMarkerApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class ConflictMarkerApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/ConflictMarkerApiTest.cpp
+++ b/tests/capi/ConflictMarkerApiTest.cpp
@@ -5,6 +5,7 @@
 // conflict markers, not a hand-written approximation of them.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -105,17 +106,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/DiscoveryApiTest.cpp
+++ b/tests/capi/DiscoveryApiTest.cpp
@@ -28,9 +28,11 @@ std::string jsonNeedle(const std::filesystem::path& path) {
 class DiscoveryApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/DiscoveryApiTest.cpp
+++ b/tests/capi/DiscoveryApiTest.cpp
@@ -1,5 +1,6 @@
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <cstdlib>
 #include <filesystem>
@@ -9,6 +10,8 @@
 
 namespace gbm::capi {
 namespace {
+
+using ::gbm::testing::GitCli;
 
 // Windows paths contain backslashes, which JSON escapes as `\\` -- searching
 // the raw path.string() as a substring of serialized JSON never matches
@@ -38,14 +41,8 @@ protected:
         std::filesystem::remove_all(base_);
         std::filesystem::create_directories(repo_);
 
-#ifdef _WIN32
-        const std::string cmd = "git -C \"" + repo_.string() +
-                                "\" init --quiet --initial-branch=main >NUL 2>&1";
-#else
-        const std::string cmd = "git -C \"" + repo_.string() +
-                                "\" init --quiet --initial-branch=main >/dev/null 2>&1";
-#endif
-        ASSERT_EQ(std::system(cmd.c_str()), 0);
+        ASSERT_EQ(GitCli::run(repo_, {"init", "--quiet", "--initial-branch=main"}),
+                  0);
     }
 
     void TearDown() override {

--- a/tests/capi/FileAtRevisionApiTest.cpp
+++ b/tests/capi/FileAtRevisionApiTest.cpp
@@ -96,9 +96,11 @@ std::string readAllBytes(const std::filesystem::path& path) {
 class FileAtRevisionApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/FileAtRevisionApiTest.cpp
+++ b/tests/capi/FileAtRevisionApiTest.cpp
@@ -27,6 +27,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -150,7 +152,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     /// Fires the export and blocks until its reply arrives, returning the

--- a/tests/capi/FileAtRevisionApiTest.cpp
+++ b/tests/capi/FileAtRevisionApiTest.cpp
@@ -11,6 +11,7 @@
 // ExportsABinaryFileByteIdentical exists to prove.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -145,17 +146,11 @@ protected:
         std::filesystem::remove_all(out_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     /// Fires the export and blocks until its reply arrives, returning the

--- a/tests/capi/FileHistoryApiTest.cpp
+++ b/tests/capi/FileHistoryApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -101,7 +103,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/FileHistoryApiTest.cpp
+++ b/tests/capi/FileHistoryApiTest.cpp
@@ -2,6 +2,7 @@
 // extern "C" surface (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -96,17 +97,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/FileHistoryApiTest.cpp
+++ b/tests/capi/FileHistoryApiTest.cpp
@@ -60,9 +60,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class FileHistoryApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/IdentityApiTest.cpp
+++ b/tests/capi/IdentityApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class IdentityApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/IdentityApiTest.cpp
+++ b/tests/capi/IdentityApiTest.cpp
@@ -2,6 +2,7 @@
 // commit-graph maintenance slice of the extern "C" surface (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -93,17 +94,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string localIdentityJson() {

--- a/tests/capi/IdentityApiTest.cpp
+++ b/tests/capi/IdentityApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -98,7 +100,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string localIdentityJson() {

--- a/tests/capi/InitCloneApiTest.cpp
+++ b/tests/capi/InitCloneApiTest.cpp
@@ -28,9 +28,11 @@ std::string lastResultJson() {
 class InitCloneApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/InitCloneApiTest.cpp
+++ b/tests/capi/InitCloneApiTest.cpp
@@ -5,6 +5,7 @@
 // askpass for it, so this stays fully offline, same as RemoteApiTest.cpp.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <cstdlib>
 #include <filesystem>
@@ -14,6 +15,8 @@
 
 namespace gbm::capi {
 namespace {
+
+using ::gbm::testing::GitCli;
 
 std::string lastResultJson() {
     std::string json(static_cast<std::size_t>(gbm_last_result_json_len()), '\0');
@@ -52,18 +55,22 @@ protected:
         const std::filesystem::path scratch = base_ / "origin-scratch";
         std::filesystem::create_directories(scratch);
 
-        auto run = [](const std::string& cmd) { ASSERT_EQ(std::system(cmd.c_str()), 0); };
-        run("git init --quiet --bare --initial-branch=main \"" + origin.string() + "\"");
-        run("git -C \"" + scratch.string() + "\" init --quiet --initial-branch=main");
-        run("git -C \"" + scratch.string() + "\" config user.email test@example.com");
-        run("git -C \"" + scratch.string() + "\" config user.name Test");
+        auto run = [](const std::filesystem::path& dir, std::vector<std::string> args) {
+            ASSERT_EQ(GitCli::run(dir, std::move(args)), 0);
+        };
+        // `git init <dir>` names the directory as an argument rather than
+        // running inside it, so the working directory here is the parent.
+        run(base_, {"init", "--quiet", "--bare", "--initial-branch=main", origin.string()});
+        run(scratch, {"init", "--quiet", "--initial-branch=main"});
+        run(scratch, {"config", "user.email", "test@example.com"});
+        run(scratch, {"config", "user.name", "Test"});
         {
             std::ofstream file(scratch / "README.md");
             file << "hello\n";
         }
-        run("git -C \"" + scratch.string() + "\" add README.md");
-        run("git -C \"" + scratch.string() + "\" commit --quiet -m initial");
-        run("git -C \"" + scratch.string() + "\" push --quiet \"" + origin.string() + "\" main");
+        run(scratch, {"add", "README.md"});
+        run(scratch, {"commit", "--quiet", "-m", "initial"});
+        run(scratch, {"push", "--quiet", origin.string(), "main"});
         return origin;
     }
 

--- a/tests/capi/LfsApiTest.cpp
+++ b/tests/capi/LfsApiTest.cpp
@@ -7,6 +7,7 @@
 // probe ran and published a boolean, not which value it published.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -93,17 +94,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/LfsApiTest.cpp
+++ b/tests/capi/LfsApiTest.cpp
@@ -23,6 +23,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -98,7 +100,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/LfsApiTest.cpp
+++ b/tests/capi/LfsApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class LfsApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/MergeApiTest.cpp
+++ b/tests/capi/MergeApiTest.cpp
@@ -19,6 +19,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -112,7 +114,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/MergeApiTest.cpp
+++ b/tests/capi/MergeApiTest.cpp
@@ -3,6 +3,7 @@
 // diverging branches.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -107,17 +108,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/MergeApiTest.cpp
+++ b/tests/capi/MergeApiTest.cpp
@@ -75,9 +75,11 @@ bool waitForOperationFinished(EventLog& log) {
 class MergeApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/OperationLogApiTest.cpp
+++ b/tests/capi/OperationLogApiTest.cpp
@@ -6,6 +6,7 @@
 // process-wide gbm::Log sink gets routed back to the right session.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <algorithm>
 #include <chrono>
@@ -107,17 +108,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/OperationLogApiTest.cpp
+++ b/tests/capi/OperationLogApiTest.cpp
@@ -77,9 +77,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class OperationLogApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/OperationLogApiTest.cpp
+++ b/tests/capi/OperationLogApiTest.cpp
@@ -23,6 +23,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 // Windows paths contain backslashes, which JSON escapes as `\\` -- searching
 // the raw path.string() as a substring of serialized JSON never matches
 // there, even though the same code is correct on POSIX where paths use `/`.
@@ -112,7 +114,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/OriginalOperationMessageApiTest.cpp
+++ b/tests/capi/OriginalOperationMessageApiTest.cpp
@@ -115,9 +115,11 @@ bool waitForWorkingCopyStatusUpdated(EventLog& log) {
 class OriginalOperationMessageApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/OriginalOperationMessageApiTest.cpp
+++ b/tests/capi/OriginalOperationMessageApiTest.cpp
@@ -20,6 +20,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -160,29 +162,18 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {
-        const std::string outFile = (repo_ / "..gbm_rev.txt").string();
-        std::string command = "git -C \"" + repo_.string() + "\" rev-parse " + revision + " > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(repo_, {"rev-parse", revision}).firstLine();
     }
 
     // Trims trailing newlines: `git log --format=%B` appends its own
     // terminator on top of the commit message's own trailing newline, and
     // that formatting detail is not what these tests care about.
     std::string headCommitMessage() {
-        const std::string outFile = (repo_ / "..gbm_msg.txt").string();
-        std::string command =
-            "git -C \"" + repo_.string() + "\" log -1 --format=%B > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        std::string content = GitCli::capture(repo_, {"log", "-1", "--format=%B"}).out;
         while (!content.empty() && content.back() == '\n') {
             content.pop_back();
         }

--- a/tests/capi/OriginalOperationMessageApiTest.cpp
+++ b/tests/capi/OriginalOperationMessageApiTest.cpp
@@ -4,6 +4,7 @@
 // gbm_cherry_pick_continue_with_message()/gbm_rebase_continue_with_message().
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -155,17 +156,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {

--- a/tests/capi/PatchApiTest.cpp
+++ b/tests/capi/PatchApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class PatchApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/PatchApiTest.cpp
+++ b/tests/capi/PatchApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -108,17 +110,11 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {
-        const std::string outFile = (repo_ / "..gbm_rev.txt").string();
-        std::string command = "git -C \"" + repo_.string() + "\" rev-parse " + revision + " > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(repo_, {"rev-parse", revision}).firstLine();
     }
 
     bool waitForWorkingCopyOperationFinished() {
@@ -153,9 +149,16 @@ TEST_F(PatchApiTest, ApplyPatchFilesAppliesADiffToTheWorkTree) {
     // the work tree and re-apply it through gbm_patch_apply_files() instead.
     std::ofstream(repo_ / "file.txt") << "v1\nv2\nv3\n";
     const std::filesystem::path patchFile = outputDir_ / "change.patch";
-    std::string diffCommand =
-        "git -C \"" + repo_.string() + "\" diff > \"" + patchFile.string() + "\"";
-    ASSERT_EQ(std::system(diffCommand.c_str()), 0);
+    // Written out here rather than by a shell redirect. GitCliResult::out is
+    // not byte-exact stdout -- the line splitter behind it drops the final
+    // separator -- so the newline `git apply` expects at the end of the last
+    // hunk is put back explicitly. That is exact for this fixture, whose file
+    // content is LF-only and newline-terminated; a patch over CRLF content or
+    // over a file with no trailing newline would need real bytes instead.
+    const auto diff = GitCli::capture(repo_, {"diff"});
+    ASSERT_EQ(diff.exitCode, 0);
+    ASSERT_FALSE(diff.out.empty());
+    std::ofstream(patchFile, std::ios::binary) << diff.out << "\n";
     ASSERT_EQ(runGit({"checkout", "--quiet", "--", "file.txt"}), 0);
 
     // gbm_patch_apply_files() shells out with paths.commandDir() as its

--- a/tests/capi/PatchApiTest.cpp
+++ b/tests/capi/PatchApiTest.cpp
@@ -2,6 +2,7 @@
 // surface (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -103,17 +104,11 @@ protected:
         std::filesystem::remove_all(outputDir_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string commitHex(const std::string& revision) {

--- a/tests/capi/RebaseApiTest.cpp
+++ b/tests/capi/RebaseApiTest.cpp
@@ -60,9 +60,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class RebaseApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/RebaseApiTest.cpp
+++ b/tests/capi/RebaseApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -102,17 +103,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     bool waitForOperationFinished() {

--- a/tests/capi/RebaseApiTest.cpp
+++ b/tests/capi/RebaseApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -107,7 +109,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     bool waitForOperationFinished() {
@@ -147,8 +149,7 @@ TEST_F(RebaseApiTest, PlainRebaseReplaysFeatureCommitsOntoMain) {
     // feature no longer contains "Commit unique to main" as an unmerged
     // ancestor of main -- after a successful rebase, main is now an ancestor
     // of feature.
-    const std::string command = "git -C \"" + repo_.string() + "\" merge-base --is-ancestor main feature";
-    EXPECT_EQ(std::system(command.c_str()), 0);
+    EXPECT_EQ(GitCli::run(repo_, {"merge-base", "--is-ancestor", "main", "feature"}), 0);
 
     std::ifstream file(repo_ / "feature.txt");
     ASSERT_TRUE(file.good());

--- a/tests/capi/ReflogApiTest.cpp
+++ b/tests/capi/ReflogApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -95,17 +96,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/ReflogApiTest.cpp
+++ b/tests/capi/ReflogApiTest.cpp
@@ -60,9 +60,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class ReflogApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/ReflogApiTest.cpp
+++ b/tests/capi/ReflogApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -100,7 +102,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/RemoteApiTest.cpp
+++ b/tests/capi/RemoteApiTest.cpp
@@ -92,9 +92,11 @@ bool waitForOperationFinished(EventLog& log) {
 class RemoteApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/RemoteApiTest.cpp
+++ b/tests/capi/RemoteApiTest.cpp
@@ -4,6 +4,7 @@
 // never invokes askpass for it, so these stay fully offline.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -18,6 +19,8 @@
 
 namespace gbm::capi {
 namespace {
+
+using ::gbm::testing::GitCli;
 
 struct EventLog {
     std::mutex mutex;
@@ -133,16 +136,7 @@ protected:
     int runGit(std::vector<std::string> args) { return runIn(repo_, std::move(args)); }
 
     int runIn(const std::filesystem::path& dir, std::vector<std::string> args) {
-        std::string command = "git -C \"" + dir.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return GitCli::run(dir, std::move(args));
     }
 
     std::string remotesJson() {

--- a/tests/capi/ResetApiTest.cpp
+++ b/tests/capi/ResetApiTest.cpp
@@ -51,9 +51,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class ResetApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/ResetApiTest.cpp
+++ b/tests/capi/ResetApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -91,17 +93,11 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string headCommitSubject() {
-        const std::string outFile = (repo_ / "..gbm_reset_test_head.txt").string();
-        std::string command = "git -C \"" + repo_.string() + "\" log -1 --format=%s > \"" + outFile + "\"";
-        [[maybe_unused]] const int rc = std::system(command.c_str());
-        std::ifstream in(outFile);
-        std::string line;
-        std::getline(in, line);
-        return line;
+        return GitCli::capture(repo_, {"log", "-1", "--format=%s"}).firstLine();
     }
 
     bool waitForOperationFinished() {
@@ -125,13 +121,7 @@ TEST_F(ResetApiTest, SoftResetMovesHeadKeepsIndexAndWorkTree) {
 
     EXPECT_EQ(headCommitSubject(), "First commit");
     // Soft reset leaves the second commit's changes staged.
-    const std::string outFile = (repo_ / "..gbm_reset_test_staged.txt").string();
-    std::string diffCmd = "git -C \"" + repo_.string() + "\" diff --cached --name-only > \"" + outFile + "\"";
-    [[maybe_unused]] const int rc = std::system(diffCmd.c_str());
-    std::ifstream in(outFile);
-    std::string line;
-    std::getline(in, line);
-    EXPECT_EQ(line, "file.txt");
+    EXPECT_EQ(GitCli::capture(repo_, {"diff", "--cached", "--name-only"}).firstLine(), "file.txt");
 }
 
 TEST_F(ResetApiTest, HardResetMovesHeadAndDiscardsWorkTreeChanges) {
@@ -176,13 +166,9 @@ TEST_F(ResetApiTest, RestorePathsStagedUnstagesAFile) {
         return false;
     }));
 
-    const std::string outFile = (repo_ / "..gbm_restore_test_staged.txt").string();
-    std::string diffCmd = "git -C \"" + repo_.string() + "\" diff --cached --name-only > \"" + outFile + "\"";
-    [[maybe_unused]] const int rc = std::system(diffCmd.c_str());
-    std::ifstream in(outFile);
-    std::string line;
-    std::getline(in, line);
-    EXPECT_TRUE(line.empty()) << "expected nothing staged after --staged restore, got: " << line;
+    const std::string staged =
+        GitCli::capture(repo_, {"diff", "--cached", "--name-only"}).firstLine();
+    EXPECT_TRUE(staged.empty()) << "expected nothing staged after --staged restore, got: " << staged;
 }
 
 TEST_F(ResetApiTest, CleanUntrackedRemovesUntrackedFiles) {

--- a/tests/capi/ResetApiTest.cpp
+++ b/tests/capi/ResetApiTest.cpp
@@ -2,6 +2,7 @@
 // two commits and uncommitted changes.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -86,17 +87,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string headCommitSubject() {

--- a/tests/capi/SessionApiTest.cpp
+++ b/tests/capi/SessionApiTest.cpp
@@ -24,6 +24,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -104,7 +106,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/SessionApiTest.cpp
+++ b/tests/capi/SessionApiTest.cpp
@@ -7,6 +7,7 @@
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
 #include "core/graph/GraphSnapshot.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -99,17 +100,11 @@ protected:
 
     /// Shells out to the real `git` binary directly (not through gbm_capi) to
     /// build the fixture repository -- mirrors GitIntegrationTest's `run()`.
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::filesystem::path repo_;

--- a/tests/capi/SessionApiTest.cpp
+++ b/tests/capi/SessionApiTest.cpp
@@ -66,9 +66,11 @@ bool anyEventOfType(const std::vector<std::pair<int32_t, std::string>>& events, 
 class CapiSessionTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/StashApiTest.cpp
+++ b/tests/capi/StashApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -101,7 +103,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string stashesJson() {

--- a/tests/capi/StashApiTest.cpp
+++ b/tests/capi/StashApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h), against a real repository with uncommitted changes.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -96,17 +97,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string stashesJson() {

--- a/tests/capi/StashApiTest.cpp
+++ b/tests/capi/StashApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class StashApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/SubmoduleApiTest.cpp
+++ b/tests/capi/SubmoduleApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -16,6 +17,8 @@
 
 namespace gbm::capi {
 namespace {
+
+using ::gbm::testing::GitCli;
 
 struct EventLog {
     std::mutex mutex;
@@ -120,16 +123,7 @@ protected:
     }
 
     int runGitIn(const std::filesystem::path& dir, std::vector<std::string> args) {
-        std::string command = "git -C \"" + dir.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return GitCli::run(dir, std::move(args));
     }
 
     std::string submodulesJson() {

--- a/tests/capi/SubmoduleApiTest.cpp
+++ b/tests/capi/SubmoduleApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class SubmoduleApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/TagApiTest.cpp
+++ b/tests/capi/TagApiTest.cpp
@@ -5,6 +5,7 @@
 // offline like every other capi test.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -19,6 +20,8 @@
 
 namespace gbm::capi {
 namespace {
+
+using ::gbm::testing::GitCli;
 
 struct EventLog {
     std::mutex mutex;
@@ -118,16 +121,7 @@ protected:
     int runGit(std::vector<std::string> args) { return runIn(repo_, std::move(args)); }
 
     int runIn(const std::filesystem::path& dir, std::vector<std::string> args) {
-        std::string command = "git -C \"" + dir.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return GitCli::run(dir, std::move(args));
     }
 
     bool remoteHasTag(const std::string& name) {

--- a/tests/capi/TagApiTest.cpp
+++ b/tests/capi/TagApiTest.cpp
@@ -77,9 +77,11 @@ bool waitForWorkingCopyOperationFinished(EventLog& log) {
 class TagApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/UndoApiTest.cpp
+++ b/tests/capi/UndoApiTest.cpp
@@ -19,6 +19,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -134,7 +136,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string undoJournalJson() {

--- a/tests/capi/UndoApiTest.cpp
+++ b/tests/capi/UndoApiTest.cpp
@@ -98,9 +98,11 @@ bool waitForRefreshesToSettle(EventLog& log) {
 class UndoApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/UndoApiTest.cpp
+++ b/tests/capi/UndoApiTest.cpp
@@ -3,6 +3,7 @@
 // doc comment for the thread-safety story behind gbm_undo_journal_json().
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -129,17 +130,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string undoJournalJson() {

--- a/tests/capi/WorkingCopyApiTest.cpp
+++ b/tests/capi/WorkingCopyApiTest.cpp
@@ -62,9 +62,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class WorkingCopyApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/WorkingCopyApiTest.cpp
+++ b/tests/capi/WorkingCopyApiTest.cpp
@@ -3,6 +3,7 @@
 // uncommitted changes -- the working-copy analog of SessionApiTest.cpp.
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -99,17 +100,11 @@ protected:
         std::filesystem::remove_all(repo_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string statusJson() {

--- a/tests/capi/WorkingCopyApiTest.cpp
+++ b/tests/capi/WorkingCopyApiTest.cpp
@@ -19,6 +19,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -104,7 +106,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string statusJson() {

--- a/tests/capi/WorktreeApiTest.cpp
+++ b/tests/capi/WorktreeApiTest.cpp
@@ -2,6 +2,7 @@
 // (gbm_capi.h).
 #include "capi/gbm_capi.h"
 #include "core/git/GitExecutable.h"
+#include "support/GitCli.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -97,17 +98,11 @@ protected:
         std::filesystem::remove_all(extra_, ec);
     }
 
+    /// Fixture git, without a shell in the middle -- see tests/support/GitCli.h
+    /// for why that matters (one process instead of two, and no per-platform
+    /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        std::string command = "git -C \"" + repo_.string() + "\"";
-        for (const auto& arg : args) {
-            command += " \"" + arg + "\"";
-        }
-#ifdef _WIN32
-        command += " >NUL 2>&1";
-#else
-        command += " >/dev/null 2>&1";
-#endif
-        return std::system(command.c_str());
+        return ::gbm::testing::GitCli::run(repo_, std::move(args));
     }
 
     std::string worktreesJson() {

--- a/tests/capi/WorktreeApiTest.cpp
+++ b/tests/capi/WorktreeApiTest.cpp
@@ -63,9 +63,11 @@ void logCallback(GbmSessionHandle, int32_t eventType, const uint8_t* payload, in
 class WorktreeApiTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
-        auto detected = GitExecutable::detect();
-        if (!detected) {
-            GTEST_SKIP() << "no usable git found: " << detected.error().message;
+        // GitCli detects git once per test binary and caches it; this used to
+        // be a GitExecutable::detect() per suite, i.e. one `git --version`
+        // process each -- 29 of them across this binary.
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
         }
     }
 

--- a/tests/capi/WorktreeApiTest.cpp
+++ b/tests/capi/WorktreeApiTest.cpp
@@ -18,6 +18,8 @@
 namespace gbm::capi {
 namespace {
 
+using ::gbm::testing::GitCli;
+
 struct EventLog {
     std::mutex mutex;
     std::condition_variable cv;
@@ -102,7 +104,7 @@ protected:
     /// for why that matters (one process instead of two, and no per-platform
     /// quoting hazard).
     int runGit(std::vector<std::string> args) {
-        return ::gbm::testing::GitCli::run(repo_, std::move(args));
+        return GitCli::run(repo_, std::move(args));
     }
 
     std::string worktreesJson() {

--- a/tests/support/GitCli.cpp
+++ b/tests/support/GitCli.cpp
@@ -1,0 +1,72 @@
+#include "support/GitCli.h"
+
+#include "core/base/CancellationToken.h"
+#include "core/git/GitCommand.h"
+#include "core/git/GitExecutable.h"
+#include "core/git/IProcessRunner.h"
+
+#include <chrono>
+#include <memory>
+
+namespace gbm::testing {
+namespace {
+
+/// One detection and one runner per test binary. Detection spawns a
+/// `git --version`, and the previous per-fixture arrangement paid for that
+/// once per test rather than once per process.
+struct Shared {
+    std::filesystem::path executable;
+    std::unique_ptr<IProcessRunner> runner;
+
+    Shared() {
+        auto detected = GitExecutable::detect();
+        if (!detected) {
+            return;
+        }
+        executable = detected->executable;
+        runner = makeProcessRunner(executable);
+    }
+};
+
+Shared& shared() {
+    // Function-local static: initialised once, thread-safely, on first use.
+    static Shared instance;
+    return instance;
+}
+
+}  // namespace
+
+const std::filesystem::path& GitCli::executable() {
+    return shared().executable;
+}
+
+GitCliResult GitCli::capture(const std::filesystem::path& repoDir, std::vector<std::string> args) {
+    Shared& git = shared();
+    if (git.runner == nullptr) {
+        // No usable git. -1 is distinguishable from any real git exit code, so
+        // a fixture that forgot to skip fails loudly instead of reading a
+        // suspiciously empty result as success.
+        return GitCliResult{-1, {}};
+    }
+
+    GitCommand command(repoDir, std::move(args));
+    // Matches RealRepoTest's own budget. Fixture commands are local and fast;
+    // this is only here so a wedged git cannot hang the whole suite.
+    command.timeout = std::chrono::seconds(120);
+
+    auto result = git.runner->run(command, CancellationToken{});
+    if (result) {
+        return GitCliResult{result->exitCode, std::move(result->out)};
+    }
+    // A non-zero exit arrives as a failed GitResult carrying git's exit code.
+    // Fixtures assert on that code (`ASSERT_NE(..., 0)` for a ref that must not
+    // exist, for instance), so it is passed through rather than flattened.
+    const GitError& error = result.error();
+    return GitCliResult{error.exitCode != 0 ? error.exitCode : -1, {}};
+}
+
+int GitCli::run(const std::filesystem::path& repoDir, std::vector<std::string> args) {
+    return capture(repoDir, std::move(args)).exitCode;
+}
+
+}  // namespace gbm::testing

--- a/tests/support/GitCli.h
+++ b/tests/support/GitCli.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace gbm::testing {
+
+/// Result of a fixture git command: git's own exit code plus its stdout.
+struct GitCliResult {
+    int exitCode = 0;
+    /// Records joined by '\n' with no trailing separator, exactly as
+    /// IProcessRunner::run() reassembles them.
+    std::string out;
+};
+
+/// Runs a real git for test *fixtures* -- setting a repository up, and reading
+/// it back to check what the code under test did to it.
+///
+/// This replaces the `std::system("git -C \"...\" ... >/dev/null 2>&1")` helper
+/// that was copy-pasted into 26 capi test fixtures. Three reasons, in order of
+/// how much they matter:
+///
+/// 1. **A shell is a second process.** `std::system()` runs `/bin/sh -c` on
+///    POSIX and `cmd.exe /c` on Windows, so every fixture git command costs two
+///    process creations rather than one. Windows pays roughly two orders of
+///    magnitude more for process creation than Linux does, and the capi suite
+///    issues ~900 fixture git commands -- see
+///    docs/reports/windows-process-cost.md.
+/// 2. **Quoting through a shell is a real, already-hit hazard.** Building a
+///    command *string* means every argument has to survive a shell that differs
+///    per platform. BranchApiTest carried a five-line comment about exactly
+///    this: single quotes are POSIX syntax that `cmd.exe` passes through
+///    literally, and unquoted `%(refname:short)` is a syntax error in dash
+///    because of the parentheses. An argv vector has no such failure mode.
+/// 3. **`std::system()` cannot capture stdout.** Fixtures that needed to read
+///    git's output redirected it to a temp file and read that back. `capture()`
+///    returns it directly.
+///
+/// The git binary is located once per test binary rather than once per fixture.
+class GitCli {
+public:
+    /// Runs git in `repoDir` and returns its exit code, discarding output.
+    /// Drop-in for the old `runGit()`: callers compare against 0.
+    ///
+    /// Note this is git's *actual* exit code. `std::system()` returned a POSIX
+    /// wait status -- `exitCode << 8` -- so the old helper's non-zero values
+    /// were never git's own. Every call site only ever compared against zero,
+    /// so the change is compatible, and the value is now meaningful.
+    static int run(const std::filesystem::path& repoDir, std::vector<std::string> args);
+
+    /// As `run()`, but also returns stdout.
+    static GitCliResult capture(const std::filesystem::path& repoDir,
+                                std::vector<std::string> args);
+
+    /// Absolute path of the git this class runs, or an empty path if none was
+    /// found. Lets a fixture skip rather than fail when git is unavailable.
+    static const std::filesystem::path& executable();
+};
+
+}  // namespace gbm::testing

--- a/tests/support/GitCli.h
+++ b/tests/support/GitCli.h
@@ -11,7 +11,37 @@ struct GitCliResult {
     int exitCode = 0;
     /// Records joined by '\n' with no trailing separator, exactly as
     /// IProcessRunner::run() reassembles them.
+    ///
+    /// Note this is *not* byte-exact stdout: the line splitter behind it drops
+    /// the final separator and strips a '\r' before every '\n'. That is fine
+    /// for the ref names, oids and subjects fixtures read, and wrong for a blob
+    /// or a patch -- see docs/reports/windows-process-cost.md.
     std::string out;
+
+    /// First line only, for the callers that used to `std::getline` once out of
+    /// a redirect file and ignore whatever followed.
+    std::string firstLine() const {
+        const std::size_t end = out.find('\n');
+        return end == std::string::npos ? out : out.substr(0, end);
+    }
+
+    /// Non-empty lines, for the callers that used to loop over that file.
+    std::vector<std::string> lines() const {
+        std::vector<std::string> result;
+        std::size_t start = 0;
+        while (start <= out.size()) {
+            const std::size_t end = out.find('\n', start);
+            const std::size_t stop = end == std::string::npos ? out.size() : end;
+            if (stop > start) {
+                result.push_back(out.substr(start, stop - start));
+            }
+            if (end == std::string::npos) {
+                break;
+            }
+            start = end + 1;
+        }
+        return result;
+    }
 };
 
 /// Runs a real git for test *fixtures* -- setting a repository up, and reading

--- a/tests/unit/GitCliTest.cpp
+++ b/tests/unit/GitCliTest.cpp
@@ -1,0 +1,97 @@
+// GitCli is the fixture-side git runner that replaced std::system() in the capi
+// tests. It is itself test infrastructure, so the properties the migration
+// depends on are asserted here rather than assumed: that an argument reaches
+// git verbatim (no shell in between), that stdout comes back, and that a
+// non-zero exit is reported as git's own code rather than a wait status.
+#include "support/GitCli.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace gbm::testing {
+namespace {
+
+class GitCliTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (GitCli::executable().empty()) {
+            GTEST_SKIP() << "no usable git found";
+        }
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        repo_ =
+            std::filesystem::temp_directory_path() / ("gbm-gitcli-" + std::string(info->name()));
+        std::filesystem::remove_all(repo_);
+        std::filesystem::create_directories(repo_);
+        ASSERT_EQ(GitCli::run(repo_, {"init", "--quiet", "--initial-branch=main"}), 0);
+        ASSERT_EQ(GitCli::run(repo_, {"config", "user.email", "test@example.invalid"}), 0);
+        ASSERT_EQ(GitCli::run(repo_, {"config", "user.name", "Test"}), 0);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(repo_, ec);
+    }
+
+    void write(const std::string& name, const std::string& contents) {
+        std::ofstream out(repo_ / name, std::ios::binary | std::ios::trunc);
+        out << contents;
+    }
+
+    std::filesystem::path repo_;
+};
+
+TEST_F(GitCliTest, ReturnsStdoutInsteadOfNeedingARedirectToATempFile) {
+    write("a.txt", "one\n");
+    ASSERT_EQ(GitCli::run(repo_, {"add", "a.txt"}), 0);
+    ASSERT_EQ(GitCli::run(repo_, {"commit", "--quiet", "-m", "first"}), 0);
+
+    const GitCliResult branch = GitCli::capture(repo_, {"branch", "--format=%(refname:short)"});
+    EXPECT_EQ(branch.exitCode, 0);
+    EXPECT_EQ(branch.out, "main");
+}
+
+TEST_F(GitCliTest, PassesAnArgumentThroughVerbatimWithNoShellInTheMiddle) {
+    // `%(refname:short)` unquoted is a syntax error in dash because of the
+    // parentheses, and a single-quoted argument reaches git.exe with the quotes
+    // still attached under cmd.exe. Both were real problems for the string-and-
+    // shell helper this replaced; neither can happen through an argv vector.
+    // A commit subject with a space, a quote and a dollar sign proves the same
+    // point on the write side.
+    write("a.txt", "one\n");
+    ASSERT_EQ(GitCli::run(repo_, {"add", "a.txt"}), 0);
+    const std::string subject = R"(a "quoted" $subject with spaces)";
+    ASSERT_EQ(GitCli::run(repo_, {"commit", "--quiet", "-m", subject}), 0);
+
+    const GitCliResult logged = GitCli::capture(repo_, {"log", "-1", "--format=%s"});
+    EXPECT_EQ(logged.exitCode, 0);
+    EXPECT_EQ(logged.out, subject);
+}
+
+TEST_F(GitCliTest, ReportsGitsOwnExitCodeRatherThanAWaitStatus) {
+    // std::system() returned exitCode << 8 on POSIX, so a failing git looked
+    // like 256 rather than 1. Fixtures only ever compared against zero, but the
+    // value is now the real one and worth pinning.
+    const int rc = GitCli::run(repo_, {"rev-parse", "--verify", "--quiet", "refs/heads/nope"});
+    EXPECT_NE(rc, 0);
+    EXPECT_EQ(rc, 1);
+}
+
+TEST_F(GitCliTest, RunsInTheDirectoryItIsGivenNotTheProcessWorkingDirectory) {
+    // RemoteApiTest and InitCloneApiTest drive a second repository (a bare
+    // origin, a scratch clone source) alongside the fixture's own.
+    const std::filesystem::path other = repo_.string() + "-other";
+    std::filesystem::remove_all(other);
+    std::filesystem::create_directories(other);
+    ASSERT_EQ(GitCli::run(other, {"init", "--quiet", "--initial-branch=trunk"}), 0);
+
+    EXPECT_EQ(GitCli::capture(other, {"symbolic-ref", "--short", "HEAD"}).out, "trunk");
+    EXPECT_EQ(GitCli::capture(repo_, {"symbolic-ref", "--short", "HEAD"}).out, "main");
+
+    std::error_code ec;
+    std::filesystem::remove_all(other, ec);
+}
+
+}  // namespace
+}  // namespace gbm::testing

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -903,6 +903,47 @@ TEST_F(RealRepoTest, HonoursAMaxCountLimit) {
     EXPECT_EQ((*snapshot)->rowCount(), 4u);
 }
 
+// readHead() reads HEAD's oid and its symbolic name out of a single
+// `git rev-parse --revs-only HEAD --symbolic-full-name HEAD`, and tells the two
+// apart by whether the second line is the literal string "HEAD". That is a
+// detail of git's own output, so these two cases are asserted against a real
+// git rather than only against FakeProcessRunner -- RefStoreHeadTest.cpp pins
+// the parsing and the invocation count, but a fake cannot notice if a future
+// git prints something else. The unborn third case is
+// HandlesAnEmptyRepositoryWithoutError, below.
+TEST_F(RealRepoTest, ReadsABranchHeadFromRealGit) {
+    commitFile("a.txt", "one\n", "first");
+
+    RefStore store(*runner_, paths_);
+    auto head = store.readHead(CancellationToken{});
+    ASSERT_TRUE(head) << head.error().message;
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Branch);
+    EXPECT_EQ(head->fullRef, "refs/heads/main");
+    EXPECT_EQ(head->branchName, "main");
+
+    auto expected = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(expected);
+    EXPECT_EQ(head->target.hex(), expected->out);
+}
+
+TEST_F(RealRepoTest, ReadsADetachedHeadFromRealGit) {
+    commitFile("a.txt", "one\n", "first");
+    ASSERT_TRUE(run({"checkout", "--quiet", "--detach"}));
+
+    RefStore store(*runner_, paths_);
+    auto head = store.readHead(CancellationToken{});
+    ASSERT_TRUE(head) << head.error().message;
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Detached);
+    EXPECT_TRUE(head->branchName.empty());
+    EXPECT_TRUE(head->fullRef.empty());
+
+    // The oid still has to be right: detaching must not cost the caller the
+    // commit HEAD is sitting on.
+    auto expected = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(expected);
+    EXPECT_EQ(head->target.hex(), expected->out);
+}
+
 TEST_F(RealRepoTest, HandlesAnEmptyRepositoryWithoutError) {
     // No commits at all. A fresh `git init` must open cleanly rather than
     // reporting a failure the user cannot act on.

--- a/tests/unit/ProcessRunnerTest.cpp
+++ b/tests/unit/ProcessRunnerTest.cpp
@@ -233,12 +233,10 @@ TEST(HistoryProvider, SurvivesAChildKilledMidStream) {
 TEST(RefStore, ParsesForEachRefOutputIncludingTrackingInfo) {
     FakeProcessRunner runner;
 
-    FakeProcessRunner::Response symbolic;
-    symbolic.out = "refs/heads/main";
-    runner.whenArgsContain({"symbolic-ref"}, symbolic);
-
+    // readHead() resolves HEAD's oid and its symbolic name in one rev-parse,
+    // so the scripted reply is both lines: "<oid>\n<symbolic full name>".
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a') + "\nrefs/heads/main";
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     // Fields are separated by the ASCII unit separator, which cannot appear in a
@@ -283,7 +281,7 @@ TEST(RefStore, TreatsAnUnbornHeadAsANormalState) {
     runner.whenArgsContain({"symbolic-ref"}, symbolic);
 
     FakeProcessRunner::Response revParse;
-    revParse.exitCode = 1;  // --verify --quiet finds nothing
+    revParse.exitCode = 1;  // HEAD does not resolve: no commits yet
     runner.whenArgsContain({"rev-parse"}, revParse);
     runner.whenArgsContain({"for-each-ref"}, FakeProcessRunner::Response{});
 
@@ -297,9 +295,8 @@ TEST(RefStore, TreatsAnUnbornHeadAsANormalState) {
 
 TEST(RefStore, TripsTheRefCountGuardOnAHugeRefSet) {
     FakeProcessRunner runner;
-    runner.whenArgsContain({"symbolic-ref"}, FakeProcessRunner::Response{});
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a');  // an oid with no symbolic name: detached
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     const char sep = '\x1f';
@@ -382,12 +379,10 @@ TEST(RefStore, ExcludesAGoneUpstreamFromHistorySeeds) {
 
 TEST(RefStore, ParsesGoneTrackFieldWithoutCountingAsAheadOrBehind) {
     FakeProcessRunner runner;
-    FakeProcessRunner::Response symbolic;
-    symbolic.out = "refs/heads/feature";
-    runner.whenArgsContain({"symbolic-ref"}, symbolic);
-
+    // readHead() resolves HEAD's oid and its symbolic name in one rev-parse,
+    // so the scripted reply is both lines: "<oid>\n<symbolic full name>".
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a') + "\nrefs/heads/feature";
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     const char sep = '\x1f';
@@ -419,12 +414,10 @@ TEST(RefStore, LoadsEveryRefWithASingleForEachRefInvocation) {
     // minutes. Every parsed field would still be correct if someone did that,
     // so the process count is the only thing that can catch it.
     FakeProcessRunner runner;
-    FakeProcessRunner::Response symbolic;
-    symbolic.out = "refs/heads/main";
-    runner.whenArgsContain({"symbolic-ref"}, symbolic);
-
+    // readHead() resolves HEAD's oid and its symbolic name in one rev-parse,
+    // so the scripted reply is both lines: "<oid>\n<symbolic full name>".
     FakeProcessRunner::Response revParse;
-    revParse.out = std::string(40, 'a');
+    revParse.out = std::string(40, 'a') + "\nrefs/heads/main";
     runner.whenArgsContain({"rev-parse"}, revParse);
 
     // Enough refs, each with tracking info, that a per-ref process would be
@@ -457,11 +450,12 @@ TEST(RefStore, LoadsEveryRefWithASingleForEachRefInvocation) {
     EXPECT_EQ(forEachRefCalls, 1u)
         << "one load() must cost exactly one for-each-ref, not one per ref";
 
-    // Three processes in total: symbolic-ref and rev-parse for HEAD
-    // (readHead), then the single for-each-ref. Pinned so that adding "just
-    // one more quick git call" to load() has to be a deliberate edit to this
-    // number.
-    EXPECT_EQ(runner.invocationCount(), 3u);
+    // Two processes in total: one rev-parse resolving HEAD's oid and symbolic
+    // name together (readHead), then the single for-each-ref. This was three
+    // until readHead() stopped issuing a separate symbolic-ref -- see
+    // RefStoreHeadTest.cpp. Pinned so that adding "just one more quick git
+    // call" to load() has to be a deliberate edit to this number.
+    EXPECT_EQ(runner.invocationCount(), 2u);
 }
 
 }  // namespace

--- a/tests/unit/RefStoreHeadTest.cpp
+++ b/tests/unit/RefStoreHeadTest.cpp
@@ -1,0 +1,138 @@
+// RefStore::readHead()'s command shape, asserted through FakeProcessRunner.
+//
+// The point of these tests is the *invocation count* as much as the parsed
+// result. readHead() used to issue two git processes unconditionally -- a
+// `symbolic-ref` for the branch name followed by a `rev-parse` for the oid --
+// and it is on two hot paths at once: RefStore::load() runs it on every refs
+// refresh, and OperationRunner::recordUndoPoint() runs it before every
+// undoable write. Process creation is roughly two orders of magnitude more
+// expensive on Windows than on Linux, so a spare spawn there is not a
+// rounding error; see docs/reports/windows-process-cost.md.
+//
+// A behaviour-only test would stay green if someone reverted the merge back to
+// two commands, so every case below pins invocationCount() explicitly.
+#include "core/git/RefStore.h"
+#include "support/FakeProcessRunner.h"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace gbm {
+namespace {
+
+using testing::FakeProcessRunner;
+
+RepoPaths testPaths() {
+    return RepoPaths("/repo", "/repo/.git", "/repo/.git");
+}
+
+constexpr const char* kOid = "8de891509a719cf9c23b3b6e9baebb9ad30f5878";
+
+/// `run()` reassembles stdout from the line splitter and trims the trailing
+/// separator, so a two-line git result reaches the caller as "a\nb" with no
+/// final newline. The fake passes `out` through verbatim, so the scripted
+/// responses here must already be in that shape.
+FakeProcessRunner::Response combinedReply(const std::string& oid, const std::string& symbolic) {
+    FakeProcessRunner::Response reply;
+    reply.out = oid + "\n" + symbolic;
+    return reply;
+}
+
+TEST(RefStoreReadHead, OnABranchResolvesNameAndOidInASingleInvocation) {
+    FakeProcessRunner runner;
+    runner.whenArgsContain({"rev-parse", "--symbolic-full-name"},
+                           combinedReply(kOid, "refs/heads/main"));
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Branch);
+    EXPECT_EQ(head->fullRef, "refs/heads/main");
+    EXPECT_EQ(head->branchName, "main");
+    EXPECT_EQ(head->target.hex(), kOid);
+
+    EXPECT_EQ(runner.invocationCount(), 1u);
+}
+
+TEST(RefStoreReadHead, DetachedIsRecognisedFromTheLiteralHeadSymbolicName) {
+    // `--symbolic-full-name HEAD` prints the literal string "HEAD" when HEAD is
+    // detached. That is unambiguous rather than merely convenient: a real
+    // branch always comes back fully qualified as `refs/heads/...`, so a bare
+    // "HEAD" cannot be a branch name reaching this code by accident.
+    FakeProcessRunner runner;
+    runner.whenArgsContain({"rev-parse", "--symbolic-full-name"}, combinedReply(kOid, "HEAD"));
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Detached);
+    EXPECT_TRUE(head->branchName.empty());
+    EXPECT_EQ(head->target.hex(), kOid);
+
+    EXPECT_EQ(runner.invocationCount(), 1u);
+}
+
+TEST(RefStoreReadHead, UnbornFallsBackToSymbolicRefAndKeepsTheBranchName) {
+    // A repository with no commits yet is a normal state, not a failure, and
+    // the branch HEAD points at is still worth showing. The combined command
+    // cannot supply it -- with `--revs-only` an unresolvable HEAD yields empty
+    // output -- so this is the one case that still costs a second process.
+    // It is also the case most likely to be dropped by a later refactor, hence
+    // asserting the name and not just the kind.
+    FakeProcessRunner runner;
+    runner.whenArgsContain({"rev-parse", "--symbolic-full-name"}, FakeProcessRunner::Response{});
+    FakeProcessRunner::Response symbolic;
+    symbolic.out = "refs/heads/dev";
+    runner.whenArgsContain({"symbolic-ref", "--quiet", "HEAD"}, symbolic);
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Unborn);
+    EXPECT_EQ(head->fullRef, "refs/heads/dev");
+    EXPECT_EQ(head->branchName, "dev");
+
+    EXPECT_EQ(runner.invocationCount(), 2u);
+}
+
+TEST(RefStoreReadHead, UsesRevsOnlySoAnUnbornHeadIsNotReportedAsAFatalError) {
+    // Without `--revs-only`, `git rev-parse HEAD --symbolic-full-name HEAD`
+    // exits 128 and writes "fatal: ambiguous argument 'HEAD'" to stderr on an
+    // unborn repository. ProcessRunner records *every* invocation into
+    // Log::instance(), stderr included, so that wording would surface in the
+    // user's operation log every time a freshly-initialised repository is
+    // opened -- describing a normal state as a fatal error. The flag is load
+    // bearing, not decoration.
+    FakeProcessRunner runner;
+    RefStore store(runner, testPaths());
+    (void)store.readHead(CancellationToken{});
+
+    ASSERT_GE(runner.invocationCount(), 1u);
+    const std::vector<std::string> args = runner.invokedArgs(0);
+    EXPECT_NE(std::find(args.begin(), args.end(), "--revs-only"), args.end());
+}
+
+TEST(RefStoreReadHead, AFailedGitStillLeavesAUsableUnbornHead) {
+    // Parity with the previous implementation: a rev-parse that errors outright
+    // (not a repository, git missing) must not propagate as a failed
+    // GitResult -- a repository that cannot answer still has to open.
+    FakeProcessRunner runner;
+    FakeProcessRunner::Response failure;
+    failure.exitCode = 128;
+    failure.err = "fatal: not a git repository";
+    runner.setDefaultResponse(failure);
+
+    RefStore store(runner, testPaths());
+    auto head = store.readHead(CancellationToken{});
+
+    ASSERT_TRUE(head);
+    EXPECT_EQ(head->kind, HeadInfo::Kind::Unborn);
+}
+
+}  // namespace
+}  // namespace gbm


### PR DESCRIPTION
> ## ⚠️ 速度預測失敗了（事先寫死的判準，沒有事後移動）
>
> 預測 Windows ctest 由 ~0.43 降到 **~0.26 s/test**，並事先宣告落在 0.37–0.49 即為失敗。
>
> | run | tests | ctest | s/test |
> |---|---|---|---|
> | 修改前母體（六次） | 502–511 | — | 0.4002–0.4923（mean 0.4309） |
> | 只有 #79 | 519 | 184.2 s | 0.3549 |
> | **#79 + 本 PR** | 523 | 211.9 s | **0.4052** |
>
> **0.4052 正好是母體平均，落在失敗區間。** 而且改得比較少的 #79 反而比較快，兩個方向都不成立因果訊號。誠實的讀法是：**Windows CI 上偵測不到效果。**
>
> 模型錯在假設 `cost(cmd.exe) ≈ cost(git.exe)`。實際上 `cmd.exe` 是常駐的小型系統程式，`git.exe` 在 Windows 要拉進 MSYS2 runtime，貴得多——移除 903 個 shell 等於移除 903 個**便宜**的行程，1348 個貴的一個沒少。行程數 −41% 仍為真，只是不換算成時間。
>
> **仍然成立的是另外三件事**（見下方「比省下的秒數更重要的兩件事」與 CI guard）：shell 引號地雷在結構上消失、被測 repo 內不再留暫存檔、guard 擋住回歸。這本來就是比較好的那半論證；秒數那半不存在。合不合請照這個標準判斷，不要照原本的速度說法。

> **這個 PR 建在 #79 之上，但 base 指向 `main`。**
>
> 一開始 base 設成 `perf/windows-head-read-single-spawn`（因為本 PR 擴充的 `docs/reports/windows-process-cost.md` 是 #79 建立的，`GitCli.h` 與 CI guard 的註解也指向它）。**那樣做會讓整個 CI 完全不跑**——`ci.yml` 與 `cq.yml` 的觸發條件都是 `pull_request: branches: [main]`，所以非 `main` base 的 PR 只有 GitGuardian 會動。對一個核心主張要靠 Windows CI 驗收的 PR，沒有 CI 比 diff 難讀嚴重得多，因此改回 `main`。
>
> 代價是：**在 #79 合併之前，本 PR 的 diff 會包含 #79 的三個 commit**（`5989409` / `8b043e8` / `83f3944`）。只看本 PR 自己的改動請比對 `perf/windows-head-read-single-spawn...test/fixture-drop-std-system`。#79 合併後這個 diff 會自動收乾淨。請先合 #79。

#79 的報告把「what this does not fix」第一項寫成：903 個 fixture git 呼叫來自建在 `std::system()` 上的 `runGit()`，在 Windows 上每次生 **`cmd.exe` 加 `git.exe` 兩個行程**，fixture 就佔了約 1806 個行程，對上 app 的 386 個——而且 `src/` 底下任何改動都碰不到。

這個 PR 就是修那一項。

## 結果（確定性數字）

| | 修改前 | 修改後 |
|---|---|---|
| git 行程 | 1378 | 1348 |
| shell 行程 | 903 | **0** |
| **總計** | **2281** | **1348** |

**少 933 個行程，−41%**，正好是每行程成本模型預測的數字。順帶消失的 30 個 git 行程是 `GitExecutable::detect()`：29 個 fixture 各自跑一次 `git --version` 只為了決定要不要 skip，`GitCli` 改成每個 test binary 偵測一次。

## 做法

`tests/support/GitCli.h` 透過既有的 `makeProcessRunner()` 直接 spawn git，不經 shell。`gbm_capi_tests` **本來就已連結 `gbm_core`**，所以沒有新相依、也不需要自己寫 spawn 程式碼。

- `run(dir, args)` → exit code，drop-in 取代舊的 `runGit`
- `capture(dir, args)` → 另外回傳 stdout，供 12 處原本「導向暫存檔再讀回來」的呼叫點使用；`firstLine()` / `lines()` 對應原本 `std::getline` 一次或迴圈讀完兩種用法

## 比省下的秒數更重要的兩件事

1. **引號問題消失了。** `BranchApiTest` 原本帶著一段五行註解，解釋單引號是 POSIX shell 語法、`cmd.exe` 會原封不動傳給 `git.exe`，所以 git 收到的 `--format` 字串裡真的含引號、分支名永遠不是裸的；而不加引號則讓 dash 把 `%(refname:short)` 的括號當語法錯誤。**走 argv 之後這個失敗模式在結構上不存在**，那段註解和 workaround 一起移除。
2. **被測 repo 裡不再留垃圾。** `CommitFilesApiTest` / `CommitMetaApiTest` 把 `rev-parse HEAD` 導向 **repo 內部**的 `head-oid.txt`，替後續每一次 status 讀取留下一個未追蹤檔案。`capture()` 直接回傳 stdout，檔案消失。

## 量測與其限制

**單檔的乾淨量測**（`WorkingCopyApiTest --gtest_repeat=10`，800 次 fixture 呼叫）：中位數 **33.72 s → 30.56 s**，兩組**範圍不重疊**，每次呼叫省 3.95 ms（預測 4.39 ms，誤差 10% 內）。

**整個 binary 的 A/B**（各 3 次）：

| | 樣本 | 中位數 |
|---|---|---|
| 修改前（`main`） | 64.19 / 54.95 / 45.49 | 54.95 s |
| 修改後 | 38.43 / 40.97 / 52.49 | **40.97 s** |

中位數 −25%，**但兩組範圍重疊**（最快的 before 比最慢的 after 還快），所以 macOS 上 n=3 只是方向性證據，不足以定論。這在預期內：`/bin/sh` 本來就便宜。**這裡該相信的是確定性的行程數；Windows 才是效果應該大到看得見的地方**，因為被移除的是 `cmd.exe`。

Windows CI 的驗收判準先寫死，不事後改：#79 已經測到**同一份程式碼兩次 run 相差 19%**，所以

- 落在 **0.37–0.49 s/test** → 效果在雜訊內，預測失敗
- 落到 **~0.26 s/test 附近** → 預測成立

**單跑一次不算數**，需要每邊 2–3 次取中位數。

## CI guard

`cq.yml` 新增一條 grep，`tests/` 底下再出現 `std::system` 就讓 build 紅——理由和它旁邊那條「core 不得引入 Qt」一樣：加回去之後**測試仍然會通過**，只是變慢又脆弱，CI 其他任何一項都看不到。已用突變測試確認 guard 會抓（塞一行進 `GitCliTest.cpp` 後轉紅）。

## 驗證

- `ctest -j4` **525/525 全過**
- `./scripts/format-check.sh` 乾淨
- `GitCliTest` 四條測試釘住遷移所依賴的性質：參數逐字送達（無 shell）、stdout 直接回傳、**非零結束碼是 git 自己的碼而非 POSIX wait status**（`std::system` 回的是 `exitCode << 8`，舊 helper 的非零值從來不是 git 的）、以及指定目錄而非行程工作目錄
- `tests/` 底下已無任何 `std::system` 呼叫，剩餘 6 處都是註解

過程中出現過的測試失敗全是 **#70 家族**（`UndoApiTest` ×2、`MergeApiTest`、`BisectApiTest`，都是 10s `waitFor` 逾時形狀，單獨重跑即過），**沒有新形狀**。#70 維持開啟。

## 仍未處理

**CI 的 ctest 是序列執行的**（`tbase` preset 沒設 `execution.jobs`）。開平行能再大幅壓縮 Windows，但那正是 #70 的觸發條件——在 #70 定案前開 `-j` 是拿 wall clock 換 flake。**刻意不做。**
