### PR TITLE
docs: #77 已修，更正 CLAUDE.md 裡把它記成未解決 flake 的段落

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -871,19 +871,44 @@ also records the untested hypothesis (a fixed 10s budget losing to parallel
 load) and warns against raising the timeout before confirming it — that
 would paper over a real refresh-coalescing bug if one exists.
 
-**A second, unrelated flake was isolated during Tier 0c's CI run and must
-not be folded into #70**: `WorkingCopyApiTest.UnstageHunkReversesAFullyStagedSingleHunkFile`
-fails with `LockHeld` — "Another Git process appears to be running in this
-repository", the lock being its *own* temp repo's `.git/index.lock`. Unlike
-#70's shape it is **not** a timeout and **not** load-dependent: run alone
-with no parallel `ctest`, it failed 1 in 12 and again at iteration 30 of
-40, each time in ~0.36s, nowhere near any timeout budget. So the test races
-itself — a working-copy operation is reported complete before git has
-released the index lock the next one needs. Tracked as **#77**, which
-records the captured error verbatim and warns that raising a timeout (the
-#70 remedy) does nothing here. Practical consequence: a red macOS capi job
-on an unrelated branch may be either flake, and they need different
-triage — read the failure text before assuming.
+**A second flake was isolated during Tier 0c's CI run and must not be
+folded into #70** — `WorkingCopyApiTest.UnstageHunkReversesAFullyStagedSingleHunkFile`
+failing with `LockHeld` ("Another Git process appears to be running in this
+repository", the lock being its *own* temp repo's `.git/index.lock`). Unlike
+#70's shape it was **not** a timeout and **not** load-dependent: run alone
+with no parallel `ctest`, it failed 1 in 12 and again at iteration 30 of 40,
+each time in ~0.36s, nowhere near any timeout budget. **Fixed** — #77, closed
+by PR #78 (`3f6cfa1`).
+
+Two things about it are worth keeping, because both are the kind of mistake
+that is cheap to repeat:
+
+- **It was a real product race, not a test artifact**, and the first
+  diagnosis recorded here was wrong in an instructive way. This paragraph
+  used to say "a working-copy operation is reported complete before git has
+  released the index lock the next one needs" — blaming the *previous
+  write*. That write's lock was long gone. The actual holder was the
+  **background status/diff that follows it on `sharedReadPool()`**: a
+  different pool from `OperationRunner`'s single serial worker, so reads and
+  writes are not serialised against each other, and a plain `git status`
+  rewrites the index (and takes `.git/index.lock`) whenever its stat cache
+  has gone stale. Writes never collide with writes; only a background read
+  can collide with a write. The fix is `--no-optional-locks` in
+  `GitCommand::globalFlags()` — see its doc comment for why it is global
+  rather than tagged onto the ~28 read call sites.
+- **The end-to-end flake could not be reproduced on demand afterwards, in
+  either direction.** After the fix the test passed 60/60 — but so did a
+  control run with the fix removed, and 40/40 under parallel `ctest` load.
+  Each test uses its own temp repository, so the race is intra-process
+  thread scheduling, not inter-process contention, and that stress method
+  cannot surface it. The evidence for the fix is the deterministic
+  mechanism test (`RealRepoTest.StatusReadDoesNotRewriteTheIndex`, red
+  before and green after) plus the causal chain above — not an A/B.
+
+**#70 is still open**, and the triage advice stands: a red capi job may be
+either shape, and they need different treatment — read the failure text
+before assuming. A 10s `waitFor`/`waitForRefreshesToSettle` timeout under
+load is #70; anything else is new.
 
 ### Tier 5 (fix/tier-5-native-window-title) — issue closed, not implemented
 


### PR DESCRIPTION
#77 已由 PR #78（`3f6cfa1`）修好並併入 `main`，但 `CLAUDE.md` 那段仍把它描述成未解決的 flake。這是 #78 內文裡就先記下的跨分支相依：#73 寫下那段文字時 #77 確實還開著，兩個 PR 各自合併後那段就過期了。

## 除了「改成已修復」之外，還更正了它自己的診斷

原文寫的是：

> a working-copy operation is reported complete before git has released the index lock the next one needs

也就是把鎖歸咎於**前一個寫入操作**。調查結果推翻了這個說法——那個操作的鎖早就放了。真正的持有者是**它之後在 `sharedReadPool()` 上跑的背景 status/diff**：

- `OperationRunner` 是單一序列 worker，**寫入之間永遠不會互撞**
- `Session::refreshWorkingCopy()` 丟到 `sharedReadPool()`，與 `operations_` 是不同的 pool，兩者不序列化
- 普通的 `git status` 在 stat cache 過期時會改寫 index，因此要拿 `.git/index.lock`

所以唯一可能互撞的組合是「背景讀取 vs 操作寫入」。這是**真的產品 race，不是測試寫壞**——實際使用時一次背景重新整理同樣會擋掉使用者緊接著的操作。

留著這段前後對照，是因為「把鎖歸咎於前一個同類操作」是很容易再犯一次的推論。

## 也記下證據的限制

端對端壓力測試**兩個方向都無法按需重現**：修好後 60/60 全過，但**拿掉修正的對照組也是 60/60**，平行 `ctest` 負載下 40/40。每個測試用自己的 temp repo，race 是行程內的 thread 排程，那個壓力方法看不到它。

證據建立在**確定性的機制測試**（`RealRepoTest.StatusReadDoesNotRewriteTheIndex`，修好前紅、修好後綠）加上因果鏈，不是 A/B。這點寫進 CLAUDE.md，免得之後有人把「60/60」讀成實證。

## #70 維持開啟

原本的分流建議保留並寫得更明確：紅掉的 capi job 可能是兩種形狀之一，處理方式不同——**先讀失敗訊息**。10 秒的 `waitFor` / `waitForRefreshesToSettle` 逾時是 #70；其他都是新的。

純文件改動，不動任何程式碼。
