### PR TITLE
feat: spec P13 B 區多選，與 05-B / 05-E / Compare 兩處入口（#54、#55、#56、#57）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ compile_commands.json
 *.user
 *.swp
 .DS_Store
+# Per-machine MCP server config (an IDE bridge on a localhost port), not
+# shareable -- and it sits at both the repo root and app_flutter/, so a
+# `git add` on either directory sweeps it up. One did.
+.mcp.json
 
 # Test/scratch output
 tests/golden/*.actual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,8 +484,12 @@ that were previously invisible rather than absent.
   (cloud-off for gone, new `assets/icons/cloud-off.svg`) at 0.62 opacity,
   single tap inert, double tap checks out as a new local branch, and its
   right-click menu swaps to the 05-C subset (Checkout as new local…/Copy
-  branch name/Prune this ref/Delete on remote…, "Fetch this branch" omitted
-  — `gbm_remote_fetch()` has no per-ref fetch capability). `sidebar_panel.dart`
+  branch name/Prune this ref/Delete on remote…, ~~"Fetch this branch" omitted
+  — `gbm_remote_fetch()` has no per-ref fetch capability~~ — **stale**:
+  `gbm_capi.h`'s `gbm_remote_fetch()` takes `refs`/`refCount` and restricts
+  the fetch to exactly those refs, `BranchTreeItem`'s `onFetchRef` is wired
+  to it, and 05-C's parity assertion passes with the item present).
+  `sidebar_panel.dart`
   wires the three real actions: `checkout(target: fullName, createBranch:
   true, newBranchName: shortName)`, `pruneRemote(remoteName, [fullName])`,
   and `context.push(RoutePaths.deleteRemoteBranchDialogFor(...))` — the
@@ -1221,3 +1225,118 @@ that the audit was written against 12 pages and the spec now has 16, and its
 `REVISIONS`-affected rows were corrected in place — including two that had
 been excused as spec-internal collisions and no longer are. P14/P15/P16 are
 **not** audited; nothing under `lib/` was changed for them.
+
+### Tier 2 + Tier 3 (feat/tier-2-3-multi-select-compare) — issues #54–#57
+
+Spec **P13 section B**: the selection model itself, plus the three things
+that were blocked on it. Twelve sequential commits on one branch. **Three of
+the four issues' premises were wrong**, and all three corrections changed
+where the work went — read this before re-reading their issue text.
+
+- **#56 said `Merge into current` needed an oid→branch-name step.** It does
+  not. `gbm_merge_branch`'s `target` is pushed straight into
+  `git merge <target>` (`MergeOps.cpp:59,82`) and only an empty string is
+  rejected; an oid is a legal committish, and `startRebase(upstream)` is the
+  same. There was no prerequisite, only wiring.
+- **#57 said `Compare with…` probably needed a new dialog.** It needed none.
+  `sidebar_panel.dart`'s `_compareStash()`/`_compareTag()` already
+  established the convention — open a Compare tab with only the left side
+  filled and let the Compare page's own `CompareRefPicker` take the right.
+- **#55 said there was no UI path to Compare at all.** `Repository →
+  Compare…` (`Ctrl/Cmd+Shift+C`) already existed and worked. Only spec's
+  literal 「同時選兩個分支 → 右鍵 Compare」 was missing.
+- **#54 said there was no multi-select mechanism.** The sidebar already had
+  a checkbox one (the "delete gone branches" flow). What was missing was
+  MULTIKEYS' click semantics and the menus.
+
+**One selection model, two providers.** `ListSelection<T>`
+(`data/models/list_selection.dart`) is an immutable `(ordered items, anchor)`
+pair with five transitions, `isContiguousIn` and `orderedBy`.
+`commitSelectionProvider` and `branchSelectionProvider` each hold one —
+separate on purpose, per spec's 「選取狀態跨 scope 不混用」.
+`selectedCommitProvider` is no longer independently writable: it is now
+`ref.watch(commitSelectionProvider(identity)).anchor`, which is exactly its
+old single-select meaning and leaves `commit_detail_panel.dart` /
+`changed_files_panel.dart` untouched. **The checkbox and Ctrl/Cmd-click
+write the same `branchSelectionProvider` state** — a checkbox tick *is*
+`ListSelection.toggle`. Growing a second selection set is the bug shape this
+whole arrangement exists to prevent.
+
+Things worth knowing before touching this again, most of them found by
+running rather than reading:
+
+- **Contiguity is judged on the unfiltered snapshot**, never on the rendered
+  rows. Three commits that look adjacent under a search filter are not a
+  range git can replay, so cherry-pick/revert correctly stay disabled for
+  them. Every *transition*, on the other hand, is expressed against the
+  visible list, so a Shift range never silently spans hidden rows.
+- **`Ctrl/Cmd+A` must be bound inside the list's own focus scope, never
+  app-wide.** A `Shortcuts` closer to a focused editor than
+  `DefaultTextEditingShortcuts` steals text select-all — so the branch
+  tree's binding wraps the tree scroll area only, deliberately leaving the
+  filter `TextField` outside it. `GbmActionId.editSelectAll`'s handler
+  follows `_invokeTextIntent`'s existing shape (non-null in the handler map,
+  forwarding by focus, `GbmSelectAllIntent` first then `SelectAllTextIntent`)
+  rather than inventing a second mechanism.
+- **Tapping an `InkWell` does not give it focus.** It is focusable for
+  traversal, but a tap does not request focus, so the branch tree's
+  `Ctrl/Cmd+A` did nothing after clicking a row. `_onBranchSelect` now calls
+  `_treeFocus.requestFocus()` first. The test for it must use a *modifier*
+  click, since a plain click routes through checkout instead.
+- **`gbm_push` grew `branches`/`branchCount`**, mirroring
+  `gbm_branch_delete`'s existing multi-name convention. `git push <remote> a
+  b c` is natively 「依序執行，失敗不中斷其餘」 and is one background task,
+  where chaining N calls from Dart would emit N `OPERATION_FINISHED` events
+  against spec page 10 — the same reasoning Tier 0c's rename hit.
+  **`branchCount 0` is not equivalent to naming the current branch**: it
+  passes no refspec at all, so git pushes through the configured upstream
+  and *refuses outright* when there is none. Measured, not assumed — the
+  first version of `PushWithNoBranchesStillPushesTheCurrentOne` failed on
+  exactly that and its doc comment now records it.
+- **Spec says nothing about how a multi-branch Fetch/Push picks its remote**,
+  so `sidebar_panel.dart` owns that decision and documents it there: Fetch
+  groups by each branch's own upstream remote (a branch with no upstream has
+  no remote-tracking ref and is skipped) and passes `refs`/`refCount` so it
+  is one call per remote, not N. Push does the same for published branches;
+  unpublished ones go to the repository's *sole* remote in their own call
+  with `--set-upstream`, because folding them into a same-remote group would
+  let `push -u` repoint a branch that tracks a differently-named upstream.
+  With several remotes and an unpublished branch selected, Push is disabled
+  **with a stated reason** rather than silently dropping branches.
+- **Remote names come from `remoteBranchParts()`, never a first-slash
+  split.** `RefInfo.upstream` is the full `refs/remotes/origin/x`, so that
+  split yields `"refs"` — the live bug tracked as **#74** in
+  `delete_branch_dialog.dart`, untouched here.
+- **`RefInfo.ahead` only means anything when `upstream` is non-empty.** A
+  branch that never had one reports `ahead: 0`, which rendered literally
+  would claim "0 unpushed commits" — the opposite of the truth. The
+  delete-branches confirmation says 「no upstream」 for those instead. The
+  test is `upstream.isNotEmpty`, **not** `hasTrackingInfo` (Tier 0c's trap).
+
+**Right-click has two halves, both implemented**: on an already-selected row
+the selection is untouched and the menu gains a counted title; on an
+unselected row the selection collapses to just that row first, so no action
+ever runs against a selection the user cannot see.
+
+**Single-item-only actions stay visible and disabled with a tooltip**, never
+hidden — 「隱藏會讓人以為功能不存在」. That means `enabled: false` **and**
+`onTap: null`, since `enabled` alone is only a visual signal
+(`gbm_menu.dart`). `GbmMenuItem` gained `tooltip` and `showGbmContextMenu`
+gained `title` for this; the title deliberately does **not** count toward
+`validateGbmMenuItems`' 8-item cap, which is spec page 05's limit on
+*actions*.
+
+**Two deliberate reductions, recorded rather than faked**:
+`MULTIACTS`' `Squash` is not offered at all — no capi supports "squash these
+N commits" (`gbm_capi.h` has merge's `--squash` mode and interactive
+rebase's Squash ordinal, neither of which is that). And the History status
+bar reports count + contiguity only, not spec's 「合計 diff」: `ChangedFile`
+carries no +/- line counts, and the only `--numstat` path is
+`CompareOps.cpp`'s range diff, so a running total would fire a diff on every
+selection change.
+
+**What is still not done from P13 B**: 05-B's own menu is now conflict-gated
+(that gap is closed), but the file and stash rows in `MULTIACTS` — Stage /
+Unstage / Discard on multiple files, Drop on multiple stashes — were already
+partly present and were not re-audited against MULTIKEYS' click semantics
+here. **#76** stays open for that and for P13 A/P14–P16.

--- a/app_flutter/.mcp.json
+++ b/app_flutter/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "idea": {
-      "url": "http://127.0.0.1:64343/stream",
-      "type": "http"
-    }
-  }
-}

--- a/app_flutter/.mcp.json
+++ b/app_flutter/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "idea": {
+      "url": "http://127.0.0.1:64343/stream",
+      "type": "http"
+    }
+  }
+}

--- a/app_flutter/integration_test/README.md
+++ b/app_flutter/integration_test/README.md
@@ -7,15 +7,22 @@ temporary git repository created per test.
 
 ## Precondition
 
-The native library must already exist at `app_flutter/build/native/`:
+The native library must be resolvable by `native_library.dart`'s candidate
+list. **`scripts/build_capi.sh` does not exist in this repo** -- that name
+appears in `native_library.dart`'s doc comment and in earlier revisions of
+this file, but no such script was ever added, so do not go looking for it.
 
-```bash
-./scripts/build_capi.sh   # or build_capi.ps1 on Windows
-```
+What actually happens on macOS, observed while adding
+`multi_push_flow_test.dart`: `flutter test integration_test/<file> -d macos`
+builds the Runner target, whose "Build gbm_capi" Xcode Run Script phase runs
+`cmake --preset capi-only` and copies the result next to the executable
+inside the `.app` -- candidate #2. So the dylib is rebuilt from current
+source on every run, and no manual step is needed. Linux and Windows reach
+candidate #2 the same way, via their CMake Phase B block.
 
-`flutter test integration_test/` does not go through either of the
-packaged-build paths that would otherwise put it there (see
-`lib/data/ffi/native_library.dart`'s doc comment).
+Candidate #3 (`app_flutter/build/native/`) is the manual escape hatch. If you
+put a dylib there by hand, remember it is a **copy**: see the staleness
+warning below.
 
 ## Running
 
@@ -27,6 +34,7 @@ flutter test integration_test/commit_flow_test.dart -d macos
 flutter test integration_test/conflict_flow_test.dart -d macos
 flutter test integration_test/context_menu_flows_test.dart -d macos
 flutter test integration_test/rename_branch_flow_test.dart -d macos
+flutter test integration_test/multi_push_flow_test.dart -d macos
 ```
 
 (`-d linux` / `-d windows` on those platforms.)
@@ -41,12 +49,13 @@ future Flutter/`flutter_tools` version fixes multi-app-launch sequencing.
 
 ## The native library must be current, not merely present
 
-`build_capi.sh` is a precondition on *every* run that touches a new capi
-entry point, not a one-off setup step: `build/native/libgbm_capi.dylib` is a
-copy, so a stale one keeps loading happily and the flow under test fails in
-a way that looks like a Dart bug. `context_menu_flows_test.dart`'s discard
-flow needs `gbm_discard_lines`, which did not exist in any dylib built
-before it.
+`build/native/libgbm_capi.dylib` is a **copy**, not a symlink: a stale one
+keeps loading happily and the flow under test then fails in a way that looks
+exactly like a Dart bug. `context_menu_flows_test.dart`'s discard flow needs
+`gbm_discard_lines`, which did not exist in any dylib built before it;
+`multi_push_flow_test.dart` needs `gbm_push`'s two-parameter multi-branch
+form. If you populated candidate #3 by hand, re-copy it after every capi
+change -- the Xcode/CMake build phases feeding candidate #2 do not touch it.
 
 ## Shared preferences are the machine's real ones
 

--- a/app_flutter/integration_test/multi_push_flow_test.dart
+++ b/app_flutter/integration_test/multi_push_flow_test.dart
@@ -1,0 +1,146 @@
+// Device-tier E2E for the multi-branch push added alongside spec P13's
+// branch multi-select.
+//
+// Why this file has to exist -- the same reason
+// `rename_branch_flow_test.dart` does, and the reason is worth repeating
+// because nothing else in the suite can stand in for it: `gbm_push` grew
+// two parameters (`branches`, `branchCount`) on the C side and the matching
+// `dart:ffi` typedef grew them on the Dart side. `lookupFunction` matches by
+// **symbol name only, never by signature**, so if those two halves ever
+// disagree the mismatch compiles, `flutter analyze`s, and passes every
+// `test/**` suite (all of which run on `FakeGbmBindings`) and every
+// `tests/capi/**` suite (which calls the C++ directly, never through FFI) --
+// and then corrupts the stack the first time a real user pushes.
+//
+// This drives `RepoSessionController.pushChanges` on the real session rather
+// than through the sidebar's multi-select menu: the seam under test is the
+// FFI call itself, and going through the UI would make a signature
+// regression indistinguishable from a menu-wiring regression. The menu's own
+// wiring is covered at widget/integration tier in `test/`.
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/app.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'support/real_repo_harness.dart';
+
+/// Creates a bare `origin` and pushes only `main` to it, so the two feature
+/// branches below start out unpublished -- otherwise a no-op push would
+/// satisfy the assertions without ever exercising the refspec list.
+String _setUpBareOrigin(String repoPath) {
+  final Directory bare = Directory.systemTemp.createTempSync('gbm_e2e_origin_');
+  final String originPath = bare.resolveSymbolicLinksSync();
+  Process.runSync('git', <String>[
+    'init',
+    '--bare',
+    '--initial-branch=main',
+    originPath,
+  ]);
+  runGit(repoPath, <String>['remote', 'add', 'origin', originPath]);
+  runGit(repoPath, <String>['push', '--set-upstream', 'origin', 'main']);
+  return originPath;
+}
+
+List<String> _remoteBranches(String originPath) {
+  final String out = runGit(originPath, <String>[
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/heads',
+  ]).stdout.toString();
+  return out
+      .split('\n')
+      .map((String s) => s.trim())
+      .where((String s) => s.isNotEmpty)
+      .toList()
+    ..sort();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late String repoPath;
+  late String originPath;
+
+  setUp(() {
+    repoPath = createTempGitRepo();
+    originPath = _setUpBareOrigin(repoPath);
+    runGit(repoPath, <String>['branch', 'lane-allocator']);
+    runGit(repoPath, <String>['branch', 'ref-chips']);
+  });
+
+  tearDown(() {
+    deleteTempGitRepo(repoPath);
+    deleteTempGitRepo(originPath);
+  });
+
+  testWidgets('pushing several branches sends one push that lands them all', (
+    tester,
+  ) async {
+    expect(_remoteBranches(originPath), <String>['main']);
+
+    await pumpRealAppOn(tester, repoPath);
+
+    final ProviderContainer container = ProviderScope.containerOf(
+      tester.element(find.byType(GbmApp)),
+      listen: false,
+    );
+    final RepoSessionController controller = container.read(
+      repoSessionProvider(RepoIdentity.forWorkDir(repoPath)).notifier,
+    );
+
+    controller.pushChanges(
+      remoteName: 'origin',
+      branches: const <String>['lane-allocator', 'ref-chips'],
+      setUpstream: true,
+    );
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+
+    expect(
+      _remoteBranches(originPath),
+      <String>['lane-allocator', 'main', 'ref-chips'],
+      reason:
+          'both selected branches must land. A signature mismatch across the '
+          'FFI seam would not surface as a wrong branch list -- it would '
+          'crash or push garbage -- so reaching this assertion at all is '
+          'most of what this test proves.',
+    );
+  });
+
+  testWidgets('pushing with no branches still pushes the current one', (
+    tester,
+  ) async {
+    // branchCount 0 is the pre-existing "no refspec, let git decide"
+    // behaviour, which the multi-branch change had to preserve. Asserted
+    // here because it is the argument shape every existing push button in
+    // the app still uses.
+    File('$repoPath/README.md').writeAsStringSync('# changed\n');
+    runGit(repoPath, <String>['commit', '-am', 'second']);
+    final String head = runGit(repoPath, <String>[
+      'rev-parse',
+      'HEAD',
+    ]).stdout.toString().trim();
+
+    await pumpRealAppOn(tester, repoPath);
+
+    final ProviderContainer container = ProviderScope.containerOf(
+      tester.element(find.byType(GbmApp)),
+      listen: false,
+    );
+    container
+        .read(repoSessionProvider(RepoIdentity.forWorkDir(repoPath)).notifier)
+        .pushChanges(remoteName: 'origin');
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+
+    expect(
+      runGit(originPath, <String>[
+        'rev-parse',
+        'refs/heads/main',
+      ]).stdout.toString().trim(),
+      head,
+    );
+  });
+}

--- a/app_flutter/integration_test/rename_branch_flow_test.dart
+++ b/app_flutter/integration_test/rename_branch_flow_test.dart
@@ -95,7 +95,7 @@ Future<void> _openRenameDialog(WidgetTester tester, String branch) async {
   await gesture.up();
   await tester.pumpAndSettle();
 
-  await tester.tap(find.text('Rename branch'));
+  await tester.tap(find.text('Rename…'));
   await tester.pumpAndSettle(const Duration(seconds: 1));
 }
 

--- a/app_flutter/lib/actions/gbm_action_id.dart
+++ b/app_flutter/lib/actions/gbm_action_id.dart
@@ -27,6 +27,7 @@ enum GbmActionId {
   editCut,
   editCopy,
   editPaste,
+  editSelectAll,
   editFindInHistory,
   editFindInFiles,
   editFilterBranches,

--- a/app_flutter/lib/actions/gbm_menu_model.dart
+++ b/app_flutter/lib/actions/gbm_menu_model.dart
@@ -135,6 +135,7 @@ const List<GbmMenuModel> gbmMenus = <GbmMenuModel>[
       GbmMenuItemModel(id: GbmActionId.editCut, label: 'Cut'),
       GbmMenuItemModel(id: GbmActionId.editCopy, label: 'Copy'),
       GbmMenuItemModel(id: GbmActionId.editPaste, label: 'Paste'),
+      GbmMenuItemModel(id: GbmActionId.editSelectAll, label: 'Select all'),
       GbmMenuItemModel(
         id: GbmActionId.editFindInHistory,
         label: 'Find in history',

--- a/app_flutter/lib/actions/gbm_selection_gesture.dart
+++ b/app_flutter/lib/actions/gbm_selection_gesture.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// Which of spec page 13's three mouse rows a click on a list row means.
+///
+/// `MULTIKEYS` names them directly:
+/// - 單擊 -> [single] (只選這一項，anchor 移到這一項)
+/// - Ctrl / Cmd + 單擊 -> [toggle] (切換單項，anchor 移到此項)
+/// - Shift + 單擊 -> [range] (anchor 到此項的連續範圍)
+enum SelectionGesture { single, toggle, range }
+
+/// Reads the modifier state at click time and maps it to a [SelectionGesture].
+///
+/// [pressed] is normally `HardwareKeyboard.instance.logicalKeysPressed`;
+/// it is a parameter so a widget test can drive a gesture without having to
+/// hold real keys down.
+///
+/// The toggle modifier is Cmd on macOS and Ctrl elsewhere, matching how
+/// `gbm_shortcuts.dart` picks `meta` vs `control` for every other binding.
+///
+/// **Shift wins when both are held.** `MULTIKEYS` does not define
+/// Ctrl/Cmd+Shift+click, so rather than inventing a third behaviour (some
+/// file managers make it an additive range) this collapses to the range the
+/// user can see themselves selecting.
+SelectionGesture selectionGestureFromKeys(
+  Set<LogicalKeyboardKey> pressed, {
+  required bool isMacOS,
+}) {
+  final Set<LogicalKeyboardKey> shiftKeys = <LogicalKeyboardKey>{
+    LogicalKeyboardKey.shift,
+    LogicalKeyboardKey.shiftLeft,
+    LogicalKeyboardKey.shiftRight,
+  };
+  final Set<LogicalKeyboardKey> metaKeys = <LogicalKeyboardKey>{
+    LogicalKeyboardKey.meta,
+    LogicalKeyboardKey.metaLeft,
+    LogicalKeyboardKey.metaRight,
+  };
+  final Set<LogicalKeyboardKey> controlKeys = <LogicalKeyboardKey>{
+    LogicalKeyboardKey.control,
+    LogicalKeyboardKey.controlLeft,
+    LogicalKeyboardKey.controlRight,
+  };
+
+  if (pressed.any(shiftKeys.contains)) return SelectionGesture.range;
+  final Set<LogicalKeyboardKey> toggleKeys = isMacOS ? metaKeys : controlKeys;
+  if (pressed.any(toggleKeys.contains)) return SelectionGesture.toggle;
+  return SelectionGesture.single;
+}
+
+/// [selectionGestureFromKeys] against the live keyboard and the current
+/// platform -- what a row's `onTap` calls.
+SelectionGesture currentSelectionGesture() => selectionGestureFromKeys(
+  HardwareKeyboard.instance.logicalKeysPressed,
+  isMacOS: defaultTargetPlatform == TargetPlatform.macOS,
+);
+
+/// "Select every row of the list that currently has focus."
+///
+/// A dedicated intent rather than Flutter's `SelectAllTextIntent` because a
+/// commit list is not a text field: the same Ctrl/Cmd+A has to mean "select
+/// all rows" over a list and "select all text" inside an editor, and the
+/// only thing that can tell them apart is which one holds focus. The
+/// workspace's `editSelectAll` handler offers this one first and falls back
+/// to the text intent when no list consumed it -- see
+/// `workspace_screen.dart`'s `_invokeSelectAll`.
+class GbmSelectAllIntent extends Intent {
+  const GbmSelectAllIntent();
+}
+
+/// `Shift + ↑ / ↓`: 以鍵盤延伸範圍 (extend the range by keyboard).
+/// [delta] is -1 for up and 1 for down.
+class GbmExtendSelectionIntent extends Intent {
+  const GbmExtendSelectionIntent(this.delta);
+
+  final int delta;
+}

--- a/app_flutter/lib/actions/gbm_shortcuts.dart
+++ b/app_flutter/lib/actions/gbm_shortcuts.dart
@@ -136,6 +136,12 @@ Map<GbmActionId, GbmKeyboardShortcut> gbmActionShortcuts(bool isMacOS) {
     GbmActionId.editCut: _makeShortcut(LogicalKeyboardKey.keyX, isMacOS),
     GbmActionId.editCopy: _makeShortcut(LogicalKeyboardKey.keyC, isMacOS),
     GbmActionId.editPaste: _makeShortcut(LogicalKeyboardKey.keyV, isMacOS),
+    // Spec page 13's REVISIONS row adds Edit -> Select all at the plain
+    // Ctrl/Cmd+A. It does not collide with repositoryAmendLastCommit, which
+    // is Ctrl/Cmd+Shift+A, and it deliberately keeps the same key a text
+    // field uses: the handler routes by focus, so it means "select all rows"
+    // over a list and "select all text" inside an editor.
+    GbmActionId.editSelectAll: _makeShortcut(LogicalKeyboardKey.keyA, isMacOS),
     GbmActionId.editFindInHistory: _makeShortcut(
       LogicalKeyboardKey.keyF,
       isMacOS,

--- a/app_flutter/lib/data/ffi/gbm_bindings.dart
+++ b/app_flutter/lib/data/ffi/gbm_bindings.dart
@@ -624,7 +624,8 @@ typedef _PushNative =
     Void Function(
       Pointer<Void> session,
       Pointer<Utf8> remoteName,
-      Pointer<Utf8> branch,
+      Pointer<Pointer<Utf8>> branches,
+      Int32 branchCount,
       Int32 setUpstream,
       Int32 pushTags,
       Int32 forceWithLease,
@@ -633,7 +634,8 @@ typedef PushDart =
     void Function(
       Pointer<Void> session,
       Pointer<Utf8> remoteName,
-      Pointer<Utf8> branch,
+      Pointer<Pointer<Utf8>> branches,
+      int branchCount,
       int setUpstream,
       int pushTags,
       int forceWithLease,

--- a/app_flutter/lib/data/models/list_selection.dart
+++ b/app_flutter/lib/data/models/list_selection.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/foundation.dart';
+
+/// One list's multi-selection, as spec page 13's `MULTIKEYS` table defines
+/// it: an ordered set of chosen items plus a single **anchor** — the item a
+/// subsequent Shift-click measures its range from.
+///
+/// Spec's framing is that single-selection is the degenerate case, not a
+/// separate mode: 「單選是多選的特例：所有清單一律維持一組 selection + 一個
+/// anchor」 (every list keeps one selection and one anchor; a single
+/// selection is just the case where that set has one member). So the same
+/// type backs History's commit list and the sidebar's branch tree, each
+/// holding its own instance — spec keeps selections from bleeding across
+/// lists (「選取狀態跨 scope 不混用」), which is why this is a plain value
+/// type rather than one shared global.
+///
+/// Immutable: every transition returns a new instance (docs/ARCHITECTURE.md
+/// invariant 2), so a Riverpod notifier can publish it directly and widget
+/// rebuilds stay driven by identity rather than in-place mutation.
+///
+/// [items] keeps **insertion order**, not list order. That matters for the
+/// anchor rules below and for actions that report what they are about to do
+/// in the order the user picked. Anything that needs positional order (a
+/// range, a contiguity check, a compare's older/newer sides) resolves it
+/// against the underlying list, not against this order — see
+/// [isContiguousIn] and [orderedBy].
+@immutable
+class ListSelection<T> {
+  const ListSelection({this.items = const <Never>[], this.anchor});
+
+  /// The empty selection: nothing chosen, no anchor.
+  static ListSelection<T> empty<T>() => ListSelection<T>();
+
+  /// Chosen items, in the order they were added.
+  final List<T> items;
+
+  /// The item a Shift-click measures its range from, and the one that keeps
+  /// driving any single-target UI (History's commit detail panel reads it).
+  /// Null exactly when [items] is empty.
+  final T? anchor;
+
+  bool get isEmpty => items.isEmpty;
+  bool get isNotEmpty => items.isNotEmpty;
+  int get length => items.length;
+  bool get isMultiple => items.length > 1;
+
+  bool contains(T item) => items.contains(item);
+
+  /// `單擊`: select only this item and move the anchor here.
+  ListSelection<T> single(T item) =>
+      ListSelection<T>(items: <T>[item], anchor: item);
+
+  /// `Ctrl / Cmd + 單擊`: toggle one item, moving the anchor to it.
+  ///
+  /// Deselecting the anchor itself is the one case `MULTIKEYS` does not
+  /// spell out. Resolved here rather than ad hoc at a call site: the anchor
+  /// falls back to the most recently added of whatever remains, so the next
+  /// Shift-click still measures from something the user actually chose, and
+  /// goes null only when the selection empties out.
+  ListSelection<T> toggle(T item) {
+    if (!items.contains(item)) {
+      return ListSelection<T>(items: <T>[...items, item], anchor: item);
+    }
+    final List<T> remaining = <T>[
+      for (final T existing in items)
+        if (existing != item) existing,
+    ];
+    if (remaining.isEmpty) return ListSelection<T>();
+    return ListSelection<T>(
+      items: remaining,
+      // Removing a non-anchor item leaves the anchor where it was; removing
+      // the anchor promotes the newest survivor.
+      anchor: item == anchor ? remaining.last : anchor,
+    );
+  }
+
+  /// `Shift + 單擊` / `Shift + ↑ / ↓`: replace the selection with every item
+  /// between the anchor and [item] inclusive, taken from [all] (the list's
+  /// own order — the caller passes the *unfiltered* order where one exists).
+  ///
+  /// The anchor deliberately does **not** move: that is what makes a second
+  /// Shift-click grow or shrink the same range instead of starting a new
+  /// one. With no anchor yet, or with either end missing from [all], this
+  /// degrades to a plain single selection rather than guessing a range.
+  ListSelection<T> range(T item, List<T> all) {
+    final T? from = anchor;
+    if (from == null) return single(item);
+    final int start = all.indexOf(from);
+    final int end = all.indexOf(item);
+    if (start < 0 || end < 0) return single(item);
+    final int lo = start <= end ? start : end;
+    final int hi = start <= end ? end : start;
+    return ListSelection<T>(
+      items: <T>[for (int i = lo; i <= hi; i++) all[i]],
+      anchor: from,
+    );
+  }
+
+  /// `Ctrl / Cmd + A`: select the whole current list. The anchor stays put
+  /// when it is still present, so a following Shift-click still has the
+  /// user's own reference point; otherwise it falls to the first item.
+  ListSelection<T> selectAll(List<T> all) {
+    if (all.isEmpty) return ListSelection<T>();
+    final T? from = anchor;
+    return ListSelection<T>(
+      items: List<T>.of(all),
+      anchor: from != null && all.contains(from) ? from : all.first,
+    );
+  }
+
+  /// `Esc`: 「縮回單選（保留 anchor 項）」 — collapse back to just the
+  /// anchor rather than clearing outright, so Esc undoes the *extension*
+  /// without also throwing away where the user was.
+  ListSelection<T> collapseToAnchor() {
+    final T? from = anchor;
+    if (from == null) return ListSelection<T>();
+    return ListSelection<T>(items: <T>[from], anchor: from);
+  }
+
+  /// True when the selected items occupy an unbroken run of [all].
+  ///
+  /// Spec gates cherry-pick / revert on this: 「commit 多選只在連續範圍時開放
+  /// cherry-pick / revert / squash；不連續時這三項 disabled」. An empty
+  /// selection is not contiguous — there is nothing to act on — while a
+  /// single item trivially is. An item missing from [all] (e.g. selected
+  /// before a filter changed what the list holds) makes the answer false
+  /// rather than throwing: the honest reading of "can these be replayed as
+  /// one run" is no.
+  bool isContiguousIn(List<T> all) {
+    if (items.isEmpty) return false;
+    final List<int> indices = <int>[];
+    for (final T item in items) {
+      final int index = all.indexOf(item);
+      if (index < 0) return false;
+      indices.add(index);
+    }
+    indices.sort();
+    for (int i = 1; i < indices.length; i++) {
+      if (indices[i] != indices[i - 1] + 1) return false;
+    }
+    return true;
+  }
+
+  /// The selection in [all]'s own order rather than insertion order — what
+  /// anything positional needs: which of two commits is the older side of a
+  /// compare, which order a cherry-pick replays in. Items absent from [all]
+  /// are dropped, mirroring [isContiguousIn]'s treatment of them.
+  List<T> orderedBy(List<T> all) => <T>[
+    for (final T candidate in all)
+      if (items.contains(candidate)) candidate,
+  ];
+
+  @override
+  bool operator ==(Object other) =>
+      other is ListSelection<T> &&
+      other.anchor == anchor &&
+      listEquals(other.items, items);
+
+  @override
+  int get hashCode => Object.hash(anchor, Object.hashAll(items));
+
+  @override
+  String toString() => 'ListSelection(items: $items, anchor: $anchor)';
+}

--- a/app_flutter/lib/data/repositories/branch_selection_repository.dart
+++ b/app_flutter/lib/data/repositories/branch_selection_repository.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/list_selection.dart';
+import 'repo_identity.dart';
+
+/// The sidebar branch tree's multi-selection, keyed by short branch name.
+///
+/// A provider rather than `SidebarPanel` local `State`, for two reasons:
+/// `WorkspaceScreen._buildActionHandlers()` cannot read a widget's private
+/// state, so nothing outside the sidebar could ever act on a selection; and
+/// spec page 13's `MULTIBRANCHMENU` needs the same selection visible to the
+/// row that was right-clicked, which is a sibling widget.
+///
+/// Separate from `commitSelectionProvider` on purpose: spec keeps selections
+/// from bleeding between lists (「選取狀態跨 scope 不混用」), so the two share
+/// [ListSelection]'s transitions without sharing a value.
+///
+/// **The checkbox and Ctrl/Cmd-click write the same state.** The sidebar has
+/// had a checkbox-based bulk selection since the "delete gone branches"
+/// work; ticking a box is exactly [ListSelection.toggle], so both affordances
+/// go through here rather than growing a second, drifting selection set.
+final StateProviderFamily<ListSelection<String>, RepoIdentity>
+branchSelectionProvider =
+    StateProvider.family<ListSelection<String>, RepoIdentity>(
+      (ref, identity) => const ListSelection<String>(),
+    );

--- a/app_flutter/lib/data/repositories/history_repository.dart
+++ b/app_flutter/lib/data/repositories/history_repository.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/changed_file.dart';
 import '../models/commit_meta.dart';
 import '../models/graph_snapshot.dart';
+import '../models/list_selection.dart';
 import '../models/parsed_diff.dart';
 import 'repo_identity.dart';
 import 'repo_session_repository.dart';
@@ -89,12 +90,37 @@ void requestCommitFileDiff(
       .requestCommitFileDiff(oid, path);
 }
 
-/// The currently-selected commit's oid in [CommitGraphView], per repository
-/// -- family-scoped like every other per-repo provider here, rather than a
-/// single global `StateProvider`, so selection in one open repository never
-/// leaks into another.
-final StateProviderFamily<String?, RepoIdentity> selectedCommitProvider =
-    StateProvider.family<String?, RepoIdentity>((ref, identity) => null);
+/// The History commit list's multi-selection, per repository -- family-scoped
+/// like every other per-repo provider here, rather than a single global
+/// `StateProvider`, so selection in one open repository never leaks into
+/// another. Spec page 13 also keeps selections from bleeding *between lists*
+/// (「選取狀態跨 scope 不混用」), which is why the sidebar's branch tree holds
+/// its own [ListSelection] rather than sharing this one.
+///
+/// Holds oid hex strings. Selection is expressed against the *unfiltered*
+/// graph snapshot, so a range taken while a filter is active is still
+/// judged for contiguity against real history -- see
+/// [ListSelection.isContiguousIn].
+final StateProviderFamily<ListSelection<String>, RepoIdentity>
+commitSelectionProvider =
+    StateProvider.family<ListSelection<String>, RepoIdentity>(
+      (ref, identity) => const ListSelection<String>(),
+    );
+
+/// The currently-selected commit's oid in [CommitGraphView] -- the single
+/// target every one-commit surface reads (the commit detail panel, the
+/// changed-files panel).
+///
+/// **Derived, not independently writable**: it is exactly
+/// [commitSelectionProvider]'s anchor. Before multi-select this was its own
+/// `StateProvider` that call sites wrote to directly; keeping that alongside
+/// a selection set would have meant two selection states that could disagree,
+/// so the anchor is now the one source of truth and this is a read-only view
+/// of it. Write through [commitSelectionProvider] instead.
+final ProviderFamily<String?, RepoIdentity> selectedCommitProvider =
+    Provider.family<String?, RepoIdentity>(
+      (ref, identity) => ref.watch(commitSelectionProvider(identity)).anchor,
+    );
 
 /// The currently-selected file path within the selected commit's changed files.
 /// Null means show commit metadata; non-null means show the diff for that file.

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -2152,30 +2152,36 @@ class RepoSessionController extends StateNotifier<RepoSessionState> {
   }
 
   /// `git push`, with `--force-with-lease` when `forceWithLease` is set --
-  /// there is no plain `--force` (see gbm_push()'s doc comment). `branch`
-  /// empty pushes the current branch.
+  /// there is no plain `--force` (see gbm_push()'s doc comment).
+  ///
+  /// [branches] empty pushes the current branch. More than one is a
+  /// multi-select push: it becomes a single `git push <remote> a b c`, not N
+  /// calls, so the whole batch is one background task (spec page 10) and
+  /// git's own per-ref reporting supplies "carry on past a ref that failed".
   void pushChanges({
     String remoteName = '',
-    String branch = '',
+    List<String> branches = const <String>[],
     bool setUpstream = false,
     bool pushTags = false,
     bool forceWithLease = false,
   }) {
     if (_session == nullptr) return;
     final Pointer<Utf8> remotePtr = remoteName.toNativeUtf8();
-    final Pointer<Utf8> branchPtr = branch.toNativeUtf8();
     try {
-      _bindings.push(
-        _session,
-        remotePtr,
-        branchPtr,
-        setUpstream ? 1 : 0,
-        pushTags ? 1 : 0,
-        forceWithLease ? 1 : 0,
+      _withNativeStringArray(
+        branches,
+        (array, count) => _bindings.push(
+          _session,
+          remotePtr,
+          array,
+          count,
+          setUpstream ? 1 : 0,
+          pushTags ? 1 : 0,
+          forceWithLease ? 1 : 0,
+        ),
       );
     } finally {
       malloc.free(remotePtr);
-      malloc.free(branchPtr);
     }
   }
 

--- a/app_flutter/lib/features/dialogs/delete_branches/delete_branches_dialog.dart
+++ b/app_flutter/lib/features/dialogs/delete_branches/delete_branches_dialog.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../data/models/ref_snapshot.dart';
+import '../../../data/repositories/repo_identity.dart';
+import '../../../data/repositories/repo_session_repository.dart';
+import '../../../theme/gbm_theme.dart';
+import '../../../theme/tokens.dart';
+import '../../../widgets/gbm_button.dart';
+import '../../../widgets/gbm_dialog_shell.dart';
+import '../../sidebar/branch_tree_builder.dart';
+
+/// One branch's line in the confirmation list.
+@immutable
+class DeleteBranchLine {
+  const DeleteBranchLine({
+    required this.name,
+    required this.unpushed,
+    required this.remote,
+  });
+
+  final String name;
+
+  /// Commits on this branch its upstream does not have, or null when the
+  /// branch has no upstream at all -- see [deleteBranchLines].
+  final int? unpushed;
+
+  /// The remote its upstream lives on, empty when it has none.
+  final String remote;
+
+  bool get hasUpstream => remote.isNotEmpty;
+}
+
+/// Builds the per-branch lines spec page 13 requires the confirmation to
+/// show: 「破壞性批次動作（Delete branches、Drop stashes）的確認 dialog 逐項
+/// 列出名稱與未 push 的 commit 數，並區分「本地」與「遠端」兩份清單，不用
+/// 一句「刪除 3 個分支？」概括」.
+///
+/// **`ahead` only means anything when there is an upstream.** A branch that
+/// never had one reports `ahead: 0`, which rendered literally would claim
+/// "0 unpushed commits" -- the opposite of the truth, since *every* commit
+/// on it is unpushed. Those lines carry a null [DeleteBranchLine.unpushed]
+/// and say so instead.
+///
+/// The upstream test is `upstream.isNotEmpty`, **not** `hasTrackingInfo`:
+/// the latter mirrors git's `%(upstream:track)`, which is an empty string
+/// for a branch exactly in sync with its upstream (see CLAUDE.md's Tier 0c
+/// note), so it would wrongly report the most common case as untracked.
+///
+/// The remote name comes from [remoteBranchParts], never from splitting
+/// `upstream` at its first slash -- `upstream` is the *full* ref name
+/// (`refs/remotes/origin/x`), so that split yields `"refs"`. That is exactly
+/// the live bug tracked as #74 in `delete_branch_dialog.dart`.
+List<DeleteBranchLine> deleteBranchLines(List<String> names, RefSnapshot refs) {
+  final Map<String, RefInfo> byName = <String, RefInfo>{
+    for (final RefInfo r in refs.refs)
+      if (r.kind == RefKind.localBranch) r.shortName: r,
+  };
+  return <DeleteBranchLine>[
+    for (final String name in names)
+      if (byName[name] case final RefInfo branch)
+        DeleteBranchLine(
+          name: name,
+          unpushed: branch.upstream.isEmpty ? null : branch.ahead,
+          remote: branch.upstream.isEmpty
+              ? ''
+              : remoteBranchParts(branch.upstream).$1,
+        )
+      else
+        DeleteBranchLine(name: name, unpushed: null, remote: ''),
+  ];
+}
+
+/// Confirms a multi-branch delete, listing every branch by name with its
+/// unpushed-commit count and splitting local from remote, per spec page 13.
+///
+/// Routed as `/repo/:repoId/dialogs/delete-branches?names=a,b,c`. Distinct
+/// from `delete_branch_dialog.dart`, which is the single-branch 05-B flow
+/// with its own branch picker.
+class DeleteBranchesDialogContent extends ConsumerStatefulWidget {
+  const DeleteBranchesDialogContent({
+    super.key,
+    required this.identity,
+    required this.names,
+  });
+
+  final RepoIdentity identity;
+  final List<String> names;
+
+  @override
+  ConsumerState<DeleteBranchesDialogContent> createState() =>
+      _DeleteBranchesDialogContentState();
+}
+
+class _DeleteBranchesDialogContentState
+    extends ConsumerState<DeleteBranchesDialogContent> {
+  bool _alsoDeleteRemote = false;
+  bool _force = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    final RepoSessionState session = ref.watch(
+      repoSessionProvider(widget.identity),
+    );
+    final List<DeleteBranchLine> lines = deleteBranchLines(
+      widget.names,
+      session.refs,
+    );
+    final List<DeleteBranchLine> tracked = lines
+        .where((DeleteBranchLine l) => l.hasUpstream)
+        .toList();
+
+    return GbmDialogShell(
+      title: 'Delete ${lines.length} branches',
+      actions: <Widget>[
+        GbmButton(label: 'Cancel', onPressed: () => context.pop()),
+        const SizedBox(width: GbmSpacing.space2),
+        GbmButton(
+          label: 'Delete ${lines.length} branches',
+          kind: GbmButtonKind.danger,
+          onPressed: lines.isEmpty ? null : () => _delete(lines, tracked),
+        ),
+      ],
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          _sectionTitle(context, 'Local branches'),
+          for (final DeleteBranchLine line in lines) _BranchLineRow(line: line),
+          if (tracked.isNotEmpty) ...<Widget>[
+            const SizedBox(height: GbmSpacing.space3),
+            _sectionTitle(context, 'Remote branches'),
+            for (final DeleteBranchLine line in tracked)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 1),
+                child: Text(
+                  '${line.remote}/${line.name}',
+                  style: TextStyle(
+                    fontFamily: GbmTypography.fontMono,
+                    fontSize: GbmTypography.textXs,
+                    color: colors.textSecondary,
+                  ),
+                ),
+              ),
+            CheckboxListTile(
+              value: _alsoDeleteRemote,
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              title: Text(
+                'Also delete on the remote',
+                style: TextStyle(
+                  fontSize: GbmTypography.textSm,
+                  color: colors.textPrimary,
+                ),
+              ),
+              onChanged: (bool? value) =>
+                  setState(() => _alsoDeleteRemote = value ?? false),
+            ),
+          ],
+          CheckboxListTile(
+            value: _force,
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            controlAffinity: ListTileControlAffinity.leading,
+            title: Text(
+              'Delete even if not fully merged',
+              style: TextStyle(
+                fontSize: GbmTypography.textSm,
+                color: colors.textPrimary,
+              ),
+            ),
+            onChanged: (bool? value) => setState(() => _force = value ?? false),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionTitle(BuildContext context, String text) => Padding(
+    padding: const EdgeInsets.only(bottom: GbmSpacing.space1),
+    child: Text(
+      text,
+      style: TextStyle(
+        fontSize: GbmTypography.textXs,
+        fontWeight: GbmTypography.weightSemibold,
+        color: context.gbmColors.textTertiary,
+      ),
+    ),
+  );
+
+  void _delete(List<DeleteBranchLine> lines, List<DeleteBranchLine> tracked) {
+    final RepoSessionController notifier = ref.read(
+      repoSessionProvider(widget.identity).notifier,
+    );
+    // One call, not N: gbm_branch_delete takes every name at once, matching
+    // `git branch -d`'s own multi-name support -- "a multi-select delete is
+    // one operation, not N" (gbm_capi.h). N calls would also emit N
+    // OPERATION_FINISHED events against spec page 10's one-background-task
+    // rule.
+    notifier.deleteBranch(
+      names: <String>[for (final DeleteBranchLine l in lines) l.name],
+      force: _force,
+    );
+    if (_alsoDeleteRemote) {
+      // Grouped by remote: gbm_branch_delete's remote form runs
+      // `git push <remoteName> --delete <names...>`, so a selection spanning
+      // two remotes needs one call each rather than one call with a remote
+      // name that is only right for some of them.
+      final Map<String, List<String>> byRemote = <String, List<String>>{};
+      for (final DeleteBranchLine line in tracked) {
+        byRemote.putIfAbsent(line.remote, () => <String>[]).add(line.name);
+      }
+      byRemote.forEach((String remote, List<String> names) {
+        notifier.deleteBranch(
+          names: names,
+          isRemote: true,
+          remoteName: remote,
+          force: _force,
+        );
+      });
+    }
+    context.pop();
+  }
+}
+
+class _BranchLineRow extends StatelessWidget {
+  const _BranchLineRow({required this.line});
+
+  final DeleteBranchLine line;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    final String detail = switch (line.unpushed) {
+      null => 'no upstream — nothing has been pushed',
+      0 => 'fully pushed',
+      final int n => '$n unpushed commit${n == 1 ? '' : 's'}',
+    };
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              line.name,
+              style: TextStyle(
+                fontFamily: GbmTypography.fontMono,
+                fontSize: GbmTypography.textXs,
+                color: colors.textPrimary,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: GbmSpacing.space2),
+          Text(
+            detail,
+            style: TextStyle(
+              fontSize: GbmTypography.textXs,
+              color: line.unpushed == null || line.unpushed! > 0
+                  ? colors.warning
+                  : colors.textTertiary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app_flutter/lib/features/dialogs/rebase_onto/rebase_onto_dialog.dart
+++ b/app_flutter/lib/features/dialogs/rebase_onto/rebase_onto_dialog.dart
@@ -24,9 +24,22 @@ import '../../../widgets/gbm_dialog_shell.dart';
 ///
 /// Routed as `/repo/:repoId/dialogs/rebase-onto`.
 class RebaseOntoDialogContent extends ConsumerStatefulWidget {
-  const RebaseOntoDialogContent({super.key, required this.identity});
+  const RebaseOntoDialogContent({
+    super.key,
+    required this.identity,
+    this.target,
+  });
 
   final RepoIdentity identity;
+
+  /// Pre-selects what to rebase onto. 05-B's "Rebase current onto here"
+  /// passes a branch name, which is already one of the dropdown's own
+  /// options; 05-E's "Rebase onto here" passes a commit oid, which is not,
+  /// so [_candidateItems] adds it as an extra option rather than dropping a
+  /// target the user explicitly picked. `git rebase` takes any committish,
+  /// so an oid is a perfectly good upstream -- see gbm_capi.h's
+  /// gbm_rebase_start.
+  final String? target;
 
   @override
   ConsumerState<RebaseOntoDialogContent> createState() =>
@@ -37,6 +50,37 @@ class _RebaseOntoDialogContentState
     extends ConsumerState<RebaseOntoDialogContent> {
   String? _target;
   bool _stashFirst = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _target = widget.target;
+  }
+
+  /// The branch list, plus [RebaseOntoDialogContent.target] itself when it
+  /// is not one of those branches (a commit oid). Without that extra entry
+  /// `DropdownButtonFormField` would assert on an `initialValue` that is
+  /// not among its items, and silently dropping the pre-fill would send the
+  /// user back to picking a target they already chose.
+  List<DropdownMenuItem<String>> _candidateItems(List<RefInfo> candidates) {
+    final String? target = widget.target;
+    final bool targetIsBranch = candidates.any(
+      (RefInfo b) => b.shortName == target,
+    );
+    return <DropdownMenuItem<String>>[
+      if (target != null && !targetIsBranch)
+        DropdownMenuItem<String>(
+          value: target,
+          // Abbreviated the way every other oid in the app is, so the row
+          // reads as a commit rather than as a 40-character branch name.
+          child: Text(
+            target.length >= 8 ? 'commit ${target.substring(0, 8)}' : target,
+          ),
+        ),
+      for (final RefInfo b in candidates)
+        DropdownMenuItem<String>(value: b.shortName, child: Text(b.shortName)),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -94,13 +138,7 @@ class _RebaseOntoDialogContentState
               isDense: true,
               border: OutlineInputBorder(),
             ),
-            items: <DropdownMenuItem<String>>[
-              for (final RefInfo b in candidates)
-                DropdownMenuItem<String>(
-                  value: b.shortName,
-                  child: Text(b.shortName),
-                ),
-            ],
+            items: _candidateItems(candidates),
             onChanged: (String? value) => setState(() => _target = value),
           ),
           const SizedBox(height: GbmSpacing.space2),

--- a/app_flutter/lib/features/dialogs/reset_branch/reset_branch_dialog.dart
+++ b/app_flutter/lib/features/dialogs/reset_branch/reset_branch_dialog.dart
@@ -13,9 +13,19 @@ import '../../../widgets/gbm_dialog_shell.dart';
 /// (src/app/dialogs/ResetBranchDialog.cpp). Routed as
 /// `/repo/:repoId/dialogs/reset-branch`.
 class ResetBranchDialogContent extends ConsumerStatefulWidget {
-  const ResetBranchDialogContent({super.key, required this.identity});
+  const ResetBranchDialogContent({
+    super.key,
+    required this.identity,
+    this.target,
+  });
 
   final RepoIdentity identity;
+
+  /// Pre-fills the "Reset to" field. 05-E's "Reset branch to here…" passes
+  /// the right-clicked commit's oid; null keeps the dialog's own default of
+  /// the current branch, which is what Branch -> Reset… has always opened
+  /// with.
+  final String? target;
 
   @override
   ConsumerState<ResetBranchDialogContent> createState() =>
@@ -34,7 +44,7 @@ class _ResetBranchDialogContentState
       repoSessionProvider(widget.identity),
     );
     _targetController = TextEditingController(
-      text: session.refs.head.branchName,
+      text: widget.target ?? session.refs.head.branchName,
     );
   }
 

--- a/app_flutter/lib/features/history_graph/commit_graph_view.dart
+++ b/app_flutter/lib/features/history_graph/commit_graph_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../actions/gbm_selection_gesture.dart';
 import '../../data/models/commit_meta.dart';
@@ -8,9 +9,12 @@ import '../../data/models/graph_snapshot.dart';
 import '../../data/models/list_selection.dart';
 import '../../data/models/ref_snapshot.dart';
 import '../../data/repositories/branch_repository.dart';
+import '../../data/repositories/compare_tabs_repository.dart';
+import '../../data/services/file_save_picker.dart';
 import '../../data/repositories/history_repository.dart';
 import '../../data/repositories/repo_identity.dart';
 import '../../data/repositories/repo_session_repository.dart';
+import '../../routing/route_paths.dart';
 import '../../theme/gbm_theme.dart';
 import '../../theme/tokens.dart';
 import '../../widgets/prompt_text_dialog.dart';
@@ -217,6 +221,72 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
     _publish(current.range(visibleOids[next], visibleOids));
   }
 
+  String get _repoId => Uri.encodeComponent(widget.identity.workDir);
+
+  RepoSessionController get _session =>
+      ref.read(repoSessionProvider(widget.identity).notifier);
+
+  /// The selection in history order, newest first -- the order History
+  /// itself renders and the order the menu's counted labels describe.
+  List<String> _selectedNewestFirst() {
+    final GraphSnapshotView graph = ref.read(
+      repoGraphProvider(widget.identity),
+    );
+    return ref
+        .read(commitSelectionProvider(widget.identity))
+        .orderedBy(graph.oidsHex);
+  }
+
+  /// gbm_cherry_pick and gbm_revert both take commits **oldest first** (see
+  /// gbm_capi.h: revert states it shares cherry-pick's convention), and
+  /// History is newest-first. Reversing here rather than at each call site
+  /// keeps the one place that has to know about it findable.
+  List<String> _selectedOldestFirst() =>
+      _selectedNewestFirst().reversed.toList(growable: false);
+
+  void _copySelectedShas() {
+    // One per line, per MULTIACTS' 「支援 — 每行一個 hash 複製」.
+    Clipboard.setData(ClipboardData(text: _selectedNewestFirst().join('\n')));
+  }
+
+  /// COMPARES 3: 「History 內 Ctrl/Cmd 點選兩個 commit → 右鍵 Compare」.
+  ///
+  /// With two selected, both sides are filled directly, older on the left so
+  /// the diff reads forwards in time -- the same older-left/newer-right
+  /// convention `_compareStash` follows. With one, only the left is known,
+  /// and the Compare tab's own ref picker chooses the right, exactly as
+  /// 05-D's "Compare with…" on a tag already does.
+  void _compareSelection() {
+    final List<String> ordered = _selectedNewestFirst();
+    if (ordered.isEmpty) return;
+    final String tabId = ordered.length >= 2
+        ? ref
+              .read(compareTabsProvider(widget.identity).notifier)
+              .open(left: ordered.last, right: ordered.first)
+        : ref
+              .read(compareTabsProvider(widget.identity).notifier)
+              .open(left: ordered.first);
+    context.go(RoutePaths.compareFor(_repoId, tabId));
+  }
+
+  /// 05-E's "Compare with working copy": the right side is the live tree,
+  /// which [CompareTabSpec] models as a null right rather than a ref string
+  /// (gbm_capi has a genuinely different call for it).
+  void _compareWithWorkingCopy(String oid) {
+    final String tabId = ref
+        .read(compareTabsProvider(widget.identity).notifier)
+        .open(left: oid);
+    context.go(RoutePaths.compareFor(_repoId, tabId));
+  }
+
+  Future<void> _exportSelectedPatches() async {
+    final String? dir = await ref.read(fileSavePickerProvider).pickDirectory();
+    if (dir == null || !mounted) return;
+    // Oldest first so the generated 0001-, 0002-… numbering runs forwards
+    // through history, matching what `git format-patch` produces for a range.
+    _session.exportPatches(_selectedOldestFirst(), dir);
+  }
+
   @override
   Widget build(BuildContext context) {
     final GraphSnapshotView graph = ref.watch(
@@ -236,6 +306,11 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
       repoSessionProvider(
         widget.identity,
       ).select((state) => state.effectiveIdentity.email),
+    );
+    final bool conflictActive = ref.watch(
+      repoSessionProvider(
+        widget.identity,
+      ).select((RepoSessionState state) => state.conflictActive),
     );
     final GbmColors colors = context.gbmColors;
 
@@ -289,6 +364,7 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
                   selection,
                   refs,
                   effectiveEmail,
+                  conflictActive,
                 ),
         ),
       ],
@@ -303,7 +379,13 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
     ListSelection<String> selection,
     RefSnapshot refs,
     String effectiveEmail,
+    bool conflictActive,
   ) {
+    // Contiguity is judged against the **unfiltered** snapshot, not the
+    // rendered list: three commits that look adjacent under a filter are
+    // not a range git can replay, so cherry-pick and revert correctly stay
+    // disabled for them (MULTIACTS).
+    final bool contiguous = selection.isContiguousIn(graph.oidsHex);
     // The rendered order, as oids. Every selection transition is expressed
     // against this rather than against `visibleRows` (snapshot indices), so
     // a range never silently spans rows a filter is hiding.
@@ -361,21 +443,29 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
                 onContextMenuRequested: oid.isEmpty
                     ? null
                     : () => _normaliseSelectionForMenu(oid),
+                menuSelectionCount: selection.length,
+                menuSelectionIsContiguous: contiguous,
+                conflictActive: conflictActive,
+                menuTitle: selection.length > 1
+                    ? '${selection.length} commits'
+                    : null,
+                onCopySha: oid.isEmpty ? null : _copySelectedShas,
                 onCheckout: oid.isEmpty
                     ? null
-                    : () => ref
-                          .read(repoSessionProvider(widget.identity).notifier)
-                          .checkout(target: oid, detach: true),
+                    : () => _session.checkout(target: oid, detach: true),
+                onMerge: oid.isEmpty
+                    ? null
+                    // gbm_merge_branch's `target` is pushed straight into
+                    // `git merge <target>` (MergeOps.cpp), so an oid is a
+                    // perfectly good merge target -- no oid-to-branch-name
+                    // resolution step is needed despite the parameter's name.
+                    : () => _session.mergeBranch(oid, MergeMode.noFastForward),
                 onCherryPick: oid.isEmpty
                     ? null
-                    : () => ref
-                          .read(repoSessionProvider(widget.identity).notifier)
-                          .cherryPick(<String>[oid]),
+                    : () => _session.cherryPick(_selectedOldestFirst()),
                 onRevert: oid.isEmpty
                     ? null
-                    : () => ref
-                          .read(repoSessionProvider(widget.identity).notifier)
-                          .revert(<String>[oid]),
+                    : () => _session.revert(_selectedOldestFirst()),
                 onCreateBranchHere: oid.isEmpty
                     ? null
                     : () => _createBranchFromCommit(
@@ -384,6 +474,21 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
                         widget.identity,
                         oid,
                       ),
+                onCompare: oid.isEmpty ? null : _compareSelection,
+                onRebaseOntoHere: oid.isEmpty
+                    ? null
+                    : () => context.push(
+                        RoutePaths.rebaseOntoDialogFor(_repoId, target: oid),
+                      ),
+                onResetBranchHere: oid.isEmpty
+                    ? null
+                    : () => context.push(
+                        RoutePaths.resetBranchDialogFor(_repoId, target: oid),
+                      ),
+                onExportAsPatch: oid.isEmpty ? null : _exportSelectedPatches,
+                onCompareWithWorkingCopy: oid.isEmpty
+                    ? null
+                    : () => _compareWithWorkingCopy(oid),
               );
             },
           ),

--- a/app_flutter/lib/features/history_graph/commit_graph_view.dart
+++ b/app_flutter/lib/features/history_graph/commit_graph_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../actions/gbm_selection_gesture.dart';
 import '../../data/models/commit_meta.dart';
 import '../../data/models/graph_snapshot.dart';
 import '../../data/models/list_selection.dart';
@@ -43,6 +44,17 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
   final ScrollController _controller = ScrollController();
   final TextEditingController _searchController = TextEditingController();
 
+  /// Focus owner for the commit list, so `_SelectionShortcuts`' bindings
+  /// only fire while the list is what the user is actually working in.
+  ///
+  /// Focus is requested explicitly from [_publish] rather than relying on
+  /// the rows' `InkWell`s: an InkWell is focusable for keyboard traversal
+  /// but a plain tap does not move focus to it, so without this the very
+  /// gesture that creates a selection would leave focus wherever it was
+  /// (typically the filter field), and Shift+↑/↓, Ctrl/Cmd+A and Esc would
+  /// all silently do nothing.
+  final FocusNode _listFocus = FocusNode(debugLabel: 'CommitGraphView list');
+
   @override
   void initState() {
     super.initState();
@@ -52,6 +64,7 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
   @override
   void dispose() {
     _searchController.dispose();
+    _listFocus.dispose();
     _controller
       ..removeListener(_onScroll)
       ..dispose();
@@ -125,18 +138,83 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
         .createBranch(name: name, startPoint: commitOid);
   }
 
-  /// MULTIKEYS' `單擊` row: select only this commit and move the anchor to
-  /// it. Written through [commitSelectionProvider] rather than to
+  StateController<ListSelection<String>> get _selectionController =>
+      ref.read(commitSelectionProvider(widget.identity).notifier);
+
+  /// Publishes a new selection and keeps the single-target surfaces in step
+  /// with its anchor: the changed-files panel reloads for the new anchor and
+  /// any file drilled into under the previous one is cleared, since it may
+  /// not exist in this commit at all.
+  ///
+  /// Written through [commitSelectionProvider] rather than to
   /// `selectedCommitProvider`, which is now that selection's anchor read
   /// back out (see its doc comment) and no longer independently writable.
-  void _selectSingle(String oid) {
-    final StateController<ListSelection<String>> selection = ref.read(
-      commitSelectionProvider(widget.identity).notifier,
-    );
-    selection.state = selection.state.single(oid);
+  void _publish(ListSelection<String> next) {
+    _listFocus.requestFocus();
+    final String? previousAnchor = _selectionController.state.anchor;
+    _selectionController.state = next;
+    final String? anchor = next.anchor;
+    if (anchor == null || anchor == previousAnchor) return;
     ref.read(selectedCommitFilePathProvider(widget.identity).notifier).state =
         null;
-    requestCommitFiles(ref, widget.identity, oid);
+    requestCommitFiles(ref, widget.identity, anchor);
+  }
+
+  /// Applies one of spec page 13's three mouse rows.
+  ///
+  /// [visibleOids] is the list **as rendered** -- under a filter that is the
+  /// match list, not the whole snapshot. A Shift-range therefore never
+  /// reaches across rows the user cannot see. Contiguity is a separate
+  /// question answered against the unfiltered snapshot (see
+  /// [_selectedAreContiguous]), which is why a range taken under a filter
+  /// can be a perfectly good selection and still, correctly, be too gappy
+  /// to cherry-pick.
+  void _onRowSelect(
+    String oid,
+    SelectionGesture gesture,
+    List<String> visibleOids,
+  ) {
+    final ListSelection<String> current = _selectionController.state;
+    _publish(switch (gesture) {
+      SelectionGesture.single => current.single(oid),
+      SelectionGesture.toggle => current.toggle(oid),
+      SelectionGesture.range => current.range(oid, visibleOids),
+    });
+  }
+
+  /// Spec page 13's right-click rule, run before the menu is built: an
+  /// already-selected row leaves the selection alone; any other row
+  /// collapses to just itself first.
+  void _normaliseSelectionForMenu(String oid) {
+    final ListSelection<String> current = _selectionController.state;
+    if (current.contains(oid)) return;
+    _publish(current.single(oid));
+  }
+
+  /// `Shift + ↑ / ↓`: 以鍵盤延伸範圍 — move the selection's free end one
+  /// row in [delta]'s direction, measured in the rendered list so it tracks
+  /// what the user sees.
+  ///
+  /// The free end is the end that is **not** the anchor, mirroring what a
+  /// Shift-click does: the anchor stays pinned and the other end travels.
+  /// Picking "whichever end lies in the direction of travel" instead would
+  /// make Shift+Up after a downward range grow it upward rather than shrink
+  /// it back, which is not how any list behaves.
+  void _extendSelection(int delta, List<String> visibleOids) {
+    if (visibleOids.isEmpty) return;
+    final ListSelection<String> current = _selectionController.state;
+    final List<String> ordered = current.orderedBy(visibleOids);
+    final String? anchor = current.anchor;
+    if (ordered.isEmpty || anchor == null || !visibleOids.contains(anchor)) {
+      _publish(current.single(visibleOids.first));
+      return;
+    }
+    final String freeEnd = ordered.first == anchor
+        ? ordered.last
+        : ordered.first;
+    final int from = visibleOids.indexOf(freeEnd);
+    final int next = (from + delta).clamp(0, visibleOids.length - 1);
+    _publish(current.range(visibleOids[next], visibleOids));
   }
 
   @override
@@ -150,8 +228,8 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
     final Map<String, CommitMeta> metaCache = ref.watch(
       commitMetaProvider(widget.identity),
     );
-    final String? selectedOid = ref.watch(
-      selectedCommitProvider(widget.identity),
+    final ListSelection<String> selection = ref.watch(
+      commitSelectionProvider(widget.identity),
     );
     final RefSnapshot refs = ref.watch(repoRefsProvider(widget.identity));
     final String effectiveEmail = ref.watch(
@@ -208,7 +286,7 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
                   visibleRows,
                   query,
                   metaCache,
-                  selectedOid,
+                  selection,
                   refs,
                   effectiveEmail,
                 ),
@@ -222,71 +300,93 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
     List<int> visibleRows,
     String query,
     Map<String, CommitMeta> metaCache,
-    String? selectedOid,
+    ListSelection<String> selection,
     RefSnapshot refs,
     String effectiveEmail,
   ) {
+    // The rendered order, as oids. Every selection transition is expressed
+    // against this rather than against `visibleRows` (snapshot indices), so
+    // a range never silently spans rows a filter is hiding.
+    final List<String> visibleOids = <String>[
+      for (final int index in visibleRows)
+        if (index < graph.oidsHex.length) graph.oidsHex[index],
+    ];
+
     return LayoutBuilder(
       builder: (context, constraints) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) _requestVisibleMeta(constraints.maxHeight);
         });
-        return ListView.builder(
-          controller: _controller,
-          itemExtent: kCommitRowHeight,
-          itemCount: visibleRows.length,
-          itemBuilder: (context, position) {
-            // `position` walks the filtered result list; `index` is the row's
-            // real place in the unfiltered snapshot, which is what selection
-            // and the graph edge lookups are keyed on.
-            final int index = visibleRows[position];
-            final GraphRow row = graph.rows[index];
-            final String oid = index < graph.oidsHex.length
-                ? graph.oidsHex[index]
-                : '';
-            final CommitMeta? meta = metaCache[oid];
-            return CommitRow(
-              row: row,
-              oidHex: oid,
-              graph: graph,
-              rowIndex: index,
-              maxLane: graph.laneCount,
-              meta: meta,
-              showGraph: query.isEmpty,
-              selected: oid.isNotEmpty && oid == selectedOid,
-              refChips: oid.isEmpty
-                  ? const <RefChipData>[]
-                  : refChipsForCommit(refs, oid),
-              isOwnCommit:
-                  meta != null &&
-                  effectiveEmail.isNotEmpty &&
-                  meta.author.email == effectiveEmail,
-              onTap: oid.isEmpty ? null : () => _selectSingle(oid),
-              onCheckout: oid.isEmpty
-                  ? null
-                  : () => ref
-                        .read(repoSessionProvider(widget.identity).notifier)
-                        .checkout(target: oid, detach: true),
-              onCherryPick: oid.isEmpty
-                  ? null
-                  : () => ref
-                        .read(repoSessionProvider(widget.identity).notifier)
-                        .cherryPick([oid]),
-              onRevert: oid.isEmpty
-                  ? null
-                  : () => ref
-                        .read(repoSessionProvider(widget.identity).notifier)
-                        .revert([oid]),
-              onCreateBranchHere: oid.isEmpty
-                  ? null
-                  : () => _createBranchFromCommit(
-                      context,
-                      ref,
-                      widget.identity,
-                      oid,
-                    ),
-            );
-          },
+        return _SelectionShortcuts(
+          focusNode: _listFocus,
+          onSelectAll: () =>
+              _publish(_selectionController.state.selectAll(visibleOids)),
+          onCollapse: () =>
+              _publish(_selectionController.state.collapseToAnchor()),
+          onExtend: (int delta) => _extendSelection(delta, visibleOids),
+          child: ListView.builder(
+            controller: _controller,
+            itemExtent: kCommitRowHeight,
+            itemCount: visibleRows.length,
+            itemBuilder: (context, position) {
+              // `position` walks the filtered result list; `index` is the
+              // row's real place in the unfiltered snapshot, which is what
+              // the graph edge lookups are keyed on.
+              final int index = visibleRows[position];
+              final GraphRow row = graph.rows[index];
+              final String oid = index < graph.oidsHex.length
+                  ? graph.oidsHex[index]
+                  : '';
+              final CommitMeta? meta = metaCache[oid];
+              return CommitRow(
+                row: row,
+                oidHex: oid,
+                graph: graph,
+                rowIndex: index,
+                maxLane: graph.laneCount,
+                meta: meta,
+                showGraph: query.isEmpty,
+                selected: oid.isNotEmpty && selection.contains(oid),
+                refChips: oid.isEmpty
+                    ? const <RefChipData>[]
+                    : refChipsForCommit(refs, oid),
+                isOwnCommit:
+                    meta != null &&
+                    effectiveEmail.isNotEmpty &&
+                    meta.author.email == effectiveEmail,
+                onSelect: oid.isEmpty
+                    ? null
+                    : (SelectionGesture gesture) =>
+                          _onRowSelect(oid, gesture, visibleOids),
+                onContextMenuRequested: oid.isEmpty
+                    ? null
+                    : () => _normaliseSelectionForMenu(oid),
+                onCheckout: oid.isEmpty
+                    ? null
+                    : () => ref
+                          .read(repoSessionProvider(widget.identity).notifier)
+                          .checkout(target: oid, detach: true),
+                onCherryPick: oid.isEmpty
+                    ? null
+                    : () => ref
+                          .read(repoSessionProvider(widget.identity).notifier)
+                          .cherryPick(<String>[oid]),
+                onRevert: oid.isEmpty
+                    ? null
+                    : () => ref
+                          .read(repoSessionProvider(widget.identity).notifier)
+                          .revert(<String>[oid]),
+                onCreateBranchHere: oid.isEmpty
+                    ? null
+                    : () => _createBranchFromCommit(
+                        context,
+                        ref,
+                        widget.identity,
+                        oid,
+                      ),
+              );
+            },
+          ),
         );
       },
     );
@@ -377,6 +477,82 @@ class _CommitSearchField extends StatelessWidget {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+/// Keyboard half of spec page 13's `MULTIKEYS`, scoped to the commit list.
+///
+/// **Deliberately not registered app-wide.** Ctrl/Cmd+A is also every text
+/// field's "select all text", so binding it in `WorkspaceActionShortcuts`
+/// would steal it from the commit summary box and the history filter. Living
+/// here means it only fires while focus is inside the list -- a row's own
+/// `InkWell` takes focus when tapped, which puts the focus chain through
+/// this widget, so no explicit focus plumbing is needed.
+///
+/// [GbmSelectAllIntent] rather than Flutter's `SelectAllTextIntent` for the
+/// same reason `workspace_screen.dart`'s handler offers it first: a list and
+/// an editor need the same key to mean two different things, and focus is
+/// what tells them apart.
+class _SelectionShortcuts extends StatelessWidget {
+  const _SelectionShortcuts({
+    required this.focusNode,
+    required this.onSelectAll,
+    required this.onCollapse,
+    required this.onExtend,
+    required this.child,
+  });
+
+  final FocusNode focusNode;
+  final VoidCallback onSelectAll;
+  final VoidCallback onCollapse;
+  final ValueChanged<int> onExtend;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // Shortcuts/Actions sit **above** [focusNode], not below it. A key event
+    // dispatches to the primary focus and then walks its *ancestors*, so a
+    // Shortcuts nested inside the focused node would never see anything.
+    return Shortcuts(
+      shortcuts: <ShortcutActivator, Intent>{
+        const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
+            const GbmExtendSelectionIntent(-1),
+        const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
+            const GbmExtendSelectionIntent(1),
+        // Both modifiers are registered rather than branching on platform:
+        // an unheld modifier simply never matches, and this keeps the list
+        // working under a remote/VM session where the platform reported and
+        // the keyboard actually attached disagree.
+        const SingleActivator(LogicalKeyboardKey.keyA, meta: true):
+            const GbmSelectAllIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyA, control: true):
+            const GbmSelectAllIntent(),
+        const SingleActivator(LogicalKeyboardKey.escape): const DismissIntent(),
+      },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          GbmExtendSelectionIntent: CallbackAction<GbmExtendSelectionIntent>(
+            onInvoke: (GbmExtendSelectionIntent intent) {
+              onExtend(intent.delta);
+              return null;
+            },
+          ),
+          GbmSelectAllIntent: CallbackAction<GbmSelectAllIntent>(
+            onInvoke: (GbmSelectAllIntent intent) {
+              onSelectAll();
+              return null;
+            },
+          ),
+          DismissIntent: CallbackAction<DismissIntent>(
+            onInvoke: (DismissIntent intent) {
+              onCollapse();
+              return null;
+            },
+          ),
+        },
+        child: Focus(focusNode: focusNode, child: child),
       ),
     );
   }

--- a/app_flutter/lib/features/history_graph/commit_graph_view.dart
+++ b/app_flutter/lib/features/history_graph/commit_graph_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/models/commit_meta.dart';
 import '../../data/models/graph_snapshot.dart';
+import '../../data/models/list_selection.dart';
 import '../../data/models/ref_snapshot.dart';
 import '../../data/repositories/branch_repository.dart';
 import '../../data/repositories/history_repository.dart';
@@ -122,6 +123,20 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
     ref
         .read(repoSessionProvider(identity).notifier)
         .createBranch(name: name, startPoint: commitOid);
+  }
+
+  /// MULTIKEYS' `單擊` row: select only this commit and move the anchor to
+  /// it. Written through [commitSelectionProvider] rather than to
+  /// `selectedCommitProvider`, which is now that selection's anchor read
+  /// back out (see its doc comment) and no longer independently writable.
+  void _selectSingle(String oid) {
+    final StateController<ListSelection<String>> selection = ref.read(
+      commitSelectionProvider(widget.identity).notifier,
+    );
+    selection.state = selection.state.single(oid);
+    ref.read(selectedCommitFilePathProvider(widget.identity).notifier).state =
+        null;
+    requestCommitFiles(ref, widget.identity, oid);
   }
 
   @override
@@ -246,27 +261,7 @@ class _CommitGraphViewState extends ConsumerState<CommitGraphView> {
                   meta != null &&
                   effectiveEmail.isNotEmpty &&
                   meta.author.email == effectiveEmail,
-              onTap: oid.isEmpty
-                  ? null
-                  : () {
-                      ref
-                              .read(
-                                selectedCommitProvider(
-                                  widget.identity,
-                                ).notifier,
-                              )
-                              .state =
-                          oid;
-                      ref
-                              .read(
-                                selectedCommitFilePathProvider(
-                                  widget.identity,
-                                ).notifier,
-                              )
-                              .state =
-                          null;
-                      requestCommitFiles(ref, widget.identity, oid);
-                    },
+              onTap: oid.isEmpty ? null : () => _selectSingle(oid),
               onCheckout: oid.isEmpty
                   ? null
                   : () => ref

--- a/app_flutter/lib/features/history_graph/commit_selection_summary.dart
+++ b/app_flutter/lib/features/history_graph/commit_selection_summary.dart
@@ -1,0 +1,37 @@
+import '../../data/models/list_selection.dart';
+
+/// Spec page 13's History status-bar summary for a commit multi-selection.
+///
+/// P13's 「對既有頁面的連帶修改」 list says of P2 History: 「狀態列改為顯示
+/// selection 摘要（數量、是否連續、合計 diff）」, and its 多選的共通規則 block
+/// repeats the middle one as a hard rule — 「狀態列一律寫出是否連續」 — because
+/// contiguity is exactly what gates cherry-pick / revert in `MULTIACTS`. A
+/// user looking at three greyed-out menu items needs somewhere that says why.
+///
+/// **Reduced deliberately: no 合計 diff.** The spec's own mock reads
+/// `4 commits · 連續 · 9 files changed · +311 −54`, but `ChangedFile` carries
+/// no added/removed line counts, and the only path in the core that runs
+/// `--numstat` is `CompareOps.cpp`'s range diff — so a running total would
+/// mean firing a range diff on every selection change. Absent rather than
+/// faked, same convention as `MULTIACTS`' `Squash`.
+///
+/// Returns null below two items rather than `1 commit · contiguous`: a single
+/// commit has nothing to be contiguous *with*, so the phrase would be filler,
+/// and the status bar's usual repo status (branch, ahead/behind, commit
+/// count) is the more useful thing to keep in that space. 「單選是多選的特例」
+/// governs the selection *model*, which [ListSelection] already honours; it
+/// does not require the summary to narrate a selection of one.
+///
+/// [allOids] is the **unfiltered** snapshot order, not the rendered rows —
+/// the same list `commit_graph_view.dart` judges contiguity against, so a
+/// filtered view cannot report three commits as a replayable run when the
+/// snapshot has others between them.
+String? commitSelectionSummary({
+  required ListSelection<String> selection,
+  required List<String> allOids,
+}) {
+  if (selection.length < 2) return null;
+  final bool contiguous = selection.isContiguousIn(allOids);
+  return '${selection.length} commits · '
+      '${contiguous ? 'contiguous' : 'not contiguous'}';
+}

--- a/app_flutter/lib/features/history_graph/widgets/commit_menu_items.dart
+++ b/app_flutter/lib/features/history_graph/widgets/commit_menu_items.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/gbm_menu.dart';
+
+/// Reason strings for the items spec page 13 keeps visible but disabled.
+///
+/// Spec writes these tooltips in Chinese because the spec itself is; the app
+/// ships English labels throughout, so these are the same rules in the UI's
+/// own language rather than a mixed-language menu.
+const String kSingleCommitOnlyTooltip = 'Only works on a single commit';
+const String kContiguousOnlyTooltip = 'Selection must be contiguous commits';
+const String kTwoCommitsAtMostTooltip = 'Compare takes one or two commits';
+const String kConflictActiveTooltip =
+    'Finish or abort the operation in progress first';
+
+/// `ctxItemsFor('commit')` from gbm_context_menus.dart's 05-E (Commit) --
+/// 7 top-level items, no danger at top level, one "More actions" submenu.
+///
+/// One pure function shared by both render sites (a plain right-click on a
+/// [CommitRow], and the multi-select-aware path in `commit_graph_view.dart`),
+/// following the template 05-D/F/G/H/I/J already use: the parity test can
+/// then assert exact label equality against the catalog instead of pumping a
+/// widget and matching prefixes.
+///
+/// **Counts, not just enablement.** With more than one commit selected the
+/// labels spell out how many they will act on, exactly as 05-F does for
+/// files ("Stage 3 files") -- spec page 13: 「任何一次動作的按鈕與選單文字都
+/// 會寫出實際數量」.
+///
+/// **Nothing is hidden.** Spec is explicit that a single-commit-only action
+/// stays visible and disabled with a tooltip rather than disappearing
+/// (「保留但 disabled，並附 tooltip 說明原因，不隱藏 — 隱藏會讓人以為功能不
+/// 存在」). Every disabled item therefore sets `enabled: false` **and**
+/// `onTap: null`: `enabled` alone is only a visual signal (see
+/// [GbmMenuItem]'s doc comment), and `onTap: null` alone would leave a
+/// full-brightness row that silently does nothing.
+///
+/// [contiguous] gates cherry-pick and revert per `MULTIACTS`: 「commit 多選只
+/// 在連續範圍時開放 cherry-pick / revert / squash；不連續時這三項 disabled」.
+/// Squash has no capi behind it anywhere in this app, so it is absent rather
+/// than faked. The caller computes contiguity against the **unfiltered**
+/// snapshot, so a range picked under a filter correctly reads as gappy.
+///
+/// [conflictActive] applies spec page 07's STATES rule to the items that
+/// move HEAD or start a second sequencer operation. The read-only items
+/// (Compare, Copy SHA, Export as patch) stay live -- nothing about a
+/// conflict makes reading history unsafe.
+List<GbmMenuItem> commitMenuItems({
+  required int count,
+  required bool contiguous,
+  required bool conflictActive,
+  required VoidCallback onCopySha,
+  VoidCallback? onCheckout,
+  VoidCallback? onMerge,
+  VoidCallback? onCherryPick,
+  VoidCallback? onCreateBranchHere,
+  VoidCallback? onCompare,
+  VoidCallback? onRebaseOntoHere,
+  VoidCallback? onResetBranchHere,
+  VoidCallback? onRevert,
+  VoidCallback? onExportAsPatch,
+  VoidCallback? onCompareWithWorkingCopy,
+}) {
+  final bool multiple = count > 1;
+
+  /// Builds one item from a callback plus the reasons it might be off.
+  /// [blockedReason] null means "nothing blocks this"; non-null both
+  /// disables and explains.
+  GbmMenuItem item(
+    String label,
+    IconData icon,
+    VoidCallback? onTap,
+    String? blockedReason,
+  ) {
+    final bool enabled = onTap != null && blockedReason == null;
+    return GbmMenuItem(
+      label: label,
+      icon: icon,
+      enabled: enabled,
+      tooltip: onTap == null ? null : blockedReason,
+      onTap: enabled ? onTap : null,
+    );
+  }
+
+  String? singleOnly() => multiple ? kSingleCommitOnlyTooltip : null;
+  String? conflictOrSingle() =>
+      conflictActive ? kConflictActiveTooltip : singleOnly();
+  String? conflictOrGappy() => conflictActive
+      ? kConflictActiveTooltip
+      : (multiple && !contiguous ? kContiguousOnlyTooltip : null);
+
+  return <GbmMenuItem>[
+    item(
+      'Checkout this commit',
+      Icons.call_split,
+      onCheckout,
+      conflictOrSingle(),
+    ),
+    item('Merge into current', Icons.call_merge, onMerge, conflictOrSingle()),
+    item(
+      multiple ? 'Cherry-pick $count commits' : 'Cherry-pick',
+      Icons.content_paste_go,
+      onCherryPick,
+      conflictOrGappy(),
+    ),
+    // MULTIACTS lists Create branch alongside Reset here / Create tag as
+    // needing a single target commit, regardless of contiguity.
+    item(
+      'Create branch here…',
+      Icons.add,
+      onCreateBranchHere,
+      conflictOrSingle(),
+    ),
+    item(
+      'Compare with…',
+      Icons.compare_arrows,
+      onCompare,
+      // One commit opens a Compare tab with the ref picker on the right;
+      // two fills both sides directly (COMPARES 3). Three or more has no
+      // meaning -- a comparison has exactly two ends.
+      count > 2 ? kTwoCommitsAtMostTooltip : null,
+    ),
+    item(
+      multiple ? 'Copy $count SHAs' : 'Copy SHA',
+      Icons.copy,
+      onCopySha,
+      null,
+    ),
+    GbmMenuItem.submenu(
+      label: 'More actions',
+      icon: Icons.more_horiz,
+      children: <GbmMenuItem>[
+        item(
+          'Rebase onto here',
+          Icons.merge_type,
+          onRebaseOntoHere,
+          conflictOrSingle(),
+        ),
+        item(
+          'Reset branch to here…',
+          Icons.restore,
+          onResetBranchHere,
+          conflictOrSingle(),
+        ),
+        item(
+          multiple ? 'Revert $count commits' : 'Revert commit',
+          Icons.undo,
+          onRevert,
+          conflictOrGappy(),
+        ),
+        // gbm_patch_export takes a list of commits, so a multi-selection
+        // exports one patch file per commit in one call -- no contiguity
+        // requirement, unlike replaying them.
+        item(
+          multiple ? 'Export $count patches…' : 'Export as patch…',
+          Icons.description_outlined,
+          onExportAsPatch,
+          null,
+        ),
+        item(
+          'Compare with working copy',
+          Icons.difference_outlined,
+          onCompareWithWorkingCopy,
+          singleOnly(),
+        ),
+      ],
+    ),
+  ];
+}

--- a/app_flutter/lib/features/history_graph/widgets/commit_row.dart
+++ b/app_flutter/lib/features/history_graph/widgets/commit_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../../actions/gbm_selection_gesture.dart';
 import '../../../data/models/commit_meta.dart';
 import '../../../data/models/graph_snapshot.dart';
 import '../../../theme/gbm_theme.dart';
@@ -35,6 +36,8 @@ class CommitRow extends StatelessWidget {
     this.meta,
     this.selected = false,
     this.onTap,
+    this.onSelect,
+    this.onContextMenuRequested,
     this.refChips = const <RefChipData>[],
     this.isOwnCommit = false,
     this.showGraph = true,
@@ -57,6 +60,26 @@ class CommitRow extends StatelessWidget {
   final CommitMeta? meta;
   final bool selected;
   final VoidCallback? onTap;
+
+  /// Reports the spec page 13 gesture a click carried (plain / Ctrl-Cmd /
+  /// Shift), leaving the selection arithmetic to the caller, which is the
+  /// only side that knows the list this row sits in.
+  ///
+  /// When null, [onTap] is used unchanged -- the pre-multi-select behaviour,
+  /// which the parity and row tests still drive.
+  final void Function(SelectionGesture gesture)? onSelect;
+
+  /// Called on right-click **before** the menu is built, so the caller can
+  /// make the selection match what the menu is about to act on.
+  ///
+  /// Spec page 13: 「右鍵點在已選中的項目上不改變 selection…；點在未選中的
+  /// 項目上先改為只選它、再開選單，避免對看不見的選取做動作」 -- right-
+  /// clicking an already-selected row leaves the selection alone, while
+  /// right-clicking an unselected one collapses to just that row first, so
+  /// no action is ever aimed at a selection the user cannot see. Only the
+  /// caller knows the selection, so the rule lives there; this is the hook
+  /// that lets it run first.
+  final VoidCallback? onContextMenuRequested;
 
   /// Chip render data for this commit (from `graph_ref_chips.dart`'s
   /// `refChipsForCommit`, already carrying the local/origin merge rule),
@@ -109,7 +132,9 @@ class CommitRow extends StatelessWidget {
         child: GbmRow(
           height: kCommitRowHeight,
           selected: selected,
-          onTap: onTap,
+          onTap: onSelect == null
+              ? onTap
+              : () => onSelect!(currentSelectionGesture()),
           padding: EdgeInsets.zero,
           child: Row(
             children: <Widget>[
@@ -263,6 +288,7 @@ class CommitRow extends StatelessWidget {
   }
 
   void _openContextMenu(BuildContext context, TapDownDetails details) {
+    onContextMenuRequested?.call();
     showGbmContextMenu(context, details.globalPosition, _buildMenuItems());
   }
 }

--- a/app_flutter/lib/features/history_graph/widgets/commit_row.dart
+++ b/app_flutter/lib/features/history_graph/widgets/commit_row.dart
@@ -9,6 +9,7 @@ import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_menu.dart';
 import '../../../widgets/gbm_row.dart';
 import '../../../widgets/gbm_tag_chip.dart';
+import 'commit_menu_items.dart';
 import 'graph_column_painter.dart';
 import 'graph_date_format.dart';
 import 'graph_ref_chips.dart';
@@ -45,6 +46,17 @@ class CommitRow extends StatelessWidget {
     this.onCherryPick,
     this.onRevert,
     this.onCreateBranchHere,
+    this.onMerge,
+    this.onCompare,
+    this.onRebaseOntoHere,
+    this.onResetBranchHere,
+    this.onExportAsPatch,
+    this.onCompareWithWorkingCopy,
+    this.menuSelectionCount = 1,
+    this.menuSelectionIsContiguous = true,
+    this.conflictActive = false,
+    this.menuTitle,
+    this.onCopySha,
   });
 
   final GraphRow row;
@@ -101,12 +113,40 @@ class CommitRow extends StatelessWidget {
   /// to omit the graph rather than draw one that lies.
   final bool showGraph;
 
-  /// Right-click context menu callbacks for 05-E commit menu. Null when no
-  /// backing capability exists for that action at this row level.
+  /// Right-click context menu callbacks for the 05-E commit menu. Null when
+  /// the caller has no destination to offer for that action.
   final VoidCallback? onCheckout;
   final VoidCallback? onCherryPick;
   final VoidCallback? onRevert;
   final VoidCallback? onCreateBranchHere;
+  final VoidCallback? onMerge;
+  final VoidCallback? onCompare;
+  final VoidCallback? onRebaseOntoHere;
+  final VoidCallback? onResetBranchHere;
+  final VoidCallback? onExportAsPatch;
+  final VoidCallback? onCompareWithWorkingCopy;
+
+  /// How many commits the menu is about to act on, and whether they form an
+  /// unbroken run -- see [commitMenuItems], which turns them into counted
+  /// labels and MULTIACTS' contiguity gate. Both default to the
+  /// single-selection case, so a caller with no multi-select (the parity
+  /// test, any future one-row surface) gets exactly the spec's singular
+  /// menu with nothing disabled.
+  final int menuSelectionCount;
+  final bool menuSelectionIsContiguous;
+
+  /// Spec page 07's STATES rule: mid-sequencer, the HEAD-moving items are
+  /// disabled. Passed in rather than re-derived here, matching how
+  /// `BranchTreeItem` and `TabRow` take the same flag.
+  final bool conflictActive;
+
+  /// Header naming the selection size, per spec page 13's
+  /// 「選單標題顯示數量」. Null for a single row, which needs no header.
+  final String? menuTitle;
+
+  /// Overrides the default "copy this row's oid" -- a multi-selection copies
+  /// every selected SHA, one per line, which only the caller can assemble.
+  final VoidCallback? onCopySha;
 
   @override
   Widget build(BuildContext context) {
@@ -251,45 +291,35 @@ class CommitRow extends StatelessWidget {
     );
   }
 
-  /// 05-E (commit row) context menu items. Includes only items with a real
-  /// backing capability: checkout (detached), cherry-pick, copy SHA, revert,
-  /// create branch. Omits merge-into-current (mergeBranch takes branch names,
-  /// not oids), compare items (M6), rebase/reset (destructive, not wired).
-  List<GbmMenuItem> _buildMenuItems() {
-    return <GbmMenuItem>[
-      if (onCheckout != null)
-        GbmMenuItem(
-          label: 'Checkout this commit',
-          icon: Icons.call_split,
-          onTap: onCheckout!,
-        ),
-      if (onCherryPick != null)
-        GbmMenuItem(
-          label: 'Cherry-pick',
-          icon: Icons.copy,
-          onTap: onCherryPick!,
-        ),
-      if (onCreateBranchHere != null)
-        GbmMenuItem(
-          label: 'Create branch here…',
-          icon: Icons.add,
-          onTap: onCreateBranchHere!,
-        ),
-      GbmMenuItem(
-        label: 'Copy SHA',
-        icon: Icons.copy,
-        onTap: () => Clipboard.setData(ClipboardData(text: oidHex)),
-      ),
-      if (onRevert != null) ...<GbmMenuItem>[
-        const GbmMenuItem.separator(),
-        GbmMenuItem(label: 'Revert commit', icon: Icons.undo, onTap: onRevert!),
-      ],
-    ];
-  }
+  /// The full 05-E menu, built from the shared [commitMenuItems] catalog
+  /// function rather than a hand-written list -- see its doc comment for
+  /// what "disabled with a tooltip" and the counted labels mean.
+  List<GbmMenuItem> _buildMenuItems() => commitMenuItems(
+    count: menuSelectionCount,
+    contiguous: menuSelectionIsContiguous,
+    conflictActive: conflictActive,
+    onCopySha:
+        onCopySha ?? () => Clipboard.setData(ClipboardData(text: oidHex)),
+    onCheckout: onCheckout,
+    onMerge: onMerge,
+    onCherryPick: onCherryPick,
+    onCreateBranchHere: onCreateBranchHere,
+    onCompare: onCompare,
+    onRebaseOntoHere: onRebaseOntoHere,
+    onResetBranchHere: onResetBranchHere,
+    onRevert: onRevert,
+    onExportAsPatch: onExportAsPatch,
+    onCompareWithWorkingCopy: onCompareWithWorkingCopy,
+  );
 
   void _openContextMenu(BuildContext context, TapDownDetails details) {
     onContextMenuRequested?.call();
-    showGbmContextMenu(context, details.globalPosition, _buildMenuItems());
+    showGbmContextMenu(
+      context,
+      details.globalPosition,
+      _buildMenuItems(),
+      title: menuTitle,
+    );
   }
 }
 

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -11,6 +11,9 @@ import '../../data/models/stash_entry.dart';
 import '../../data/repositories/branch_repository.dart';
 import '../../data/repositories/compare_tabs_repository.dart';
 import '../../data/repositories/repo_identity.dart';
+import '../../actions/gbm_selection_gesture.dart';
+import '../../data/models/list_selection.dart';
+import '../../data/repositories/branch_selection_repository.dart';
 import '../../data/repositories/repo_session_repository.dart';
 import '../../routing/route_paths.dart';
 import '../../theme/gbm_theme.dart';
@@ -21,6 +24,7 @@ import '../repo_switcher/repo_switcher_popover.dart';
 import 'branch_tree_builder.dart';
 import 'widgets/branch_folder_menu_items.dart';
 import 'widgets/branch_tree_item.dart';
+import 'widgets/multi_branch_menu_items.dart';
 import 'widgets/stash_menu_items.dart';
 
 /// Local branches for the open repository, with checkout-on-tap, plus
@@ -65,7 +69,15 @@ class SidebarPanel extends ConsumerStatefulWidget {
 }
 
 class _SidebarPanelState extends ConsumerState<SidebarPanel> {
-  final Set<String> _selected = <String>{};
+  /// Reads through to [branchSelectionProvider] -- the selection lives in a
+  /// provider, not here, so `WorkspaceScreen` and the row that was
+  /// right-clicked can both see it. Ticking a checkbox and Ctrl/Cmd-clicking
+  /// a row write the same value; see the provider's doc comment.
+  ListSelection<String> get _selection =>
+      ref.read(branchSelectionProvider(widget.identity));
+
+  StateController<ListSelection<String>> get _selectionController =>
+      ref.read(branchSelectionProvider(widget.identity).notifier);
   final Set<String> _expandedFolders = <String>{};
   final TextEditingController _filterController = TextEditingController();
   String _filterQuery = '';
@@ -73,17 +85,84 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
   @override
   void dispose() {
     _filterController.dispose();
+    _treeFocus.dispose();
     super.dispose();
+  }
+
+  /// The branch tree's own focus node, so `MULTIKEYS`' keyboard half is
+  /// scoped to the tree rather than the whole sidebar -- the filter
+  /// `TextField` above it must keep Ctrl/Cmd+A as "select all text".
+  final FocusNode _treeFocus = FocusNode(debugLabel: 'SidebarBranchTree');
+
+  /// `MULTIKEYS`' Ctrl/Cmd+A over the rows as currently rendered, so a
+  /// filtered tree selects what the user can actually see.
+  void _selectAllBranches() {
+    final List<String> all = _selectableBranchNames();
+    if (all.isEmpty) return;
+    _treeFocus.requestFocus();
+    _selectionController.state = _selection.selectAll(all);
+  }
+
+  /// `MULTIKEYS`' Esc: collapse to the anchor rather than clearing, so the
+  /// row the user started from stays selected.
+  void _collapseSelection() =>
+      _selectionController.state = _selection.collapseToAnchor();
+
+  /// `MULTIKEYS`' Shift+↑/↓. The edge that moves is the one *opposite* the
+  /// anchor, which is what makes Shift+↑ after Shift+↓ shrink the range
+  /// back instead of growing it the other way.
+  void _extendBranchSelection(int delta) {
+    final List<String> all = _selectableBranchNames();
+    final ListSelection<String> current = _selection;
+    final String? anchor = current.anchor;
+    if (all.isEmpty || anchor == null) return;
+    final int anchorIndex = all.indexOf(anchor);
+    if (anchorIndex < 0) return;
+    final List<int> indices = <int>[
+      for (final String name in current.items)
+        if (all.contains(name)) all.indexOf(name),
+    ]..sort();
+    if (indices.isEmpty) return;
+    final int movingEdge = indices.first == anchorIndex
+        ? indices.last
+        : indices.first;
+    final int next = (movingEdge + delta).clamp(0, all.length - 1);
+    _selectionController.state = current.range(all[next], all);
   }
 
   bool _isBulkSelectable(RefInfo branch) => !branch.isHead;
 
+  /// Whether right-clicking [branch] should open `MULTIBRANCHMENU` rather
+  /// than the per-row 05-B menu: it must be a bulk-selectable local row that
+  /// is *already* part of a selection of more than one.
+  bool _isInMultiSelection(RefInfo branch, {required bool isRemoteOnly}) =>
+      !isRemoteOnly &&
+      _isBulkSelectable(branch) &&
+      _selection.length > 1 &&
+      _selection.items.contains(branch.shortName);
+
   bool _isGoneAndBulkSelectable(RefInfo branch) =>
       branch.isGone && !branch.isHead && branch.worktreePath.isEmpty;
 
+  /// Drops selected names that no longer exist (a branch was deleted or
+  /// renamed under the selection).
   void _pruneSelection(List<RefInfo> branches) {
     final Set<String> names = branches.map((b) => b.shortName).toSet();
-    _selected.removeWhere((name) => !names.contains(name));
+    final ListSelection<String> current = _selection;
+    final List<String> survivors = <String>[
+      for (final String name in current.items)
+        if (names.contains(name)) name,
+    ];
+    if (survivors.length == current.length) return;
+    final String? anchor = current.anchor;
+    _selectionController.state = ListSelection<String>(
+      items: survivors,
+      anchor: survivors.isEmpty
+          ? null
+          : (anchor != null && names.contains(anchor)
+                ? anchor
+                : survivors.last),
+    );
   }
 
   Future<void> _createBranch() async {
@@ -125,6 +204,212 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
         branch: branch.shortName,
       ),
     );
+  }
+
+  /// Ctrl/Cmd-click and Shift-click on a branch row. A plain click is
+  /// deliberately not routed here -- see [BranchTreeItem.onSelect].
+  ///
+  /// A Shift range is measured over [_selectableBranchNames], the rows as
+  /// rendered (filter applied, HEAD and remote-only rows excluded), so the
+  /// range never quietly picks up a branch the user cannot see or act on.
+  void _onBranchSelect(String name, SelectionGesture gesture) {
+    // Focus first: a row's InkWell is focusable for traversal but a tap does
+    // not request focus, and without focus inside the tree the keyboard half
+    // of MULTIKEYS (Shift+↑/↓, Ctrl/Cmd+A, Esc) never reaches
+    // [_BranchSelectionShortcuts].
+    _treeFocus.requestFocus();
+    final List<String> all = _selectableBranchNames();
+    final ListSelection<String> current = _selection;
+    _selectionController.state = switch (gesture) {
+      SelectionGesture.single => current.single(name),
+      SelectionGesture.toggle => current.toggle(name),
+      SelectionGesture.range => current.range(name, all),
+    };
+  }
+
+  /// The rows a range can span: the merged tree as currently filtered,
+  /// minus HEAD and remote-only rows (neither is bulk-selectable).
+  List<String> _selectableBranchNames() {
+    final RefSnapshot refs = ref.read(repoRefsProvider(widget.identity));
+    final List<RefInfo> visible = filterBranches(
+      mergeLocalAndRemoteBranches(refs.localBranches, refs.remoteBranches),
+      _filterQuery,
+    );
+    return <String>[
+      for (final RefInfo b in visible)
+        if (_isBulkSelectable(b) && b.kind != RefKind.remoteBranch) b.shortName,
+    ];
+  }
+
+  /// Spec page 13's `MULTIBRANCHMENU`, opened by right-clicking any row
+  /// while more than one branch is selected. Right-clicking a row that is
+  /// *not* in the selection collapses to it first and gets the ordinary
+  /// 05-B menu instead -- see [_onBranchContextMenu].
+  List<GbmMenuItem> _multiBranchMenuItems(RepoSessionState session) {
+    final List<String> names = _selection.items;
+    return multiBranchMenuItems(
+      count: names.length,
+      conflictActive: !isActionEnabled(GbmActionId.branchDeleteBranch, session),
+      onCopyNames: () =>
+          Clipboard.setData(ClipboardData(text: names.join('\n'))),
+      onFetch: _fetchSelectedBranches,
+      onPush: _pushSelectedBranches,
+      fetchBlockedReason: _fetchBlockedReason(),
+      pushBlockedReason: _pushBlockedReason(),
+      onCompare: names.length == 2 ? _compareSelectedBranches : null,
+      onDelete: _deleteSelected,
+    );
+  }
+
+  /// The selected branches that still exist in the ref snapshot, as
+  /// [RefInfo] rather than bare names -- Fetch and Push both need each
+  /// branch's `upstream` to work out which remote it belongs to.
+  List<RefInfo> _selectedBranchRefs() {
+    final RefSnapshot refs = ref.read(repoRefsProvider(widget.identity));
+    final Set<String> names = _selection.items.toSet();
+    return <RefInfo>[
+      for (final RefInfo b in refs.localBranches)
+        if (names.contains(b.shortName)) b,
+    ];
+  }
+
+  /// Groups [branches] by the remote their upstream lives on.
+  ///
+  /// `RefInfo.upstream` is the **full** ref name (`%(upstream)`, e.g.
+  /// `refs/remotes/origin/main`), so the remote comes from
+  /// [remoteBranchParts] -- never from splitting on the first slash, which
+  /// yields `"refs"` and is the live bug #74 records in
+  /// `delete_branch_dialog.dart`. `upstream.isEmpty` is the "no upstream"
+  /// test, **not** `hasTrackingInfo`: the latter mirrors
+  /// `%(upstream:track)`, which is an empty string for a branch exactly in
+  /// sync with its upstream (the Tier 0c trap).
+  Map<String, List<RefInfo>> _groupByUpstreamRemote(List<RefInfo> branches) {
+    final Map<String, List<RefInfo>> byRemote = <String, List<RefInfo>>{};
+    for (final RefInfo b in branches) {
+      if (b.upstream.isEmpty) continue;
+      final (String remote, String _) = remoteBranchParts(b.upstream);
+      if (remote.isEmpty) continue;
+      byRemote.putIfAbsent(remote, () => <RefInfo>[]).add(b);
+    }
+    return byRemote;
+  }
+
+  /// MULTIBRANCHMENU's `Fetch N branches`.
+  ///
+  /// Spec page 13 says nothing about which remote a multi-branch fetch
+  /// targets, so the rule here is the only one that needs no guessing: a
+  /// branch is fetched through the remote its own upstream names. One
+  /// `gbm_remote_fetch` call per distinct remote, each carrying that
+  /// remote's refspecs -- `gbm_capi.h` rejects a non-empty `refs` with an
+  /// empty `remoteName`, so a single batched call is not available, and a
+  /// selection spanning two remotes is genuinely two fetches.
+  ///
+  /// A branch with no upstream has no remote-tracking ref to update and is
+  /// skipped; when *none* of the selection has one, the menu row is
+  /// disabled with [_fetchBlockedReason] rather than silently doing nothing.
+  void _fetchSelectedBranches() {
+    final Map<String, List<RefInfo>> byRemote = _groupByUpstreamRemote(
+      _selectedBranchRefs(),
+    );
+    final RepoSessionController session = ref.read(
+      repoSessionProvider(widget.identity).notifier,
+    );
+    byRemote.forEach((String remote, List<RefInfo> branches) {
+      session.fetchRemote(
+        remoteName: remote,
+        refs: <String>[
+          for (final RefInfo b in branches) remoteBranchParts(b.upstream).$2,
+        ],
+      );
+    });
+  }
+
+  /// MULTIBRANCHMENU's `Push N branches`.
+  ///
+  /// Published branches go to the remote their upstream names, one
+  /// `gbm_push` per remote -- and because `gbm_push` now takes a branch
+  /// list, that is one `git push <remote> a b c` per remote rather than one
+  /// per branch, which is what keeps a same-remote batch a single
+  /// background task (spec page 10).
+  ///
+  /// Unpublished branches (spec's `local` badge state, "還沒 push 過…Push
+  /// 後 badge 自動消失") are the case Push exists for, but they name no
+  /// remote. They are pushed to the repository's sole remote with
+  /// `--set-upstream` when there is exactly one; with several remotes there
+  /// is nothing to infer from, so they are excluded and the row explains
+  /// that via [_pushBlockedReason]. They are also kept in their own call
+  /// rather than folded into a same-remote published group: `push -u` would
+  /// otherwise repoint a branch that tracks a differently-named upstream.
+  void _pushSelectedBranches() {
+    final List<RefInfo> selected = _selectedBranchRefs();
+    final Map<String, List<RefInfo>> byRemote = _groupByUpstreamRemote(
+      selected,
+    );
+    final List<RefInfo> unpublished = <RefInfo>[
+      for (final RefInfo b in selected)
+        if (b.upstream.isEmpty) b,
+    ];
+    final RepoSessionController session = ref.read(
+      repoSessionProvider(widget.identity).notifier,
+    );
+    byRemote.forEach((String remote, List<RefInfo> branches) {
+      session.pushChanges(
+        remoteName: remote,
+        branches: <String>[for (final RefInfo b in branches) b.shortName],
+      );
+    });
+    final String? sole = _soleRemoteName();
+    if (unpublished.isNotEmpty && sole != null) {
+      session.pushChanges(
+        remoteName: sole,
+        branches: <String>[for (final RefInfo b in unpublished) b.shortName],
+        setUpstream: true,
+      );
+    }
+  }
+
+  /// The repository's only remote, or null when it has none or several.
+  String? _soleRemoteName() {
+    final List<RemoteInfo> remotes = ref
+        .read(repoSessionProvider(widget.identity))
+        .remotes;
+    return remotes.length == 1 ? remotes.single.name : null;
+  }
+
+  /// Why `Fetch N branches` is off, or null when it is available.
+  String? _fetchBlockedReason() =>
+      _groupByUpstreamRemote(_selectedBranchRefs()).isEmpty
+      ? 'None of the selected branches has an upstream to fetch from'
+      : null;
+
+  /// Why `Push N branches` is off, or null when it is available. See
+  /// [_pushSelectedBranches] for why an unpublished branch needs a sole
+  /// remote.
+  String? _pushBlockedReason() {
+    final List<RefInfo> selected = _selectedBranchRefs();
+    final bool anyPublished = _groupByUpstreamRemote(selected).isNotEmpty;
+    final bool anyUnpublished = selected.any((RefInfo b) => b.upstream.isEmpty);
+    if (anyUnpublished && _soleRemoteName() == null) {
+      return anyPublished
+          ? 'Some selected branches have no upstream, and this repository '
+                'has no single remote to push them to'
+          : 'The selected branches have no upstream, and this repository '
+                'has no single remote to push them to';
+    }
+    return anyPublished || anyUnpublished ? null : 'Nothing to push';
+  }
+
+  /// COMPARES 1: 「同時選兩個分支 → 右鍵 Compare」. Both sides are known, so
+  /// unlike 05-B's single-branch "Compare with…" this fills the tab
+  /// outright instead of leaving the right to the ref picker.
+  void _compareSelectedBranches() {
+    final List<String> names = _selection.items;
+    if (names.length != 2) return;
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
+    final String tabId = ref
+        .read(compareTabsProvider(widget.identity).notifier)
+        .open(left: names.first, right: names.last);
+    context.go(RoutePaths.compareFor(repoId, tabId));
   }
 
   void _deleteSingle(RefInfo branch) {
@@ -353,12 +638,14 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     );
   }
 
+  /// Spec page 13 requires a batch delete to be confirmed item by item
+  /// (「逐項列出名稱與未 push 的 commit 數」), not fired straight off the
+  /// action bar as this used to do.
   void _deleteSelected() {
-    if (_selected.isEmpty) return;
-    ref
-        .read(repoSessionProvider(widget.identity).notifier)
-        .deleteBranch(names: _selected.toList(growable: false));
-    setState(_selected.clear);
+    final List<String> names = _selection.items;
+    if (names.isEmpty) return;
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
+    context.push(RoutePaths.deleteBranchesDialogFor(repoId, names: names));
   }
 
   /// 05-C "Checkout as new local…" / double-tap on a remote-only row --
@@ -432,6 +719,9 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     final RefSnapshot refs = ref.watch(repoRefsProvider(widget.identity));
     final RepoSessionState session = ref.watch(
       repoSessionProvider(widget.identity),
+    );
+    final ListSelection<String> selection = ref.watch(
+      branchSelectionProvider(widget.identity),
     );
     final GbmColors colors = context.gbmColors;
     final List<RefInfo> branches = mergeLocalAndRemoteBranches(
@@ -516,15 +806,11 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
                       minHeight: 28,
                     ),
                     onPressed: anyGoneSelectable
-                        ? () => setState(() {
-                            _selected
-                              ..clear()
-                              ..addAll(
-                                filteredBranches
-                                    .where(_isGoneAndBulkSelectable)
-                                    .map((b) => b.shortName),
-                              );
-                          })
+                        ? () => _selectionController.state =
+                              const ListSelection<String>().selectAll(<String>[
+                                for (final RefInfo b in filteredBranches)
+                                  if (_isGoneAndBulkSelectable(b)) b.shortName,
+                              ])
                         : null,
                   ),
                 ),
@@ -623,7 +909,7 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
             ),
           ),
           // Selection action bar
-          if (_selected.isNotEmpty)
+          if (selection.isNotEmpty)
             Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: GbmSpacing.space3,
@@ -633,7 +919,7 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
                 children: <Widget>[
                   Expanded(
                     child: Text(
-                      '${_selected.length} selected',
+                      '${selection.length} selected',
                       style: TextStyle(
                         fontSize: GbmTypography.textXs,
                         color: colors.textSecondary,
@@ -641,7 +927,8 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
                     ),
                   ),
                   TextButton(
-                    onPressed: () => setState(_selected.clear),
+                    onPressed: () => _selectionController.state =
+                        const ListSelection<String>(),
                     child: Text(
                       'Clear',
                       style: TextStyle(
@@ -688,91 +975,99 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
                       ),
                     ),
                   )
-                : SingleChildScrollView(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        _buildTreeNodes(branchTree, context),
-                        if (filteredTags.isNotEmpty) ...<Widget>[
-                          Padding(
-                            padding: const EdgeInsets.fromLTRB(
-                              GbmSpacing.space3,
-                              GbmSpacing.space2,
-                              GbmSpacing.space1,
-                              GbmSpacing.space1,
-                            ),
-                            child: Text(
-                              'TAGS',
-                              style: TextStyle(
-                                fontSize: GbmTypography.textXs,
-                                fontWeight: GbmTypography.weightSemibold,
-                                color: colors.textTertiary,
-                                letterSpacing: 0.5,
+                : _BranchSelectionShortcuts(
+                    focusNode: _treeFocus,
+                    onSelectAll: _selectAllBranches,
+                    onCollapse: _collapseSelection,
+                    onExtend: _extendBranchSelection,
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          _buildTreeNodes(branchTree, context),
+                          if (filteredTags.isNotEmpty) ...<Widget>[
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(
+                                GbmSpacing.space3,
+                                GbmSpacing.space2,
+                                GbmSpacing.space1,
+                                GbmSpacing.space1,
                               ),
-                            ),
-                          ),
-                          ...filteredTags.map((tag) {
-                            return Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: GbmSpacing.space1,
-                              ),
-                              child: BranchTreeItem(
-                                ref: tag,
-                                onCheckout: () => _checkoutTagDetached(tag),
-                                onPushTag: session.remotes.length == 1
-                                    ? () =>
-                                          _pushTag(tag, session.remotes.single)
-                                    : null,
-                                onCompareRef: () => _compareTag(tag),
-                                onDeleteTag: () => _deleteTag(tag),
-                                // Sourced from isActionEnabled(), not
-                                // session.conflictActive directly -- single
-                                // source of truth for checkout availability.
-                                conflictActive: !isActionEnabled(
-                                  GbmActionId.branchCheckout,
-                                  session,
+                              child: Text(
+                                'TAGS',
+                                style: TextStyle(
+                                  fontSize: GbmTypography.textXs,
+                                  fontWeight: GbmTypography.weightSemibold,
+                                  color: colors.textTertiary,
+                                  letterSpacing: 0.5,
                                 ),
                               ),
-                            );
-                          }),
-                        ],
-                        if (filteredStashes.isNotEmpty) ...<Widget>[
-                          Padding(
-                            padding: const EdgeInsets.fromLTRB(
-                              GbmSpacing.space3,
-                              GbmSpacing.space2,
-                              GbmSpacing.space1,
-                              GbmSpacing.space1,
                             ),
-                            child: Text(
-                              'STASH',
-                              style: TextStyle(
-                                fontSize: GbmTypography.textXs,
-                                fontWeight: GbmTypography.weightSemibold,
-                                color: colors.textTertiary,
-                                letterSpacing: 0.5,
+                            ...filteredTags.map((tag) {
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: GbmSpacing.space1,
+                                ),
+                                child: BranchTreeItem(
+                                  ref: tag,
+                                  onCheckout: () => _checkoutTagDetached(tag),
+                                  onPushTag: session.remotes.length == 1
+                                      ? () => _pushTag(
+                                          tag,
+                                          session.remotes.single,
+                                        )
+                                      : null,
+                                  onCompareRef: () => _compareTag(tag),
+                                  onDeleteTag: () => _deleteTag(tag),
+                                  // Sourced from isActionEnabled(), not
+                                  // session.conflictActive directly -- single
+                                  // source of truth for checkout availability.
+                                  conflictActive: !isActionEnabled(
+                                    GbmActionId.branchCheckout,
+                                    session,
+                                  ),
+                                ),
+                              );
+                            }),
+                          ],
+                          if (filteredStashes.isNotEmpty) ...<Widget>[
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(
+                                GbmSpacing.space3,
+                                GbmSpacing.space2,
+                                GbmSpacing.space1,
+                                GbmSpacing.space1,
+                              ),
+                              child: Text(
+                                'STASH',
+                                style: TextStyle(
+                                  fontSize: GbmTypography.textXs,
+                                  fontWeight: GbmTypography.weightSemibold,
+                                  color: colors.textTertiary,
+                                  letterSpacing: 0.5,
+                                ),
                               ),
                             ),
-                          ),
-                          ...filteredStashes.map((stash) {
-                            return _buildStashRow(
-                              stash,
-                              colors,
-                              // Sourced from isActionEnabled(), not
-                              // session.conflictActive directly -- same
-                              // pattern as every other conflict-sensitive
-                              // gate in this file. branchStashChanges is
-                              // the closest existing id (stash apply/pop
-                              // mutate the working tree/index the same way
-                              // creating a stash would).
-                              !isActionEnabled(
-                                GbmActionId.branchStashChanges,
-                                session,
-                              ),
-                            );
-                          }),
+                            ...filteredStashes.map((stash) {
+                              return _buildStashRow(
+                                stash,
+                                colors,
+                                // Sourced from isActionEnabled(), not
+                                // session.conflictActive directly -- same
+                                // pattern as every other conflict-sensitive
+                                // gate in this file. branchStashChanges is
+                                // the closest existing id (stash apply/pop
+                                // mutate the working tree/index the same way
+                                // creating a stash would).
+                                !isActionEnabled(
+                                  GbmActionId.branchStashChanges,
+                                  session,
+                                ),
+                              );
+                            }),
+                          ],
                         ],
-                      ],
+                      ),
                     ),
                   ),
           ),
@@ -803,21 +1098,38 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
               : () => checkoutBranch(ref, widget.identity, node.ref.shortName),
           selected: isRemoteOnly
               ? false
-              : _selected.contains(node.ref.shortName),
+              : _selection.items.contains(node.ref.shortName),
           // None of the local-branch-only actions below apply to a
           // remote-only leaf -- there is no local branch to select for bulk
           // delete, rename, branch-from, or merge.
+          // Ticking the box is exactly a Ctrl/Cmd-click, so both go through
+          // the same transition rather than growing a second selection set.
           onSelectedChanged: isRemoteOnly
               ? null
               : _isBulkSelectable(node.ref)
-              ? (value) => setState(() {
-                  if (value) {
-                    _selected.add(node.ref.shortName);
-                  } else {
-                    _selected.remove(node.ref.shortName);
-                  }
-                })
+              ? (_) => _selectionController.state = _selection.toggle(
+                  node.ref.shortName,
+                )
               : null,
+          onSelect: isRemoteOnly || !_isBulkSelectable(node.ref)
+              ? null
+              : (SelectionGesture gesture) =>
+                    _onBranchSelect(node.ref.shortName, gesture),
+          // Spec page 13's two right-click halves. Only a row that is
+          // itself inside a >1 selection gets MULTIBRANCHMENU; every other
+          // row collapses the selection onto itself first, so the 05-B menu
+          // that opens can never act on branches scrolled out of view.
+          multiSelectMenuBuilder:
+              _isInMultiSelection(node.ref, isRemoteOnly: isRemoteOnly)
+              ? () => _multiBranchMenuItems(session)
+              : null,
+          multiSelectMenuTitle: '${_selection.length} branches selected',
+          onCollapseSelectionToThis:
+              isRemoteOnly || !_isBulkSelectable(node.ref)
+              ? null
+              : () => _selectionController.state = _selection.single(
+                  node.ref.shortName,
+                ),
           onRename: isRemoteOnly ? null : () => _renameBranch(node.ref),
           onDelete: isRemoteOnly || node.ref.isHead
               ? null
@@ -987,6 +1299,74 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Keyboard half of spec page 13's `MULTIKEYS`, scoped to the branch tree.
+///
+/// Deliberately **not** wrapped around the whole sidebar: the filter
+/// `TextField` sits above this subtree, and a `Shortcuts` closer to a
+/// focused editor than `DefaultTextEditingShortcuts` would take Ctrl/Cmd+A
+/// away from "select all text". Same shape and same reasoning as
+/// `commit_graph_view.dart`'s `_SelectionShortcuts`, including the
+/// Shortcuts/Actions-above-Focus ordering: a key event dispatches to the
+/// primary focus and then walks its *ancestors*, so a `Shortcuts` nested
+/// inside the focused node would never see anything.
+class _BranchSelectionShortcuts extends StatelessWidget {
+  const _BranchSelectionShortcuts({
+    required this.focusNode,
+    required this.onSelectAll,
+    required this.onCollapse,
+    required this.onExtend,
+    required this.child,
+  });
+
+  final FocusNode focusNode;
+  final VoidCallback onSelectAll;
+  final VoidCallback onCollapse;
+  final ValueChanged<int> onExtend;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Shortcuts(
+      shortcuts: <ShortcutActivator, Intent>{
+        const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
+            const GbmExtendSelectionIntent(-1),
+        const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
+            const GbmExtendSelectionIntent(1),
+        // Both modifiers registered rather than branching on platform: an
+        // unheld modifier simply never matches.
+        const SingleActivator(LogicalKeyboardKey.keyA, meta: true):
+            const GbmSelectAllIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyA, control: true):
+            const GbmSelectAllIntent(),
+        const SingleActivator(LogicalKeyboardKey.escape): const DismissIntent(),
+      },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          GbmExtendSelectionIntent: CallbackAction<GbmExtendSelectionIntent>(
+            onInvoke: (GbmExtendSelectionIntent intent) {
+              onExtend(intent.delta);
+              return null;
+            },
+          ),
+          GbmSelectAllIntent: CallbackAction<GbmSelectAllIntent>(
+            onInvoke: (GbmSelectAllIntent intent) {
+              onSelectAll();
+              return null;
+            },
+          ),
+          DismissIntent: CallbackAction<DismissIntent>(
+            onInvoke: (DismissIntent intent) {
+              onCollapse();
+              return null;
+            },
+          ),
+        },
+        child: Focus(focusNode: focusNode, child: child),
       ),
     );
   }

--- a/app_flutter/lib/features/sidebar/sidebar_panel.dart
+++ b/app_flutter/lib/features/sidebar/sidebar_panel.dart
@@ -204,6 +204,28 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
     context.go(RoutePaths.compareFor(repoId, tabId));
   }
 
+  // 05-B "Compare with…" -- same `left: <ref string>` mechanism as
+  // _compareTag and _compareStash. A branch name is already a valid ref, so
+  // no per-branch compare dialog is needed; the Compare page's own picker
+  // chooses the right-hand side.
+  void _compareRef(String refName) {
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
+    final String tabId = ref
+        .read(compareTabsProvider(widget.identity).notifier)
+        .open(left: refName);
+    context.go(RoutePaths.compareFor(repoId, tabId));
+  }
+
+  // 05-B "Rebase current onto here" -- the repository-level rebase dialog,
+  // pre-selected on this branch, rather than a second per-branch dialog
+  // that would duplicate its stash-first handling and commit-count preview.
+  void _rebaseOntoBranch(RefInfo branch) {
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
+    context.push(
+      RoutePaths.rebaseOntoDialogFor(repoId, target: branch.shortName),
+    );
+  }
+
   void _deleteTag(RefInfo tag) {
     ref
         .read(repoSessionProvider(widget.identity).notifier)
@@ -813,6 +835,17 @@ class _SidebarPanelState extends ConsumerState<SidebarPanel> {
               ? () => _openDeleteRemoteBranchDialog(node.ref)
               : null,
           onFetchRef: isRemoteOnly ? () => _fetchRemoteRef(node.ref) : null,
+          // 05-B's two previously-missing items. Neither needed a new
+          // dialog: Compare reuses the same open-a-tab-with-this-ref-on-the
+          // -left mechanism _compareTag/_compareStash already use, and
+          // Rebase reuses the repository-level dialog, now pre-fillable via
+          // its `target` query parameter.
+          onCompareRef: isRemoteOnly
+              ? null
+              : () => _compareRef(node.ref.shortName),
+          onRebaseOntoHere: isRemoteOnly || node.ref.isHead
+              ? null
+              : () => _rebaseOntoBranch(node.ref),
           // Sourced from isActionEnabled(), not session.conflictActive
           // directly -- single source of truth for checkout availability.
           conflictActive: !isActionEnabled(GbmActionId.branchCheckout, session),

--- a/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../../actions/gbm_selection_gesture.dart';
 import '../../../data/models/ref_snapshot.dart';
 import '../../../theme/gbm_theme.dart';
 import '../../../theme/ref_chip_colors.dart';
@@ -17,6 +18,10 @@ class BranchTreeItem extends StatelessWidget {
     required this.onCheckout,
     this.selected = false,
     this.onSelectedChanged,
+    this.onSelect,
+    this.multiSelectMenuBuilder,
+    this.multiSelectMenuTitle,
+    this.onCollapseSelectionToThis,
     this.onRename,
     this.onDelete,
     this.onNewBranchFromHere,
@@ -47,6 +52,33 @@ class BranchTreeItem extends StatelessWidget {
   /// Null hides the selection checkbox entirely (HEAD can't be
   /// multi-selected for deletion -- see SidebarPanel's doc comment).
   final ValueChanged<bool>? onSelectedChanged;
+
+  /// Reports a modifier-carrying click for spec page 13's multi-select.
+  ///
+  /// **Only [SelectionGesture.toggle] and [SelectionGesture.range] reach
+  /// here.** A plain click on a local branch row stays what it has always
+  /// been in this app -- a checkout -- rather than becoming "select only
+  /// this". `MULTIKEYS`' 單擊 row is written for lists generally and the
+  /// spec says nothing about the branch tree specifically, so changing the
+  /// sidebar's primary interaction on that basis would be a guess with a
+  /// large blast radius. History's commit list, which had no competing
+  /// single-click meaning, follows `MULTIKEYS` exactly.
+  final void Function(SelectionGesture gesture)? onSelect;
+
+  /// Spec page 13's right-click rule for a multi-selection: 「右鍵點在**已
+  /// 選中**的項目上不改變 selection，選單標題顯示數量；點在**未選中**的項
+  /// 目上先改為只選它、再開選單」.
+  ///
+  /// Both halves live here rather than in the panel because this widget owns
+  /// `onSecondaryTapDown`. [multiSelectMenuBuilder] is non-null only when
+  /// this row is *inside* a selection of more than one -- then it replaces
+  /// the per-row menu wholesale and [multiSelectMenuTitle] becomes the
+  /// menu's header. Otherwise [onCollapseSelectionToThis] runs first, so the
+  /// per-row menu that follows can never act on a selection the user can no
+  /// longer see.
+  final List<GbmMenuItem> Function()? multiSelectMenuBuilder;
+  final String? multiSelectMenuTitle;
+  final VoidCallback? onCollapseSelectionToThis;
   final VoidCallback? onRename;
   final VoidCallback? onDelete;
 
@@ -228,9 +260,15 @@ class BranchTreeItem extends StatelessWidget {
         child: InkWell(
           onTap: _isRemoteOnly
               ? null
-              : (ref.isHead || conflictActive)
-              ? null
-              : onCheckout,
+              : () {
+                  final SelectionGesture gesture = currentSelectionGesture();
+                  if (gesture != SelectionGesture.single && onSelect != null) {
+                    onSelect!(gesture);
+                    return;
+                  }
+                  if (ref.isHead || conflictActive) return;
+                  onCheckout();
+                },
           onDoubleTap: _isRemoteOnly && !conflictActive ? onCheckout : null,
           borderRadius: BorderRadius.circular(GbmSpacing.radiusSm),
           child: maybeDim,
@@ -369,6 +407,17 @@ class BranchTreeItem extends StatelessWidget {
   }
 
   void _openContextMenu(BuildContext context, TapDownDetails details) {
+    final List<GbmMenuItem> Function()? multi = multiSelectMenuBuilder;
+    if (multi != null) {
+      showGbmContextMenu(
+        context,
+        details.globalPosition,
+        multi(),
+        title: multiSelectMenuTitle,
+      );
+      return;
+    }
+    onCollapseSelectionToThis?.call();
     showGbmContextMenu(context, details.globalPosition, _buildMenuItems());
   }
 }

--- a/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
+++ b/app_flutter/lib/features/sidebar/widgets/branch_tree_item.dart
@@ -7,6 +7,7 @@ import '../../../theme/ref_chip_colors.dart';
 import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_menu.dart';
 import '../../../widgets/lucide_icon.dart';
+import 'local_branch_menu_items.dart';
 import 'tag_menu_items.dart';
 
 class BranchTreeItem extends StatelessWidget {
@@ -25,6 +26,7 @@ class BranchTreeItem extends StatelessWidget {
     this.onFetchRef,
     this.onPushTag,
     this.onCompareRef,
+    this.onRebaseOntoHere,
     this.onDeleteTag,
     this.conflictActive = false,
   });
@@ -54,6 +56,12 @@ class BranchTreeItem extends StatelessWidget {
   final VoidCallback? onNewBranchFromHere;
   final VoidCallback? onMerge;
 
+  /// 05-B's "Rebase current onto here" -- replays the current branch on top
+  /// of this one. Opens the shared rebase-onto dialog pre-filled with this
+  /// branch (see RoutePaths.rebaseOntoDialogFor's `target`), rather than a
+  /// new per-branch dialog.
+  final VoidCallback? onRebaseOntoHere;
+
   /// 05-C actions -- see [_buildMenuItems]'s branches on
   /// `ref.kind == RefKind.remoteBranch` and `ref.isGone`. [onPruneRef] is
   /// wired for both a remote-only row and a gone row (pruning the vanished
@@ -72,6 +80,11 @@ class BranchTreeItem extends StatelessWidget {
   /// tag_menu_items.dart's `onPush` doc comment for why (no single
   /// unambiguous remote to push to).
   final VoidCallback? onPushTag;
+
+  /// 05-B's and 05-D's "Compare with…" -- opens a Compare tab with this ref
+  /// on the left, leaving the right side to the Compare page's own ref
+  /// picker. Same mechanism `_compareStash`/`_compareTag` already use; no
+  /// per-branch compare dialog is involved.
   final VoidCallback? onCompareRef;
   final VoidCallback? onDeleteTag;
 
@@ -318,13 +331,10 @@ class BranchTreeItem extends StatelessWidget {
     ];
   }
 
-  /// `ctxItemsFor('branch')` from gbm_context_menus.dart's 05-B (Local
-  /// branch), scoped to what this app already has a real destination for.
-  /// "Rebase current onto here" and "Compare with…" are omitted (no
-  /// per-branch entry point exists yet -- a targeted rebase/compare would
-  /// need the same UI as its repository-level peer, not yet surfaced),
-  /// so they are left off rather than wired to something that silently does
-  /// the wrong thing.
+  /// Dispatches to whichever of the four page-05 groups this row is: 05-D
+  /// for a tag, 05-C for a remote-only row, 05-C's disabled subset for a
+  /// "gone" row, and 05-B for an ordinary local branch (the fall-through,
+  /// built by [localBranchMenuItems]).
   List<GbmMenuItem> _buildMenuItems() {
     if (_isTag) {
       return tagMenuItems(
@@ -344,53 +354,18 @@ class BranchTreeItem extends StatelessWidget {
     if (ref.isGone) {
       return _buildGoneMenuItems();
     }
-    return <GbmMenuItem>[
-      if (!ref.isHead)
-        GbmMenuItem(
-          label: 'Checkout ${ref.shortName}',
-          icon: Icons.call_split,
-          onTap: conflictActive ? null : onCheckout,
-        ),
-      if (onNewBranchFromHere != null)
-        GbmMenuItem(
-          label: 'New branch from here',
-          icon: Icons.add,
-          onTap: onNewBranchFromHere!,
-        ),
-      if (onRename != null)
-        // Spec page 13 keeps rename out of reach mid-sequencer ("分支正在被
-        // rebase / merge 佔用 -> 整個 dialog 不開啟"), and page 07 already
-        // disables every other HEAD-moving action there. Both `enabled` and
-        // `onTap` are set: `enabled` alone is only a visual signal (see
-        // GbmMenuItem's doc comment), `onTap: null` alone would leave a
-        // full-brightness item that silently does nothing.
-        GbmMenuItem(
-          label: 'Rename branch',
-          icon: Icons.edit_outlined,
-          enabled: !conflictActive,
-          onTap: conflictActive ? null : onRename!,
-        ),
-      if (onMerge != null)
-        GbmMenuItem(
-          label: 'Merge into current branch',
-          icon: Icons.call_merge,
-          onTap: onMerge!,
-        ),
-      GbmMenuItem(
-        label: 'Copy branch name',
-        icon: Icons.copy,
-        onTap: () => Clipboard.setData(ClipboardData(text: ref.shortName)),
-      ),
-      if (onDelete != null) ...<GbmMenuItem>[
-        const GbmMenuItem.separator(),
-        GbmMenuItem(
-          label: 'Delete branch',
-          icon: Icons.delete_outline,
-          danger: true,
-          onTap: onDelete!,
-        ),
-      ],
-    ];
+    return localBranchMenuItems(
+      branchName: ref.shortName,
+      isCurrent: ref.isHead,
+      conflictActive: conflictActive,
+      onCheckout: onCheckout,
+      onNewBranchFromHere: onNewBranchFromHere,
+      onRename: onRename,
+      onMerge: onMerge,
+      onRebaseOntoHere: onRebaseOntoHere,
+      onCompare: onCompareRef,
+      onDelete: onDelete,
+    );
   }
 
   void _openContextMenu(BuildContext context, TapDownDetails details) {

--- a/app_flutter/lib/features/sidebar/widgets/local_branch_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/local_branch_menu_items.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../widgets/gbm_menu.dart';
+
+/// Reason strings for items spec keeps visible but disabled. Spec writes
+/// these in Chinese because the spec is; the app ships English labels, so
+/// these are the same rules in the UI's own language.
+const String kAlreadyOnBranchTooltip = 'Already on this branch';
+const String kBranchConflictTooltip =
+    'Finish or abort the operation in progress first';
+const String kSingleBranchOnlyTooltip = 'Only works on a single branch';
+
+/// `ctxItemsFor('branch')` from gbm_context_menus.dart's 05-B (Local
+/// branch) -- 8 top-level items, at the spec's own ceiling, danger last, no
+/// submenu.
+///
+/// Extracted from `branch_tree_item.dart`'s hand-written list, which had
+/// drifted from the catalog in three ways at once: "Rebase current onto
+/// here" and "Compare with…" were missing entirely, and two labels had
+/// wandered ("Rename branch" for "Rename…", "Merge into current branch" for
+/// "Merge into current"). The parity test could not see the wording drift
+/// because it matched on prefixes; against this function it asserts exact
+/// equality, the same way 05-D/F/G/H/I/J already do.
+///
+/// Only the **local-branch** path goes through here. A remote-only row
+/// (05-C), a "gone" row (05-C's disabled subset) and a tag row (05-D) keep
+/// their own builders in `branch_tree_item.dart`, each with its own passing
+/// tests.
+///
+/// Every item stays visible. Spec page 13: 「保留但 disabled，並附 tooltip 說
+/// 明原因，不隱藏 — 隱藏會讓人以為功能不存在」. Disabled items therefore set
+/// `enabled: false` **and** `onTap: null` -- `enabled` alone is only a
+/// visual signal (see [GbmMenuItem]'s doc comment).
+///
+/// [conflictActive] applies spec page 07's STATES rule. All six actions
+/// that move HEAD, start a sequencer operation, or rewrite a ref are gated:
+/// checkout, new-branch-from-here, rename, merge, rebase and delete.
+/// Compare and Copy are read-only and stay live. Before this extraction
+/// only Checkout and Rename were gated here, leaving New branch / Merge /
+/// Delete live mid-conflict against spec.
+///
+/// [isCurrent] disables Checkout with its own reason: you cannot check out
+/// the branch you are already on. It used to be omitted outright, which
+/// made the menu one item shorter than the catalog on the HEAD row.
+List<GbmMenuItem> localBranchMenuItems({
+  required String branchName,
+  required bool isCurrent,
+  required bool conflictActive,
+  VoidCallback? onCheckout,
+  VoidCallback? onNewBranchFromHere,
+  VoidCallback? onRename,
+  VoidCallback? onMerge,
+  VoidCallback? onRebaseOntoHere,
+  VoidCallback? onCompare,
+  VoidCallback? onDelete,
+}) {
+  GbmMenuItem item(
+    String label,
+    IconData icon,
+    VoidCallback? onTap,
+    String? blockedReason, {
+    bool danger = false,
+  }) {
+    final bool enabled = onTap != null && blockedReason == null;
+    return GbmMenuItem(
+      label: label,
+      icon: icon,
+      danger: danger,
+      enabled: enabled,
+      tooltip: onTap == null ? null : blockedReason,
+      onTap: enabled ? onTap : null,
+    );
+  }
+
+  String? conflict() => conflictActive ? kBranchConflictTooltip : null;
+
+  return <GbmMenuItem>[
+    item(
+      'Checkout',
+      Icons.call_split,
+      onCheckout,
+      isCurrent ? kAlreadyOnBranchTooltip : conflict(),
+    ),
+    item('New branch from here…', Icons.add, onNewBranchFromHere, conflict()),
+    item('Rename…', Icons.edit_outlined, onRename, conflict()),
+    item('Merge into current', Icons.call_merge, onMerge, conflict()),
+    item(
+      'Rebase current onto here',
+      Icons.merge_type,
+      onRebaseOntoHere,
+      conflict(),
+    ),
+    item('Compare with…', Icons.compare_arrows, onCompare, null),
+    GbmMenuItem(
+      label: 'Copy branch name',
+      icon: Icons.copy,
+      onTap: () => Clipboard.setData(ClipboardData(text: branchName)),
+    ),
+    const GbmMenuItem.separator(),
+    item(
+      'Delete branch…',
+      Icons.delete_outline,
+      onDelete,
+      conflict(),
+      danger: true,
+    ),
+  ];
+}

--- a/app_flutter/lib/features/sidebar/widgets/multi_branch_menu_items.dart
+++ b/app_flutter/lib/features/sidebar/widgets/multi_branch_menu_items.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/gbm_menu.dart';
+import 'local_branch_menu_items.dart';
+
+/// Spec page 13's `MULTIBRANCHMENU`: what a right-click offers when more
+/// than one branch is selected.
+///
+/// The spec's own mock lists seven rows for a three-branch selection —
+/// Fetch, Push, Checkout, Rename…, Set upstream…, Copy branch names and
+/// `Delete 3 branches…` — with the middle three struck through as 單項
+/// (single-item-only). `MULTIACTS` gives the rule behind that split:
+/// Delete and Push/Fetch are 支援, while Rename / Checkout / Set upstream
+/// are 「disabled — 單項專屬，tooltip：「只能對單一分支執行」」.
+///
+/// Kept and disabled, never hidden — same rule and the same
+/// `enabled: false` **plus** `onTap: null` pairing as
+/// [localBranchMenuItems].
+///
+/// `Set upstream…` has no backing entry point anywhere in this app (no capi
+/// call, no dialog), so it renders permanently disabled here rather than
+/// being omitted: it is one of the three items the spec explicitly wants
+/// visible-but-off for a multi-selection, and hiding it would read as "this
+/// feature does not exist" — which for a single branch would be misleading
+/// once it does.
+///
+/// [count] is what the counted labels report, matching spec's own mock
+/// ("Delete 3 branches…") and 05-F's counted file labels.
+///
+/// [conflictActive] applies spec page 07 to the two live verbs: a batch
+/// delete rewrites refs and a push moves remote-tracking refs, neither of
+/// which should run mid-sequencer.
+///
+/// [fetchBlockedReason] / [pushBlockedReason] carry the caller's own reason
+/// for an unavailable Fetch/Push, because spec's rule is that a disabled row
+/// must say *why*. A plain `null` callback with no reason would render the
+/// row grey and mute, which is the failure mode the 不隱藏 rule exists to
+/// prevent. The remote-resolution rules that produce these strings are the
+/// caller's business — spec page 13 says nothing about how a multi-branch
+/// Fetch/Push picks its remote, so `sidebar_panel.dart` owns that decision
+/// and documents it there.
+List<GbmMenuItem> multiBranchMenuItems({
+  required int count,
+  required bool conflictActive,
+  required VoidCallback onCopyNames,
+  VoidCallback? onFetch,
+  VoidCallback? onPush,
+  String? fetchBlockedReason,
+  String? pushBlockedReason,
+  VoidCallback? onCompare,
+  VoidCallback? onDelete,
+}) {
+  GbmMenuItem item(
+    String label,
+    IconData icon,
+    VoidCallback? onTap,
+    String? blockedReason, {
+    bool danger = false,
+  }) {
+    final bool enabled = onTap != null && blockedReason == null;
+    return GbmMenuItem(
+      label: label,
+      icon: icon,
+      danger: danger,
+      enabled: enabled,
+      tooltip: blockedReason,
+      onTap: enabled ? onTap : null,
+    );
+  }
+
+  String? conflict() => conflictActive ? kBranchConflictTooltip : null;
+
+  return <GbmMenuItem>[
+    item(
+      'Fetch $count branches',
+      Icons.cloud_download_outlined,
+      onFetch,
+      fetchBlockedReason,
+    ),
+    item(
+      'Push $count branches',
+      Icons.cloud_upload_outlined,
+      onPush,
+      conflict() ?? pushBlockedReason,
+    ),
+    item('Checkout', Icons.call_split, null, kSingleBranchOnlyTooltip),
+    item('Rename…', Icons.edit_outlined, null, kSingleBranchOnlyTooltip),
+    item('Set upstream…', Icons.link, null, kSingleBranchOnlyTooltip),
+    // Not in MULTIBRANCHMENU's mock, but COMPARES 1's entry is literally
+    // 「同時選兩個分支 → 右鍵 Compare」, so the two-branch case needs a way
+    // to reach it. Disabled with a reason for any other count, since a
+    // comparison has exactly two ends.
+    item(
+      'Compare',
+      Icons.compare_arrows,
+      onCompare,
+      count == 2 ? null : 'Compare takes exactly two branches',
+    ),
+    GbmMenuItem(
+      label: 'Copy branch names',
+      icon: Icons.copy,
+      onTap: onCopyNames,
+    ),
+    const GbmMenuItem.separator(),
+    item(
+      'Delete $count branches…',
+      Icons.delete_outline,
+      onDelete,
+      conflict(),
+      danger: true,
+    ),
+  ];
+}

--- a/app_flutter/lib/features/status_bar/status_bar.dart
+++ b/app_flutter/lib/features/status_bar/status_bar.dart
@@ -39,6 +39,7 @@ class StatusBar extends StatefulWidget {
     this.repoState,
     this.workingCopyStatus,
     this.conflictActive = false,
+    this.selectionSummary,
   });
 
   final String currentBranch;
@@ -54,6 +55,19 @@ class StatusBar extends StatefulWidget {
   final model.RepoState? repoState;
   final WorkingCopyStatus? workingCopyStatus;
   final bool conflictActive;
+
+  /// Spec page 13's selection summary (「狀態列改為顯示 selection 摘要」),
+  /// already formatted by whoever owns the selected list — this widget stays
+  /// presentational and does not know what a commit or a branch is.
+  ///
+  /// Null both when nothing is multi-selected and when the selected list is
+  /// not the visible one: only [WorkspaceScreen] knows which tab is showing,
+  /// so it decides, rather than this widget guessing from a route.
+  ///
+  /// Loses to [conflictActive]: a conflict takes zone 1 outright. A stopped
+  /// sequencer is the one thing that must be readable at a glance, and a
+  /// selection is recoverable information (the rows are still highlighted).
+  final String? selectionSummary;
 
   @override
   State<StatusBar> createState() => _StatusBarState();
@@ -212,6 +226,24 @@ class _StatusBarState extends State<StatusBar> {
                             color: colors.textTertiary,
                           ),
                         ),
+                        if (widget.selectionSummary case final summary?) ...[
+                          const SizedBox(width: GbmSpacing.space2),
+                          Text(
+                            '·',
+                            style: TextStyle(
+                              fontSize: GbmTypography.textXs,
+                              color: colors.borderDefault,
+                            ),
+                          ),
+                          const SizedBox(width: GbmSpacing.space2),
+                          Text(
+                            summary,
+                            style: TextStyle(
+                              fontSize: GbmTypography.textXs,
+                              color: colors.textSecondary,
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ),

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -28,6 +28,7 @@ import '../../theme/tokens.dart';
 import '../../widgets/gbm_banner.dart';
 import '../../widgets/split_pane.dart';
 import '../history_graph/commit_search.dart';
+import '../history_graph/commit_selection_summary.dart';
 import '../history_graph/widgets/graph_columns_selector.dart';
 import '../log_drawer/log_drawer.dart';
 import '../repo_switcher/repo_switcher_popover.dart';
@@ -363,6 +364,27 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
               repoState: session.repoState,
               workingCopyStatus: session.workingCopyStatus,
               conflictActive: session.conflictActive,
+              // Spec page 13 puts the commit selection summary in the status
+              // bar, and the History tab is the only place that selection is
+              // visible -- showing "4 commits · contiguous" while the user is
+              // looking at Working Copy or a Compare tab would describe rows
+              // that are off screen. StatusBar is presentational and has no
+              // route awareness, so the tab test lives here.
+              //
+              // Plain equality against History's own route, the same primitive
+              // activeWorkspaceTabIndex() uses -- deliberately *without* its
+              // "no tab matched, fall back to History" clause, which exists to
+              // keep a tab highlighted while a dialog is pushed on top. Here
+              // that fallback would claim History is showing whenever any
+              // dialog is open, including one pushed from Working Copy.
+              selectionSummary:
+                  GoRouterState.of(context).uri.toString() ==
+                      RoutePaths.historyFor(repoId)
+                  ? commitSelectionSummary(
+                      selection: ref.watch(commitSelectionProvider(identity)),
+                      allOids: session.graph.oidsHex,
+                    )
+                  : null,
               onOpenLog: () {
                 setState(() {
                   _lastSeenOperationLogIndex = session.operationLog.length;

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../../actions/gbm_action_availability.dart';
 import '../../actions/gbm_action_id.dart';
 import '../../actions/gbm_menu_model.dart';
+import '../../actions/gbm_selection_gesture.dart';
 import '../../actions/gbm_sequencer_operation.dart';
 import '../../data/models/ref_snapshot.dart';
 import '../../data/models/repo_state.dart';
@@ -521,6 +522,7 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
       GbmActionId.editPaste: () => _invokeTextIntent(
         const PasteTextIntent(SelectionChangedCause.keyboard),
       ),
+      GbmActionId.editSelectAll: _invokeSelectAll,
       // Both searches live on the History view: commit search filters the
       // commit list, and "find in files" is the same field scoped to paths.
       // Navigating there first means the shortcut works from Working Copy
@@ -828,6 +830,29 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
   /// widget, which is how Edit → Undo/Redo/Cut/Copy/Paste reach whichever
   /// field has focus. Silently does nothing when no editable widget is
   /// focused -- the correct outcome for "Copy" with nothing selected.
+  /// Ctrl/Cmd+A has to mean two different things depending on what has
+  /// focus: "select every row" over a list (spec page 13's `MULTIKEYS`) and
+  /// "select all text" inside an editor. Focus is the only thing that can
+  /// tell them apart, so this offers the list intent first and falls back
+  /// to the text one when nothing consumed it.
+  ///
+  /// The handler-map entry is deliberately **non-null**. All three dispatch
+  /// paths read this one map (see CLAUDE.md's Intent / Action layer), and a
+  /// null here would grey the macOS menu item out and make the keyboard
+  /// path a no-op while leaving the in-window menu working -- the exact
+  /// split `workspace_intent_dispatch_parity_test.dart` exists to catch.
+  void _invokeSelectAll() {
+    final BuildContext? focused = primaryFocus?.context;
+    if (focused == null) return;
+    if (Actions.maybeInvoke(focused, const GbmSelectAllIntent()) != null) {
+      return;
+    }
+    Actions.maybeInvoke(
+      focused,
+      const SelectAllTextIntent(SelectionChangedCause.keyboard),
+    );
+  }
+
   void _invokeTextIntent(Intent intent) {
     final BuildContext? focused = primaryFocus?.context;
     if (focused == null) return;

--- a/app_flutter/lib/routing/app_router.dart
+++ b/app_flutter/lib/routing/app_router.dart
@@ -168,7 +168,11 @@ final Provider<GoRouter> appRouterProvider = Provider<GoRouter>((ref) {
           final RepoIdentity identity = repoIdentityFromRouteParam(
             state.pathParameters['repoId']!,
           );
-          return ResetBranchDialogContent(identity: identity);
+          final String target = state.uri.queryParameters['target'] ?? '';
+          return ResetBranchDialogContent(
+            identity: identity,
+            target: target.isEmpty ? null : target,
+          );
         },
       ),
       dialogRoute(
@@ -434,7 +438,11 @@ final Provider<GoRouter> appRouterProvider = Provider<GoRouter>((ref) {
           final RepoIdentity identity = repoIdentityFromRouteParam(
             state.pathParameters['repoId']!,
           );
-          return RebaseOntoDialogContent(identity: identity);
+          final String target = state.uri.queryParameters['target'] ?? '';
+          return RebaseOntoDialogContent(
+            identity: identity,
+            target: target.isEmpty ? null : target,
+          );
         },
       ),
       dialogRoute(

--- a/app_flutter/lib/routing/app_router.dart
+++ b/app_flutter/lib/routing/app_router.dart
@@ -15,6 +15,7 @@ import '../features/dialogs/clean_untracked/clean_untracked_dialog.dart';
 import '../features/dialogs/create_tag/create_tag_dialog.dart';
 import '../features/dialogs/credential/credential_dialog.dart';
 import '../features/dialogs/delete_branch/delete_branch_dialog.dart';
+import '../features/dialogs/delete_branches/delete_branches_dialog.dart';
 import '../features/dialogs/delete_branch_recovery/delete_branch_recovery_dialog.dart';
 import '../features/dialogs/delete_remote_branch/delete_remote_branch_dialog.dart';
 import '../features/dialogs/discard_changes/discard_changes_dialog.dart';
@@ -452,6 +453,19 @@ final Provider<GoRouter> appRouterProvider = Provider<GoRouter>((ref) {
             state.pathParameters['repoId']!,
           );
           return ForcePushDialogContent(identity: identity);
+        },
+      ),
+      dialogRoute(
+        path: RoutePaths.deleteBranchesDialog,
+        builder: (context, state) {
+          final RepoIdentity identity = repoIdentityFromRouteParam(
+            state.pathParameters['repoId']!,
+          );
+          final String names = state.uri.queryParameters['names'] ?? '';
+          return DeleteBranchesDialogContent(
+            identity: identity,
+            names: names.isEmpty ? const <String>[] : names.split(','),
+          );
         },
       ),
       dialogRoute(

--- a/app_flutter/lib/routing/route_paths.dart
+++ b/app_flutter/lib/routing/route_paths.dart
@@ -96,8 +96,19 @@ abstract final class RoutePaths {
   static String workspaceFor(String repoId) => historyFor(repoId);
   static String historyFor(String repoId) => '/repo/$repoId/history';
   static String workingCopyFor(String repoId) => '/repo/$repoId/working-copy';
-  static String resetBranchDialogFor(String repoId) =>
-      '/repo/$repoId/dialogs/reset-branch';
+
+  /// [target] pre-fills the "Reset to" field -- 05-E's "Reset branch to
+  /// here…" passes the right-clicked commit's oid. Same query-parameter
+  /// shape as [renameBranchDialogFor]; empty means "no pre-fill", and the
+  /// dialog keeps its own default (the current branch).
+  static String resetBranchDialogFor(String repoId, {String target = ''}) =>
+      Uri(
+        path: '/repo/$repoId/dialogs/reset-branch',
+        queryParameters: target.isEmpty
+            ? null
+            : <String, String>{'target': target},
+      ).toString();
+
   static String mergeDialogFor(String repoId) => '/repo/$repoId/dialogs/merge';
   static String cherryPickDialogFor(String repoId) =>
       '/repo/$repoId/dialogs/cherry-pick';
@@ -190,8 +201,15 @@ abstract final class RoutePaths {
             ? null
             : <String, String>{'branch': branch},
       ).toString();
-  static String rebaseOntoDialogFor(String repoId) =>
-      '/repo/$repoId/dialogs/rebase-onto';
+
+  /// [target] pre-selects what to rebase onto -- 05-B's "Rebase current
+  /// onto here" passes a branch name, 05-E's "Rebase onto here" a commit
+  /// oid. See [resetBranchDialogFor] for the shared shape.
+  static String rebaseOntoDialogFor(String repoId, {String target = ''}) => Uri(
+    path: '/repo/$repoId/dialogs/rebase-onto',
+    queryParameters: target.isEmpty ? null : <String, String>{'target': target},
+  ).toString();
+
   static String forcePushDialogFor(String repoId) =>
       '/repo/$repoId/dialogs/force-push';
   static String deleteRemoteBranchDialogFor(

--- a/app_flutter/lib/routing/route_paths.dart
+++ b/app_flutter/lib/routing/route_paths.dart
@@ -74,6 +74,12 @@ abstract final class RoutePaths {
       '/repo/:repoId/dialogs/rename-branch';
   static const String rebaseOntoDialog = '/repo/:repoId/dialogs/rebase-onto';
   static const String forcePushDialog = '/repo/:repoId/dialogs/force-push';
+
+  /// Multi-branch delete confirmation (spec page 13). Separate from
+  /// [deleteBranchDialog], which is 05-B's single-branch flow with its own
+  /// branch picker.
+  static const String deleteBranchesDialog =
+      '/repo/:repoId/dialogs/delete-branches';
   static const String deleteRemoteBranchDialog =
       '/repo/:repoId/dialogs/delete-remote-branch';
   static const String restoreFileDialog = '/repo/:repoId/dialogs/restore-file';
@@ -194,6 +200,19 @@ abstract final class RoutePaths {
             ? null
             : <String, String>{'branch': branch},
       ).toString();
+
+  /// [names] is carried as one comma-separated `names` parameter; a branch
+  /// name cannot contain a comma (git refuses it), so the split is safe.
+  static String deleteBranchesDialogFor(
+    String repoId, {
+    required List<String> names,
+  }) => Uri(
+    path: '/repo/$repoId/dialogs/delete-branches',
+    queryParameters: names.isEmpty
+        ? null
+        : <String, String>{'names': names.join(',')},
+  ).toString();
+
   static String deleteBranchDialogFor(String repoId, {String branch = ''}) =>
       Uri(
         path: '/repo/$repoId/dialogs/delete-branch',

--- a/app_flutter/lib/widgets/gbm_menu.dart
+++ b/app_flutter/lib/widgets/gbm_menu.dart
@@ -41,6 +41,7 @@ class GbmMenuItem {
     this.shortcut,
     this.danger = false,
     this.enabled = true,
+    this.tooltip,
     required this.onTap,
     this.children = const <GbmMenuItem>[],
   }) : separator = false,
@@ -52,6 +53,7 @@ class GbmMenuItem {
       shortcut = null,
       danger = false,
       enabled = true,
+      tooltip = null,
       onTap = null,
       separator = true,
       children = const <GbmMenuItem>[],
@@ -66,6 +68,7 @@ class GbmMenuItem {
       shortcut = null,
       danger = false,
       enabled = true,
+      tooltip = null,
       onTap = null {
     assert(_noNestedSubmenus(children));
   }
@@ -84,6 +87,14 @@ class GbmMenuItem {
   final String? shortcut;
   final bool danger;
   final bool enabled;
+
+  /// Hover text explaining *why* an item is in the state it is in -- spec
+  /// page 13's multi-select rule is explicit that a single-item-only action
+  /// stays visible but disabled "並附 tooltip 說明原因，不隱藏" (kept with a
+  /// tooltip giving the reason, not hidden), because hiding it reads as
+  /// "this feature does not exist". Null means no tooltip.
+  final String? tooltip;
+
   final bool separator;
   final bool _isSubmenuTrigger;
   final VoidCallback? onTap;
@@ -139,6 +150,7 @@ Future<void> showGbmMenu(
   BuildContext context, {
   required RelativeRect position,
   required List<GbmMenuItem> items,
+  String? title,
 }) {
   return showMenu<void>(
     context: context,
@@ -152,7 +164,7 @@ Future<void> showGbmMenu(
       PopupMenuItem<void>(
         enabled: false,
         padding: EdgeInsets.zero,
-        child: _GbmMenuPanel(items: items),
+        child: _GbmMenuPanel(items: items, title: title),
       ),
     ],
   );
@@ -167,8 +179,9 @@ Future<void> showGbmMenu(
 Future<void> showGbmContextMenu(
   BuildContext context,
   Offset globalPosition,
-  List<GbmMenuItem> items,
-) {
+  List<GbmMenuItem> items, {
+  String? title,
+}) {
   validateGbmMenuItems(items);
   final RenderBox overlay =
       Overlay.of(context).context.findRenderObject()! as RenderBox;
@@ -176,13 +189,22 @@ Future<void> showGbmContextMenu(
     Rect.fromPoints(globalPosition, globalPosition),
     Offset.zero & overlay.size,
   );
-  return showGbmMenu(context, position: position, items: items);
+  return showGbmMenu(context, position: position, items: items, title: title);
 }
 
 class _GbmMenuPanel extends StatelessWidget {
-  const _GbmMenuPanel({required this.items});
+  const _GbmMenuPanel({required this.items, this.title});
 
   final List<GbmMenuItem> items;
+
+  /// Optional non-interactive header. Spec page 13 requires a multi-select
+  /// context menu to name how many items it is about to act on ("選單標題
+  /// 顯示數量"), so a right-click on a selection of three commits opens a
+  /// menu headed "3 items" rather than looking identical to a single-row
+  /// menu. It is a label, never a row: it takes no hover, no tap, and is
+  /// deliberately not counted by [validateGbmMenuItems]'s 8-item cap, which
+  /// is spec page 05's limit on *actions*.
+  final String? title;
 
   @override
   Widget build(BuildContext context) {
@@ -198,7 +220,26 @@ class _GbmMenuPanel extends StatelessWidget {
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
+          if (title case final String header) ...<Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(10, 6, 10, 4),
+              child: Text(
+                header,
+                style: TextStyle(
+                  fontSize: GbmTypography.textXs,
+                  fontWeight: GbmTypography.weightSemibold,
+                  color: colors.textTertiary,
+                ),
+              ),
+            ),
+            Container(
+              height: 1,
+              margin: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              color: colors.borderSubtle,
+            ),
+          ],
           for (final GbmMenuItem item in items)
             item.separator
                 ? Container(
@@ -271,6 +312,7 @@ class _GbmMenuRowState extends State<_GbmMenuRow> {
               shortcut: child.shortcut,
               danger: child.danger,
               enabled: child.enabled,
+              tooltip: child.tooltip,
               onTap: child.onTap == null
                   ? null
                   : () {
@@ -298,7 +340,7 @@ class _GbmMenuRowState extends State<_GbmMenuRow> {
               ? colors.textOnAccent
               : (item.danger ? colors.danger : colors.textPrimary));
 
-    return MouseRegion(
+    final Widget row = MouseRegion(
       onEnter: (_) => setState(() => _hovered = item.enabled),
       onExit: (_) => setState(() => _hovered = false),
       child: GestureDetector(
@@ -350,5 +392,14 @@ class _GbmMenuRowState extends State<_GbmMenuRow> {
         ),
       ),
     );
+
+    // Wrapped outside MouseRegion, not inside the Container: a disabled row
+    // is exactly the case a tooltip exists to explain, and Tooltip needs to
+    // receive the pointer for the whole row to answer "why is this greyed
+    // out?" rather than only over the label text.
+    if (item.tooltip case final String message) {
+      return Tooltip(message: message, child: row);
+    }
+    return row;
   }
 }

--- a/app_flutter/test/actions/gbm_menu_model_test.dart
+++ b/app_flutter/test/actions/gbm_menu_model_test.dart
@@ -4,7 +4,7 @@ import 'package:gbm_flutter/actions/gbm_menu_model.dart';
 
 void main() {
   group('gbmMenus', () {
-    test('all 52 GbmActionId values appear exactly once across all menus', () {
+    test('all 53 GbmActionId values appear exactly once across all menus', () {
       // Flatten all items from all menus
       final allItems = <GbmMenuItemModel>[];
       for (final menu in gbmMenus) {
@@ -22,11 +22,11 @@ void main() {
         reason: 'Each GbmActionId should appear exactly once',
       );
 
-      // Check completeness: all 52 IDs should be in the set
+      // Check completeness: all 53 IDs should be in the set
       expect(
         idSet,
         GbmActionId.values.toSet(),
-        reason: 'All 52 GbmActionId values must be present',
+        reason: 'All 53 GbmActionId values must be present',
       );
     });
 
@@ -66,8 +66,8 @@ void main() {
       final nonSubmenuItems = allItems.where((item) => !item.isSubmenuParent);
       expect(
         nonSubmenuItems.length,
-        50,
-        reason: '50 items should not be submenu parents',
+        51,
+        reason: '51 items should not be submenu parents',
       );
     });
 
@@ -91,8 +91,8 @@ void main() {
       final nonDangerItems = allItems.where((item) => !item.isDanger);
       expect(
         nonDangerItems.length,
-        51,
-        reason: '51 items should not be marked as danger',
+        52,
+        reason: '52 items should not be marked as danger',
       );
     });
   });

--- a/app_flutter/test/actions/gbm_selection_gesture_test.dart
+++ b/app_flutter/test/actions/gbm_selection_gesture_test.dart
@@ -1,0 +1,85 @@
+// Spec page 13 MULTIKEYS' three mouse rows, as read off the modifier state.
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/actions/gbm_selection_gesture.dart';
+
+void main() {
+  group('selectionGestureFromKeys', () {
+    test('no modifier is a plain single selection', () {
+      expect(
+        selectionGestureFromKeys(const <LogicalKeyboardKey>{}, isMacOS: true),
+        SelectionGesture.single,
+      );
+    });
+
+    test('shift is a range on either platform', () {
+      for (final bool isMacOS in <bool>[true, false]) {
+        expect(
+          selectionGestureFromKeys(<LogicalKeyboardKey>{
+            LogicalKeyboardKey.shiftLeft,
+          }, isMacOS: isMacOS),
+          SelectionGesture.range,
+        );
+      }
+    });
+
+    test('the toggle modifier is Cmd on macOS and Ctrl elsewhere', () {
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.metaLeft,
+        }, isMacOS: true),
+        SelectionGesture.toggle,
+      );
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.controlLeft,
+        }, isMacOS: false),
+        SelectionGesture.toggle,
+      );
+    });
+
+    test('the wrong platform modifier does not toggle', () {
+      // Ctrl-click on macOS is the OS's own secondary-click; treating it as
+      // a toggle would fight the context menu that same gesture opens.
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.controlLeft,
+        }, isMacOS: true),
+        SelectionGesture.single,
+      );
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.metaLeft,
+        }, isMacOS: false),
+        SelectionGesture.single,
+      );
+    });
+
+    test('shift wins over the toggle modifier (MULTIKEYS leaves the '
+        'combination undefined; pinned here rather than invented per '
+        'call site)', () {
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.shiftLeft,
+          LogicalKeyboardKey.metaLeft,
+        }, isMacOS: true),
+        SelectionGesture.range,
+      );
+    });
+
+    test('right-hand modifier keys count too', () {
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.shiftRight,
+        }, isMacOS: true),
+        SelectionGesture.range,
+      );
+      expect(
+        selectionGestureFromKeys(<LogicalKeyboardKey>{
+          LogicalKeyboardKey.metaRight,
+        }, isMacOS: true),
+        SelectionGesture.toggle,
+      );
+    });
+  });
+}

--- a/app_flutter/test/actions/gbm_shortcuts_test.dart
+++ b/app_flutter/test/actions/gbm_shortcuts_test.dart
@@ -14,10 +14,10 @@ void main() {
       GbmActionId.branchRenameCurrentBranch,
     };
 
-    test('macOS shortcuts has exactly 36 entries, and every one but the '
+    test('macOS shortcuts has exactly 37 entries, and every one but the '
         'bare-key group uses meta=true, control=false', () {
       final shortcuts = gbmActionShortcuts(true);
-      expect(shortcuts.length, 36);
+      expect(shortcuts.length, 37);
       shortcuts.forEach((id, shortcut) {
         if (bareKeyActions.contains(id)) return;
         expect(
@@ -33,10 +33,10 @@ void main() {
       });
     });
 
-    test('non-macOS shortcuts has exactly 36 entries, and every one but the '
+    test('non-macOS shortcuts has exactly 37 entries, and every one but the '
         'bare-key group uses meta=false, control=true', () {
       final shortcuts = gbmActionShortcuts(false);
-      expect(shortcuts.length, 36);
+      expect(shortcuts.length, 37);
       for (final MapEntry<GbmActionId, GbmKeyboardShortcut> entry
           in shortcuts.entries) {
         if (bareKeyActions.contains(entry.key)) continue;
@@ -126,6 +126,33 @@ void main() {
         // The shortcuts dialog derives its text from these fields, so a
         // stray modifier would show up as "Ctrl+F2" there too.
         expect(rename.displayLabel, 'F2', reason: 'isMacOS=$isMacOS');
+      }
+    });
+  });
+
+  group('editSelectAll (spec page 13 REVISIONS)', () {
+    test('is bound to the plain Ctrl/Cmd+A, with no shift', () {
+      for (final bool isMacOS in <bool>[true, false]) {
+        final GbmKeyboardShortcut? shortcut = gbmActionShortcuts(
+          isMacOS,
+        )[GbmActionId.editSelectAll];
+        expect(shortcut, isNotNull, reason: 'isMacOS=$isMacOS');
+        expect(shortcut!.trigger, LogicalKeyboardKey.keyA);
+        expect(shortcut.shift, isFalse);
+        expect(shortcut.meta, isMacOS);
+        expect(shortcut.control, !isMacOS);
+      }
+    });
+
+    test('does not collide with repositoryAmendLastCommit, which is the '
+        'shift variant of the same key', () {
+      for (final bool isMacOS in <bool>[true, false]) {
+        final Map<GbmActionId, GbmKeyboardShortcut> shortcuts =
+            gbmActionShortcuts(isMacOS);
+        final GbmKeyboardShortcut amend =
+            shortcuts[GbmActionId.repositoryAmendLastCommit]!;
+        expect(amend.trigger, LogicalKeyboardKey.keyA);
+        expect(amend.shift, isTrue);
       }
     });
   });

--- a/app_flutter/test/data/models/list_selection_test.dart
+++ b/app_flutter/test/data/models/list_selection_test.dart
@@ -1,0 +1,212 @@
+// Walks spec page 13's MULTIKEYS table row by row against ListSelection,
+// plus the two rules MULTIACTS depends on (contiguity, positional order).
+// Pure unit tests: no widgets, no Riverpod — the transitions are the thing
+// under test, not any list that happens to use them.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/list_selection.dart';
+
+const List<String> _rows = <String>['a', 'b', 'c', 'd', 'e'];
+
+ListSelection<String> _of(List<String> items, String? anchor) =>
+    ListSelection<String>(items: items, anchor: anchor);
+
+void main() {
+  group('MULTIKEYS: 單擊 — 只選這一項，anchor 移到這一項', () {
+    test('replaces any prior selection and moves the anchor', () {
+      final ListSelection<String> result = _of(<String>[
+        'a',
+        'b',
+      ], 'a').single('d');
+      expect(result.items, <String>['d']);
+      expect(result.anchor, 'd');
+    });
+  });
+
+  group('MULTIKEYS: Ctrl/Cmd + 單擊 — 切換單項，anchor 移到此項', () {
+    test('adds an unselected item and moves the anchor to it', () {
+      final ListSelection<String> result = _of(<String>['a'], 'a').toggle('c');
+      expect(result.items, <String>['a', 'c']);
+      expect(result.anchor, 'c');
+    });
+
+    test('removes an already-selected item', () {
+      final ListSelection<String> result = _of(<String>[
+        'a',
+        'b',
+        'c',
+      ], 'c').toggle('b');
+      expect(result.items, <String>['a', 'c']);
+    });
+
+    test('deselecting a non-anchor item leaves the anchor alone', () {
+      final ListSelection<String> result = _of(<String>[
+        'a',
+        'b',
+        'c',
+      ], 'c').toggle('a');
+      expect(result.anchor, 'c');
+    });
+
+    test('deselecting the anchor promotes the newest survivor '
+        '(MULTIKEYS does not specify this; pinned here rather than decided '
+        'ad hoc at a call site)', () {
+      final ListSelection<String> result = _of(<String>[
+        'a',
+        'b',
+        'c',
+      ], 'c').toggle('c');
+      expect(result.items, <String>['a', 'b']);
+      expect(result.anchor, 'b');
+    });
+
+    test('deselecting the last item empties the selection and the anchor', () {
+      final ListSelection<String> result = _of(<String>['a'], 'a').toggle('a');
+      expect(result.isEmpty, isTrue);
+      expect(result.anchor, isNull);
+    });
+  });
+
+  group('MULTIKEYS: Shift + 單擊 — anchor 到此項的連續範圍', () {
+    test('selects the inclusive range downward', () {
+      final ListSelection<String> result = _of(<String>[
+        'b',
+      ], 'b').range('d', _rows);
+      expect(result.items, <String>['b', 'c', 'd']);
+    });
+
+    test('selects the inclusive range upward', () {
+      final ListSelection<String> result = _of(<String>[
+        'd',
+      ], 'd').range('b', _rows);
+      expect(result.items, <String>['b', 'c', 'd']);
+    });
+
+    test('leaves the anchor put so a second Shift-click resizes the '
+        'same range instead of starting a new one', () {
+      final ListSelection<String> first = _of(<String>[
+        'b',
+      ], 'b').range('e', _rows);
+      expect(first.anchor, 'b');
+      final ListSelection<String> second = first.range('c', _rows);
+      expect(second.items, <String>['b', 'c']);
+      expect(second.anchor, 'b');
+    });
+
+    test('degrades to a single selection with no anchor yet', () {
+      final ListSelection<String> result = ListSelection<String>().range(
+        'c',
+        _rows,
+      );
+      expect(result.items, <String>['c']);
+      expect(result.anchor, 'c');
+    });
+
+    test('degrades to a single selection when an end is not in the list', () {
+      final ListSelection<String> result = _of(<String>[
+        'zz',
+      ], 'zz').range('c', _rows);
+      expect(result.items, <String>['c']);
+    });
+  });
+
+  group('MULTIKEYS: Ctrl/Cmd + A — 全選當前清單', () {
+    test('selects everything and keeps a still-present anchor', () {
+      final ListSelection<String> result = _of(<String>[
+        'c',
+      ], 'c').selectAll(_rows);
+      expect(result.items, _rows);
+      expect(result.anchor, 'c');
+    });
+
+    test('falls back to the first row when the anchor is gone', () {
+      final ListSelection<String> result = _of(<String>[
+        'zz',
+      ], 'zz').selectAll(_rows);
+      expect(result.anchor, 'a');
+    });
+
+    test('an empty list yields an empty selection, not an empty anchor', () {
+      final ListSelection<String> result = _of(<String>[
+        'a',
+      ], 'a').selectAll(const <String>[]);
+      expect(result.isEmpty, isTrue);
+      expect(result.anchor, isNull);
+    });
+  });
+
+  group('MULTIKEYS: Esc — 縮回單選（保留 anchor 項）', () {
+    test('collapses to the anchor rather than clearing', () {
+      final ListSelection<String> result = _of(<String>[
+        'a',
+        'b',
+        'c',
+      ], 'b').collapseToAnchor();
+      expect(result.items, <String>['b']);
+      expect(result.anchor, 'b');
+    });
+
+    test('an empty selection stays empty', () {
+      expect(ListSelection<String>().collapseToAnchor().isEmpty, isTrue);
+    });
+  });
+
+  group('MULTIACTS: 連續範圍 gating', () {
+    test('a single item is contiguous', () {
+      expect(_of(<String>['c'], 'c').isContiguousIn(_rows), isTrue);
+    });
+
+    test('an unbroken run is contiguous regardless of insertion order', () {
+      expect(_of(<String>['d', 'b', 'c'], 'd').isContiguousIn(_rows), isTrue);
+    });
+
+    test('a gap is not contiguous', () {
+      expect(_of(<String>['a', 'c'], 'a').isContiguousIn(_rows), isFalse);
+    });
+
+    test('an empty selection is not contiguous — there is nothing to run', () {
+      expect(ListSelection<String>().isContiguousIn(_rows), isFalse);
+    });
+
+    test('an item missing from the list reads as non-contiguous, not a throw '
+        '(a filter can change what the list holds under a live selection)', () {
+      expect(_of(<String>['a', 'zz'], 'a').isContiguousIn(_rows), isFalse);
+    });
+  });
+
+  group('orderedBy', () {
+    test('returns list order, not insertion order', () {
+      expect(_of(<String>['d', 'a', 'c'], 'd').orderedBy(_rows), <String>[
+        'a',
+        'c',
+        'd',
+      ]);
+    });
+
+    test('drops items absent from the list', () {
+      expect(_of(<String>['zz', 'b'], 'b').orderedBy(_rows), <String>['b']);
+    });
+  });
+
+  group('value semantics', () {
+    test('equal items and anchor compare equal', () {
+      expect(_of(<String>['a', 'b'], 'a'), _of(<String>['a', 'b'], 'a'));
+      expect(
+        _of(<String>['a', 'b'], 'a').hashCode,
+        _of(<String>['a', 'b'], 'a').hashCode,
+      );
+    });
+
+    test('a different anchor is a different selection', () {
+      expect(_of(<String>['a', 'b'], 'a'), isNot(_of(<String>['a', 'b'], 'b')));
+    });
+
+    test('transitions never mutate the receiver', () {
+      final ListSelection<String> original = _of(<String>['a'], 'a');
+      original.toggle('b');
+      original.range('c', _rows);
+      original.selectAll(_rows);
+      expect(original.items, <String>['a']);
+      expect(original.anchor, 'a');
+    });
+  });
+}

--- a/app_flutter/test/features/context_menus/context_menu_parity_test.dart
+++ b/app_flutter/test/features/context_menus/context_menu_parity_test.dart
@@ -28,6 +28,7 @@ import 'package:gbm_flutter/features/context_menus/gbm_context_menus.dart';
 import 'package:gbm_flutter/features/diff/widgets/diff_line.dart';
 import 'package:gbm_flutter/features/diff/widgets/diff_line_menu_items.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/changed_files_panel.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/commit_menu_items.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
 import 'package:gbm_flutter/features/repo_switcher/repo_switcher_popover.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/branch_folder_menu_items.dart';
@@ -315,54 +316,85 @@ void main() {
     });
   });
 
-  group('05-E Commit (real gap -- see matrix)', () {
-    testWidgets(
-      'CommitRow matches the full 05-E catalog, including the "More '
-      'actions" submenu',
-      (tester) async {
-        await _pump(
-          tester,
-          CommitRow(
-            row: _graphRow(),
-            oidHex: 'abc12345def67890',
-            graph: GraphSnapshotView.empty,
-            rowIndex: 0,
-            maxLane: 0,
-            onCheckout: () {},
-            onCherryPick: () {},
-            onRevert: () {},
-            onCreateBranchHere: () {},
-          ),
-        );
-        await tester.tap(
-          find.byType(CommitRow),
-          buttons: kSecondaryMouseButton,
-        );
-        await tester.pumpAndSettle();
+  group('05-E Commit (conforms)', () {
+    test('commitMenuItems matches the full 05-E catalog exactly', () {
+      final List<GbmMenuItem> items = commitMenuItems(
+        count: 1,
+        contiguous: true,
+        conflictActive: false,
+        onCopySha: () {},
+        onCheckout: () {},
+        onMerge: () {},
+        onCherryPick: () {},
+        onCreateBranchHere: () {},
+        onCompare: () {},
+        onRebaseOntoHere: () {},
+        onResetBranchHere: () {},
+        onRevert: () {},
+        onExportAsPatch: () {},
+        onCompareWithWorkingCopy: () {},
+      );
+      final List<String> actual = items
+          .where((GbmMenuItem i) => !i.separator)
+          .map((GbmMenuItem i) => i.label)
+          .toList();
+      expect(actual, _specLabels(GbmContextMenuTarget.commit));
+    });
 
-        for (final String label in _specLabels(GbmContextMenuTarget.commit)) {
-          expect(find.text(label), findsOneWidget, reason: 'missing: $label');
-        }
-        await tester.tap(find.text('More actions'));
-        await tester.pumpAndSettle();
-        for (final String label in _specSubLabels(
-          GbmContextMenuTarget.commit,
-          'More actions',
-        )) {
-          expect(find.text(label), findsOneWidget, reason: 'missing: $label');
-        }
-      },
-      // Real gap, tracked in docs/reports/spec-conformance-matrix.md
-      // (Page 05, row 05-E): missing "Merge into current", "Compare
-      // with…", and the entire "More actions" submenu.
-      // commit_row.dart's own doc comment explains why each is
-      // omitted -- Merge needs mergeBranch to accept an oid rather
-      // than a branch name (or a name-resolution step first),
-      // Compare is planned as milestone M6, and rebase/reset are not
-      // yet wired on the Dart side even though the capi calls exist.
-      // Remove `skip: true` once 05-E is brought to parity.
-      skip: true,
-    );
+    test('the "More actions" submenu matches its catalog children', () {
+      final GbmMenuItem submenu = commitMenuItems(
+        count: 1,
+        contiguous: true,
+        conflictActive: false,
+        onCopySha: () {},
+      ).firstWhere((GbmMenuItem i) => i.isSubmenuTrigger);
+      expect(
+        submenu.children.map((GbmMenuItem i) => i.label).toList(),
+        _specSubLabels(GbmContextMenuTarget.commit, 'More actions'),
+      );
+    });
+
+    testWidgets('a CommitRow right-click really renders that catalog', (
+      tester,
+    ) async {
+      // The pure function above is the acceptance baseline; this checks the
+      // render site actually goes through it rather than keeping its own
+      // hand-written list, which is how 05-B/E drifted in the first place.
+      await _pump(
+        tester,
+        CommitRow(
+          row: _graphRow(),
+          oidHex: 'abc12345def67890',
+          graph: GraphSnapshotView.empty,
+          rowIndex: 0,
+          maxLane: 0,
+          onCheckout: () {},
+          onMerge: () {},
+          onCherryPick: () {},
+          onRevert: () {},
+          onCreateBranchHere: () {},
+          onCompare: () {},
+          onRebaseOntoHere: () {},
+          onResetBranchHere: () {},
+          onExportAsPatch: () {},
+          onCompareWithWorkingCopy: () {},
+        ),
+      );
+      await tester.tap(find.byType(CommitRow), buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+
+      for (final String label in _specLabels(GbmContextMenuTarget.commit)) {
+        expect(find.text(label), findsOneWidget, reason: 'missing: $label');
+      }
+      await tester.tap(find.text('More actions'));
+      await tester.pumpAndSettle();
+      for (final String label in _specSubLabels(
+        GbmContextMenuTarget.commit,
+        'More actions',
+      )) {
+        expect(find.text(label), findsOneWidget, reason: 'missing: $label');
+      }
+    });
   });
 
   group('05-F Working copy file (conforms)', () {

--- a/app_flutter/test/features/context_menus/context_menu_parity_test.dart
+++ b/app_flutter/test/features/context_menus/context_menu_parity_test.dart
@@ -33,6 +33,7 @@ import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
 import 'package:gbm_flutter/features/repo_switcher/repo_switcher_popover.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/branch_folder_menu_items.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/branch_tree_item.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/local_branch_menu_items.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/stash_menu_items.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/tag_menu_items.dart';
 import 'package:gbm_flutter/features/working_copy/widgets/working_copy_file_menu_items.dart';
@@ -70,10 +71,19 @@ Future<void> _pump(WidgetTester tester, Widget child) =>
 /// Renders the visible top-level menu's item labels, in order, excluding
 /// separators -- the `GbmMenuItem` list itself isn't reachable from a
 /// widget-pump test, only what `showGbmContextMenu`/`showGbmMenu` paint.
+/// Labels inside the open menu only.
+///
+/// Scoped to the `PopupMenuItem` showGbmMenu wraps its panel in, not to the
+/// whole `Overlay`: in these harnesses the widget under test is itself
+/// inside the overlay, so an Overlay-wide search also picks up the row's own
+/// branch name and the assertion compares the wrong list.
 List<String> _visibleMenuLabels(WidgetTester tester) {
   return tester
       .widgetList<Text>(
-        find.descendant(of: find.byType(Overlay), matching: find.byType(Text)),
+        find.descendant(
+          of: find.byType(PopupMenuItem<void>),
+          matching: find.byType(Text),
+        ),
       )
       .map((Text t) => t.data)
       .whereType<String>()
@@ -203,43 +213,50 @@ void main() {
     );
   });
 
-  group('05-B Local branch (real gap -- see matrix)', () {
-    testWidgets(
-      'BranchTreeItem matches the full 05-B catalog',
-      (tester) async {
-        await _pump(
-          tester,
-          BranchTreeItem(
-            ref: _localBranch(),
-            onCheckout: () {},
-            onRename: () {},
-            onDelete: () {},
-            onNewBranchFromHere: () {},
-            onMerge: () {},
-          ),
-        );
-        await _rightClick(tester, find.byType(BranchTreeItem));
+  group('05-B Local branch (conforms)', () {
+    test('localBranchMenuItems matches the full 05-B catalog exactly', () {
+      final List<GbmMenuItem> items = localBranchMenuItems(
+        branchName: 'feature/x',
+        isCurrent: false,
+        conflictActive: false,
+        onCheckout: () {},
+        onNewBranchFromHere: () {},
+        onRename: () {},
+        onMerge: () {},
+        onRebaseOntoHere: () {},
+        onCompare: () {},
+        onDelete: () {},
+      );
+      final List<String> actual = items
+          .where((GbmMenuItem i) => !i.separator)
+          .map((GbmMenuItem i) => i.label)
+          .toList();
+      expect(actual, _specLabels(GbmContextMenuTarget.localBranch));
+    });
 
-        final List<String> visible = _visibleMenuLabels(tester);
-        for (final String label in _specLabels(
-          GbmContextMenuTarget.localBranch,
-        )) {
-          expect(
-            visible.any((String v) => v.startsWith(label.split('…').first)),
-            isTrue,
-            reason: 'missing spec item: $label',
-          );
-        }
-      },
-      // Real gap, tracked in docs/reports/spec-conformance-matrix.md
-      // (Page 05, row 05-B): missing "Rebase current onto here" and
-      // "Compare with…" -- branch_tree_item.dart's own doc comment says
-      // both need a not-yet-built per-branch rebase/compare UI, not just
-      // a wiring change. Also wording drift: "Rename branch" vs spec
-      // "Rename…", "Merge into current branch" vs spec "Merge into
-      // current". Remove `skip: true` once 05-B is brought to parity.
-      skip: true,
-    );
+    testWidgets('a BranchTreeItem right-click really renders that catalog', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        BranchTreeItem(
+          ref: _localBranch(),
+          onCheckout: () {},
+          onRename: () {},
+          onDelete: () {},
+          onNewBranchFromHere: () {},
+          onMerge: () {},
+          onRebaseOntoHere: () {},
+          onCompareRef: () {},
+        ),
+      );
+      await _rightClick(tester, find.byType(BranchTreeItem));
+
+      expect(
+        _visibleMenuLabels(tester),
+        _specLabels(GbmContextMenuTarget.localBranch),
+      );
+    });
   });
 
   group('05-C Remote-only / gone branch (conforms)', () {

--- a/app_flutter/test/features/dialogs/delete_branches_dialog_test.dart
+++ b/app_flutter/test/features/dialogs/delete_branches_dialog_test.dart
@@ -1,0 +1,254 @@
+// Spec page 13's batch-delete confirmation: 「逐項列出名稱與未 push 的
+// commit 數，並區分「本地」與「遠端」兩份清單，不用一句「刪除 3 個分支？」
+// 概括」.
+//
+// The two assertions that matter most here are the ones a plain
+// "does it render" test would miss: `ahead` is meaningless without an
+// upstream (rendering it literally claims "0 unpushed" for a branch where
+// *everything* is unpushed), and the remote name must come from
+// remoteBranchParts, not a first-slash split -- the latter is the live #74
+// bug in the sibling single-branch dialog and would send `refs` as a remote
+// name.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/delete_branches/delete_branches_dialog.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+
+RefInfo _branch(
+  String name, {
+  String upstream = '',
+  int ahead = 0,
+  bool isHead = false,
+}) => RefInfo(
+  fullName: 'refs/heads/$name',
+  shortName: name,
+  kind: RefKind.localBranch,
+  target: 'a' * 40,
+  upstream: upstream,
+  ahead: ahead,
+  behind: 0,
+  // Deliberately *not* derived from `upstream`: a fixture that computes one
+  // field from another cannot falsify code that makes the same wrong
+  // derivation (CLAUDE.md's Tier 0c note). `false` with a populated
+  // upstream is the real in-sync case that trips hasTrackingInfo.
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: isHead,
+  isSymbolic: false,
+  worktreePath: '',
+);
+
+RefSnapshot _snapshot(List<RefInfo> refs) => RefSnapshot(
+  head: const HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: '',
+  ),
+  refs: refs,
+  refCountGuardTripped: false,
+  totalRefCount: refs.length,
+);
+
+Future<FakeRepoSessionController> _pump(
+  WidgetTester tester,
+  List<String> names,
+  List<RefInfo> refs,
+) async {
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _identity,
+    RepoSessionState(refs: _snapshot(refs)),
+  );
+  // The dialog calls context.pop() after dispatching, so it has to sit on
+  // top of something -- a single-route router throws "nothing to pop" and
+  // the delete assertions never run.
+  final GoRouter router = GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (BuildContext context, GoRouterState state) =>
+            const Scaffold(body: SizedBox.shrink()),
+      ),
+      GoRoute(
+        path: '/dialog',
+        builder: (BuildContext context, GoRouterState state) => Scaffold(
+          body: DeleteBranchesDialogContent(identity: _identity, names: names),
+        ),
+      ),
+    ],
+  );
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      repoSessionProvider(_identity).overrideWith((Ref ref) => fake),
+    ],
+  );
+  addTearDown(container.dispose);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  router.push('/dialog');
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+void main() {
+  group('deleteBranchLines', () {
+    test('a branch with no upstream reports null, not 0 unpushed commits', () {
+      final List<DeleteBranchLine> lines = deleteBranchLines(<String>[
+        'solo',
+      ], _snapshot(<RefInfo>[_branch('solo')]));
+      expect(lines.single.unpushed, isNull);
+      expect(lines.single.hasUpstream, isFalse);
+    });
+
+    test('the remote comes from the full upstream ref, not a first-slash '
+        'split (#74)', () {
+      final List<DeleteBranchLine> lines = deleteBranchLines(
+        <String>['feature/x'],
+        _snapshot(<RefInfo>[
+          _branch(
+            'feature/x',
+            upstream: 'refs/remotes/upstream/feature/x',
+            ahead: 2,
+          ),
+        ]),
+      );
+      expect(lines.single.remote, 'upstream');
+      expect(lines.single.unpushed, 2);
+    });
+
+    test('a name with no matching ref still gets a line', () {
+      final List<DeleteBranchLine> lines = deleteBranchLines(<String>[
+        'vanished',
+      ], _snapshot(const <RefInfo>[]));
+      expect(lines.single.name, 'vanished');
+      expect(lines.single.unpushed, isNull);
+    });
+  });
+
+  group('DeleteBranchesDialogContent', () {
+    testWidgets('lists every branch by name with its own unpushed count', (
+      WidgetTester tester,
+    ) async {
+      await _pump(
+        tester,
+        <String>['a', 'b'],
+        <RefInfo>[
+          _branch('a', upstream: 'refs/remotes/origin/a', ahead: 3),
+          _branch('b'),
+        ],
+      );
+      expect(find.text('a'), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('3 unpushed commits'), findsOneWidget);
+      expect(
+        find.text('no upstream — nothing has been pushed'),
+        findsOneWidget,
+      );
+      expect(find.text('Local branches'), findsOneWidget);
+      expect(find.text('Remote branches'), findsOneWidget);
+      expect(find.text('origin/a'), findsOneWidget);
+    });
+
+    testWidgets('a selection with no upstreams has no remote section at all', (
+      WidgetTester tester,
+    ) async {
+      await _pump(tester, <String>['a'], <RefInfo>[_branch('a')]);
+      expect(find.text('Remote branches'), findsNothing);
+      expect(find.text('Also delete on the remote'), findsNothing);
+    });
+
+    testWidgets('deleting issues one call for every local branch, not N', (
+      WidgetTester tester,
+    ) async {
+      final FakeRepoSessionController fake = await _pump(
+        tester,
+        <String>['a', 'b'],
+        <RefInfo>[
+          _branch('a', upstream: 'refs/remotes/origin/a'),
+          _branch('b'),
+        ],
+      );
+      await tester.tap(find.text('Delete 2 branches').last);
+      await tester.pumpAndSettle();
+
+      final List<FakeCommand> deletes = fake.commandLog
+          .where((FakeCommand c) => c.name == 'deleteBranch')
+          .toList();
+      expect(deletes, hasLength(1));
+      expect(deletes.single.args['names'], <String>['a', 'b']);
+      expect(deletes.single.args['isRemote'], isFalse);
+    });
+
+    testWidgets('"Also delete on the remote" adds one call per remote', (
+      WidgetTester tester,
+    ) async {
+      final FakeRepoSessionController fake = await _pump(
+        tester,
+        <String>['a', 'b', 'c'],
+        <RefInfo>[
+          _branch('a', upstream: 'refs/remotes/origin/a'),
+          _branch('b', upstream: 'refs/remotes/fork/b'),
+          _branch('c'),
+        ],
+      );
+      await tester.tap(find.text('Also delete on the remote'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete 3 branches').last);
+      await tester.pumpAndSettle();
+
+      final List<FakeCommand> deletes = fake.commandLog
+          .where((FakeCommand c) => c.name == 'deleteBranch')
+          .toList();
+      expect(deletes, hasLength(3));
+      expect(deletes[0].args['names'], <String>['a', 'b', 'c']);
+      expect(
+        deletes.skip(1).map((FakeCommand c) => c.args['remoteName']).toSet(),
+        <String>{'origin', 'fork'},
+        reason: 'grouped by remote; the untracked branch c is not in either',
+      );
+      for (final FakeCommand remote in deletes.skip(1)) {
+        expect(remote.args['isRemote'], isTrue);
+      }
+    });
+
+    testWidgets('the force checkbox reaches every call', (
+      WidgetTester tester,
+    ) async {
+      final FakeRepoSessionController fake = await _pump(
+        tester,
+        <String>['a'],
+        <RefInfo>[_branch('a', upstream: 'refs/remotes/origin/a')],
+      );
+      await tester.tap(find.text('Delete even if not fully merged'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete 1 branches').last);
+      await tester.pumpAndSettle();
+
+      expect(
+        fake.commandLog
+            .where((FakeCommand c) => c.name == 'deleteBranch')
+            .every((FakeCommand c) => c.args['force'] == true),
+        isTrue,
+      );
+    });
+  });
+}

--- a/app_flutter/test/features/dialogs/dialog_target_prefill_test.dart
+++ b/app_flutter/test/features/dialogs/dialog_target_prefill_test.dart
@@ -1,0 +1,169 @@
+// The `target` query parameter that lets 05-B's "Rebase current onto here"
+// and 05-E's "Rebase onto here" / "Reset branch to here…" open a dialog
+// already aimed at the row that was right-clicked, instead of making the
+// user re-pick what they just chose.
+//
+// Mirrors renameBranchDialogFor's shape, which is the template these two
+// follow.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/rebase_onto/rebase_onto_dialog.dart';
+import 'package:gbm_flutter/features/dialogs/reset_branch/reset_branch_dialog.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+const String _oid = 'abcdef0123456789abcdef0123456789abcdef01';
+
+RefInfo _branch(String name) => RefInfo(
+  fullName: 'refs/heads/$name',
+  shortName: name,
+  kind: RefKind.localBranch,
+  target: 'f' * 40,
+  upstream: '',
+  ahead: 0,
+  behind: 0,
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: name == 'main',
+  isSymbolic: false,
+  worktreePath: '',
+);
+
+RepoSessionState _state() => RepoSessionState(
+  isOpen: true,
+  refs: RefSnapshot(
+    head: const HeadInfo(
+      kind: HeadKind.branch,
+      branchName: 'main',
+      fullRef: 'refs/heads/main',
+      target: 'f',
+    ),
+    refs: <RefInfo>[_branch('main'), _branch('feature')],
+    refCountGuardTripped: false,
+    totalRefCount: 2,
+  ),
+);
+
+Future<void> _pump(WidgetTester tester, Widget dialog) async {
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      repoSessionProvider(
+        _identity,
+      ).overrideWith((ref) => FakeRepoSessionController(_identity, _state())),
+    ],
+  );
+  addTearDown(container.dispose);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        home: Scaffold(body: dialog),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('route helpers', () {
+    test('omit the query parameter entirely when there is no target', () {
+      expect(
+        RoutePaths.resetBranchDialogFor('r'),
+        '/repo/r/dialogs/reset-branch',
+      );
+      expect(
+        RoutePaths.rebaseOntoDialogFor('r'),
+        '/repo/r/dialogs/rebase-onto',
+      );
+    });
+
+    test('carry the target when given one', () {
+      expect(
+        RoutePaths.resetBranchDialogFor('r', target: _oid),
+        '/repo/r/dialogs/reset-branch?target=$_oid',
+      );
+      expect(
+        RoutePaths.rebaseOntoDialogFor('r', target: 'feature'),
+        '/repo/r/dialogs/rebase-onto?target=feature',
+      );
+    });
+  });
+
+  group('ResetBranchDialogContent', () {
+    testWidgets('pre-fills the target field when given one', (tester) async {
+      await _pump(
+        tester,
+        ResetBranchDialogContent(identity: _identity, target: _oid),
+      );
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        _oid,
+      );
+    });
+
+    testWidgets('falls back to the current branch with no target', (
+      tester,
+    ) async {
+      await _pump(tester, ResetBranchDialogContent(identity: _identity));
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'main',
+      );
+    });
+  });
+
+  group('RebaseOntoDialogContent', () {
+    testWidgets('pre-selects a branch target that is already an option', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        RebaseOntoDialogContent(identity: _identity, target: 'feature'),
+      );
+      expect(
+        tester
+            .widget<DropdownButtonFormField<String>>(
+              find.byType(DropdownButtonFormField<String>),
+            )
+            .initialValue,
+        'feature',
+      );
+    });
+
+    testWidgets('adds a commit oid as its own option rather than dropping '
+        'a target the user explicitly picked', (tester) async {
+      // The dropdown lists branches only; without the synthetic entry
+      // DropdownButtonFormField asserts on an initialValue that is not
+      // among its items.
+      await _pump(
+        tester,
+        RebaseOntoDialogContent(identity: _identity, target: _oid),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('commit ${_oid.substring(0, 8)}'), findsOneWidget);
+    });
+
+    testWidgets('leaves Start rebase disabled with no target at all', (
+      tester,
+    ) async {
+      await _pump(tester, RebaseOntoDialogContent(identity: _identity));
+      expect(
+        tester
+            .widget<DropdownButtonFormField<String>>(
+              find.byType(DropdownButtonFormField<String>),
+            )
+            .initialValue,
+        isNull,
+      );
+    });
+  });
+}

--- a/app_flutter/test/features/history_graph/commit_compare_entry_test.dart
+++ b/app_flutter/test/features/history_graph/commit_compare_entry_test.dart
@@ -1,0 +1,212 @@
+// COMPARES 3's entry point: 「History 內 Ctrl/Cmd 點選兩個 commit → 右鍵
+// Compare」. The comparison engine (merge-base detection, 2-dot/3-dot) was
+// already complete in compare_page.dart; what was missing, and what this
+// covers, is reaching it from History at all.
+//
+// Asserts the CompareTabSpec that gets opened and the route navigated to,
+// not just that a callback fired: the older/newer side assignment is the
+// part a wiring mistake would silently invert.
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/commit_meta.dart';
+import 'package:gbm_flutter/data/models/graph_snapshot.dart';
+import 'package:gbm_flutter/data/models/signature.dart';
+import 'package:gbm_flutter/data/repositories/compare_tabs_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/history_graph/commit_graph_view.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+
+/// Newest first, as History renders.
+final List<String> _oids = <String>[
+  for (final String seed in <String>['a', 'b', 'c']) seed * 40,
+];
+String _oid(String seed) => seed * 40;
+
+final LogicalKeyboardKey _toggleKey =
+    defaultTargetPlatform == TargetPlatform.macOS
+    ? LogicalKeyboardKey.metaLeft
+    : LogicalKeyboardKey.controlLeft;
+
+CommitMeta _meta(String oid) {
+  const Signature author = Signature(
+    name: 'Tester',
+    email: 't@example.com',
+    when: 0,
+    tzOffsetMinutes: 0,
+  );
+  return CommitMeta(
+    oid: oid,
+    tree: '',
+    parents: const <String>[],
+    author: author,
+    committer: author,
+    subject: 'subject ${oid.substring(0, 4)}',
+    body: '',
+    signedCommit: false,
+  );
+}
+
+late ProviderContainer _container;
+late GoRouter _router;
+
+Future<void> _pump(WidgetTester tester) async {
+  _container = ProviderContainer(
+    overrides: <Override>[
+      repoSessionProvider(_identity).overrideWith(
+        (ref) => FakeRepoSessionController(
+          _identity,
+          RepoSessionState(
+            isOpen: true,
+            graph: GraphSnapshotView(
+              rows: <GraphRow>[
+                for (final _ in _oids)
+                  const GraphRow(
+                    parentOffset: 0,
+                    edgeOffset: 0,
+                    commitTime: 0,
+                    lane: 0,
+                    color: 0,
+                    flags: 0,
+                  ),
+              ],
+              oidsHex: _oids,
+              parentPool: const <int>[],
+              laneCount: 1,
+              complete: true,
+              truncated: false,
+            ),
+            commitMetaCache: <String, CommitMeta>{
+              for (final String oid in _oids) oid: _meta(oid),
+            },
+          ),
+        ),
+      ),
+    ],
+  );
+  addTearDown(_container.dispose);
+
+  _router = GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (_, _) => Scaffold(body: CommitGraphView(identity: _identity)),
+      ),
+      GoRoute(
+        path: RoutePaths.compare,
+        builder: (_, _) => const Scaffold(body: Text('compare-page')),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: _container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: _router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Finder _rowFor(String oid) =>
+    find.byWidgetPredicate((Widget w) => w is CommitRow && w.oidHex == oid);
+
+Future<void> _openMenuOn(WidgetTester tester, String oid) async {
+  await tester.tap(_rowFor(oid), buttons: kSecondaryMouseButton);
+  await tester.pumpAndSettle();
+}
+
+List<CompareTabSpec> get _tabs =>
+    _container.read(compareTabsProvider(_identity));
+
+void main() {
+  testWidgets('two selected commits open a Compare tab with both sides '
+      'filled, older on the left', (tester) async {
+    await _pump(tester);
+
+    await tester.tap(_rowFor(_oid('a')));
+    await tester.pumpAndSettle();
+    await tester.sendKeyDownEvent(_toggleKey);
+    await tester.tap(_rowFor(_oid('c')));
+    await tester.pumpAndSettle();
+    await tester.sendKeyUpEvent(_toggleKey);
+
+    // Right-click one of the selected rows: per MULTIKEYS this must not
+    // change the selection, so Compare still sees both.
+    await _openMenuOn(tester, _oid('a'));
+    await tester.tap(find.text('Compare with…'));
+    await tester.pumpAndSettle();
+
+    expect(_tabs, hasLength(1));
+    expect(_tabs.single.left, _oid('c'), reason: 'older side goes left');
+    expect(_tabs.single.right, _oid('a'), reason: 'newer side goes right');
+    expect(find.text('compare-page'), findsOneWidget);
+  });
+
+  testWidgets('one selected commit opens a Compare tab with only the left '
+      'side, leaving the right to the ref picker', (tester) async {
+    await _pump(tester);
+
+    await _openMenuOn(tester, _oid('b'));
+    await tester.tap(find.text('Compare with…'));
+    await tester.pumpAndSettle();
+
+    expect(_tabs.single.left, _oid('b'));
+    expect(
+      _tabs.single.right,
+      isNull,
+      reason:
+          'null right is what CompareTabSpec models as Working Copy '
+          'until the picker chooses a ref',
+    );
+  });
+
+  testWidgets('"Compare with working copy" opens a working-copy tab', (
+    tester,
+  ) async {
+    await _pump(tester);
+
+    await _openMenuOn(tester, _oid('b'));
+    await tester.tap(find.text('More actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Compare with working copy'));
+    await tester.pumpAndSettle();
+
+    expect(_tabs.single.left, _oid('b'));
+    expect(_tabs.single.rightIsWorkingCopy, isTrue);
+  });
+
+  testWidgets('three selected commits leave Compare disabled and open '
+      'nothing', (tester) async {
+    await _pump(tester);
+
+    await tester.tap(_rowFor(_oid('a')));
+    await tester.pumpAndSettle();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.tap(_rowFor(_oid('c')));
+    await tester.pumpAndSettle();
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+
+    await _openMenuOn(tester, _oid('a'));
+    await tester.tap(find.text('Compare with…'));
+    await tester.pumpAndSettle();
+
+    expect(_tabs, isEmpty);
+  });
+}

--- a/app_flutter/test/features/history_graph/commit_graph_multi_select_test.dart
+++ b/app_flutter/test/features/history_graph/commit_graph_multi_select_test.dart
@@ -1,0 +1,286 @@
+// Drives CommitGraphView's spec page 13 multi-select through the real
+// commitSelectionProvider seam rather than against ListSelection in
+// isolation: the model's transitions already have unit coverage, what this
+// tier proves is that a click carrying a modifier reaches the right one,
+// that a range is measured in the *rendered* list, and that right-click
+// normalises the selection before a menu can act on it.
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/commit_meta.dart';
+import 'package:gbm_flutter/data/models/graph_snapshot.dart';
+import 'package:gbm_flutter/data/models/list_selection.dart';
+import 'package:gbm_flutter/data/models/signature.dart';
+import 'package:gbm_flutter/data/repositories/history_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/history_graph/commit_graph_view.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+
+/// Newest-first, exactly as History renders it.
+final List<String> _oids = <String>[
+  for (final String seed in <String>['a', 'b', 'c', 'd', 'e']) seed * 40,
+];
+
+/// A full 40-char oid from a one-letter shorthand: CommitRow abbreviates to
+/// eight characters, so a toy 3-char id would blow up in its own renderer
+/// rather than in anything under test.
+String _oid(String seed) => seed * 40;
+
+GraphRow _row() => const GraphRow(
+  parentOffset: 0,
+  edgeOffset: 0,
+  commitTime: 0,
+  lane: 0,
+  color: 0,
+  flags: 0,
+);
+
+CommitMeta _meta(String oid, String subject) {
+  const Signature author = Signature(
+    name: 'Tester',
+    email: 'tester@example.com',
+    when: 0,
+    tzOffsetMinutes: 0,
+  );
+  return CommitMeta(
+    oid: oid,
+    tree: '',
+    parents: const <String>[],
+    author: author,
+    committer: author,
+    subject: subject,
+    body: '',
+    signedCommit: false,
+  );
+}
+
+RepoSessionState _state() => RepoSessionState(
+  isOpen: true,
+  graph: GraphSnapshotView(
+    rows: <GraphRow>[for (final _ in _oids) _row()],
+    oidsHex: _oids,
+    parentPool: const <int>[],
+    laneCount: 1,
+    complete: true,
+    truncated: false,
+  ),
+  commitMetaCache: <String, CommitMeta>{
+    for (final String oid in _oids)
+      oid: _meta(oid, 'subject ${oid.substring(0, 4)}'),
+  },
+);
+
+late ProviderContainer _container;
+
+Future<void> _pump(WidgetTester tester) async {
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _identity,
+    _state(),
+  );
+  _container = ProviderContainer(
+    overrides: <Override>[
+      repoSessionProvider(_identity).overrideWith((ref) => fake),
+    ],
+  );
+  addTearDown(_container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: _container,
+      child: MaterialApp(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        home: Scaffold(body: CommitGraphView(identity: _identity)),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+ListSelection<String> get _selection =>
+    _container.read(commitSelectionProvider(_identity));
+
+Finder _rowFor(String oid) => find.byWidgetPredicate(
+  (Widget widget) => widget is CommitRow && widget.oidHex == oid,
+);
+
+Future<void> _tap(WidgetTester tester, String oid) async {
+  await tester.tap(_rowFor(oid));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapWith(
+  WidgetTester tester,
+  String oid,
+  LogicalKeyboardKey modifier,
+) async {
+  await tester.sendKeyDownEvent(modifier);
+  await tester.tap(_rowFor(oid));
+  await tester.pumpAndSettle();
+  await tester.sendKeyUpEvent(modifier);
+}
+
+void main() {
+  // currentSelectionGesture() branches on defaultTargetPlatform, so the
+  // toggle modifier under test has to match whatever platform the test
+  // runner reports -- otherwise a Ctrl-click here would read as a plain
+  // click and the assertion would pass or fail for the wrong reason.
+  final LogicalKeyboardKey toggleKey =
+      debugDefaultTargetPlatformOverride == TargetPlatform.macOS ||
+          defaultTargetPlatform == TargetPlatform.macOS
+      ? LogicalKeyboardKey.metaLeft
+      : LogicalKeyboardKey.controlLeft;
+
+  group('MULTIKEYS mouse rows', () {
+    testWidgets('a plain click selects only that row', (tester) async {
+      await _pump(tester);
+      await _tap(tester, _oid('c'));
+      expect(_selection.items, <String>[_oid('c')]);
+      expect(_selection.anchor, _oid('c'));
+    });
+
+    testWidgets('the toggle modifier adds a second, non-adjacent row', (
+      tester,
+    ) async {
+      await _pump(tester);
+      await _tap(tester, _oid('a'));
+      await _tapWith(tester, _oid('c'), toggleKey);
+      expect(_selection.items, <String>[_oid('a'), _oid('c')]);
+      expect(_selection.anchor, _oid('c'));
+    });
+
+    testWidgets('the toggle modifier removes an already-selected row', (
+      tester,
+    ) async {
+      await _pump(tester);
+      await _tap(tester, _oid('a'));
+      await _tapWith(tester, _oid('c'), toggleKey);
+      await _tapWith(tester, _oid('a'), toggleKey);
+      expect(_selection.items, <String>[_oid('c')]);
+    });
+
+    testWidgets('Shift selects the inclusive range from the anchor', (
+      tester,
+    ) async {
+      await _pump(tester);
+      await _tap(tester, _oid('b'));
+      await _tapWith(tester, _oid('d'), LogicalKeyboardKey.shiftLeft);
+      expect(_selection.items, <String>[_oid('b'), _oid('c'), _oid('d')]);
+      expect(_selection.anchor, _oid('b'));
+    });
+
+    testWidgets('every selected row renders as selected, not just the anchor', (
+      tester,
+    ) async {
+      await _pump(tester);
+      await _tap(tester, _oid('b'));
+      await _tapWith(tester, _oid('d'), LogicalKeyboardKey.shiftLeft);
+
+      for (final String oid in <String>[_oid('b'), _oid('c'), _oid('d')]) {
+        expect(
+          tester.widget<CommitRow>(_rowFor(oid)).selected,
+          isTrue,
+          reason: '$oid should render selected',
+        );
+      }
+      expect(tester.widget<CommitRow>(_rowFor(_oid('a'))).selected, isFalse);
+    });
+  });
+
+  group('MULTIKEYS right-click rows', () {
+    testWidgets('right-clicking an unselected row collapses to just it '
+        'before the menu opens', (tester) async {
+      await _pump(tester);
+      await _tap(tester, _oid('a'));
+      await _tapWith(tester, _oid('b'), toggleKey);
+      expect(_selection.length, 2);
+
+      await tester.tap(_rowFor(_oid('d')), buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, <String>[_oid('d')]);
+    });
+
+    testWidgets('right-clicking an already-selected row leaves the '
+        'selection alone', (tester) async {
+      await _pump(tester);
+      await _tap(tester, _oid('a'));
+      await _tapWith(tester, _oid('b'), toggleKey);
+
+      await tester.tap(_rowFor(_oid('a')), buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, <String>[_oid('a'), _oid('b')]);
+    });
+  });
+
+  group('MULTIKEYS keyboard rows', () {
+    testWidgets('Shift+Down extends the range one row', (tester) async {
+      await _pump(tester);
+      await _tap(tester, _oid('b'));
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, <String>[_oid('b'), _oid('c')]);
+    });
+
+    testWidgets('Shift+Up after Shift+Down shrinks the same range rather '
+        'than jumping', (tester) async {
+      await _pump(tester);
+      await _tap(tester, _oid('b'));
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, <String>[_oid('b'), _oid('c')]);
+    });
+
+    testWidgets('Ctrl/Cmd+A selects the whole list', (tester) async {
+      await _pump(tester);
+      await _tap(tester, _oid('c'));
+
+      await tester.sendKeyDownEvent(toggleKey);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(toggleKey);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, _oids);
+      expect(
+        _selection.anchor,
+        _oid('c'),
+        reason: 'a present anchor stays put',
+      );
+    });
+
+    testWidgets('Esc collapses to the anchor rather than clearing', (
+      tester,
+    ) async {
+      await _pump(tester);
+      await _tap(tester, _oid('b'));
+      await _tapWith(tester, _oid('d'), LogicalKeyboardKey.shiftLeft);
+      expect(_selection.length, 3);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, <String>[_oid('b')]);
+      expect(_selection.anchor, _oid('b'));
+    });
+  });
+}

--- a/app_flutter/test/features/history_graph/commit_graph_multi_select_test.dart
+++ b/app_flutter/test/features/history_graph/commit_graph_multi_select_test.dart
@@ -129,17 +129,16 @@ Future<void> _tapWith(
   await tester.sendKeyUpEvent(modifier);
 }
 
-void main() {
-  // currentSelectionGesture() branches on defaultTargetPlatform, so the
-  // toggle modifier under test has to match whatever platform the test
-  // runner reports -- otherwise a Ctrl-click here would read as a plain
-  // click and the assertion would pass or fail for the wrong reason.
-  final LogicalKeyboardKey toggleKey =
-      debugDefaultTargetPlatformOverride == TargetPlatform.macOS ||
-          defaultTargetPlatform == TargetPlatform.macOS
-      ? LogicalKeyboardKey.metaLeft
-      : LogicalKeyboardKey.controlLeft;
+/// currentSelectionGesture() branches on defaultTargetPlatform, so the toggle
+/// modifier under test has to match whatever platform the test runner
+/// reports -- otherwise a Ctrl-click here would read as a plain click and the
+/// assertion would pass or fail for the wrong reason.
+final LogicalKeyboardKey toggleKey =
+    defaultTargetPlatform == TargetPlatform.macOS
+    ? LogicalKeyboardKey.metaLeft
+    : LogicalKeyboardKey.controlLeft;
 
+void main() {
   group('MULTIKEYS mouse rows', () {
     testWidgets('a plain click selects only that row', (tester) async {
       await _pump(tester);
@@ -281,6 +280,29 @@ void main() {
 
       expect(_selection.items, <String>[_oid('b')]);
       expect(_selection.anchor, _oid('b'));
+    });
+  });
+
+  group('Ctrl/Cmd+A stays scoped to the list', () {
+    testWidgets('does nothing to the selection while the filter field '
+        'holds focus', (tester) async {
+      // The binding lives in _SelectionShortcuts, not in the app-wide
+      // WorkspaceActionShortcuts, precisely so the same key still means
+      // "select all text" in a field. If it ever migrates upward this
+      // fails, which is the point.
+      await _pump(tester);
+      await _tap(tester, _oid('c'));
+      expect(_selection.length, 1);
+
+      await tester.tap(find.byType(TextField));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(toggleKey);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(toggleKey);
+      await tester.pumpAndSettle();
+
+      expect(_selection.items, <String>[_oid('c')]);
     });
   });
 }

--- a/app_flutter/test/features/history_graph/commit_menu_items_test.dart
+++ b/app_flutter/test/features/history_graph/commit_menu_items_test.dart
@@ -1,0 +1,176 @@
+// MULTIACTS' gating rules for the 05-E commit menu: which items stay live
+// for a multi-selection, which are kept-but-disabled with a reason, and how
+// the labels report the count. Catalog parity itself is asserted in
+// context_menu_parity_test.dart; this file covers the states that catalog
+// does not describe.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/commit_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+List<GbmMenuItem> _items({
+  int count = 1,
+  bool contiguous = true,
+  bool conflictActive = false,
+}) => commitMenuItems(
+  count: count,
+  contiguous: contiguous,
+  conflictActive: conflictActive,
+  onCopySha: () {},
+  onCheckout: () {},
+  onMerge: () {},
+  onCherryPick: () {},
+  onCreateBranchHere: () {},
+  onCompare: () {},
+  onRebaseOntoHere: () {},
+  onResetBranchHere: () {},
+  onRevert: () {},
+  onExportAsPatch: () {},
+  onCompareWithWorkingCopy: () {},
+);
+
+GbmMenuItem _find(List<GbmMenuItem> items, String startsWith) {
+  for (final GbmMenuItem item in items) {
+    if (item.label.startsWith(startsWith)) return item;
+    for (final GbmMenuItem child in item.children) {
+      if (child.label.startsWith(startsWith)) return child;
+    }
+  }
+  fail('no item starting with "$startsWith"');
+}
+
+void main() {
+  group('single selection', () {
+    test('everything with a callback is enabled', () {
+      for (final GbmMenuItem item in _items()) {
+        if (item.isSubmenuTrigger) {
+          for (final GbmMenuItem child in item.children) {
+            expect(child.enabled, isTrue, reason: child.label);
+          }
+          continue;
+        }
+        expect(item.enabled, isTrue, reason: item.label);
+      }
+    });
+
+    test('an action with no callback is disabled rather than hidden', () {
+      // Spec page 13: 「保留但 disabled…不隱藏 — 隱藏會讓人以為功能不存在」.
+      final List<GbmMenuItem> items = commitMenuItems(
+        count: 1,
+        contiguous: true,
+        conflictActive: false,
+        onCopySha: () {},
+      );
+      expect(items.length, 7, reason: 'all 7 top-level items still render');
+      final GbmMenuItem checkout = _find(items, 'Checkout');
+      expect(checkout.enabled, isFalse);
+      expect(checkout.onTap, isNull, reason: 'enabled alone is only visual');
+    });
+  });
+
+  group('multi-selection labels carry the count', () {
+    test('cherry-pick, revert, copy and export are pluralised', () {
+      final List<GbmMenuItem> items = _items(count: 3);
+      expect(_find(items, 'Cherry-pick').label, 'Cherry-pick 3 commits');
+      expect(_find(items, 'Copy').label, 'Copy 3 SHAs');
+      expect(_find(items, 'Revert').label, 'Revert 3 commits');
+      expect(_find(items, 'Export').label, 'Export 3 patches…');
+    });
+
+    test('single-target items keep their singular label', () {
+      final List<GbmMenuItem> items = _items(count: 3);
+      expect(_find(items, 'Checkout').label, 'Checkout this commit');
+      expect(_find(items, 'Merge').label, 'Merge into current');
+    });
+  });
+
+  group('MULTIACTS: single-target actions are disabled with a reason', () {
+    test('checkout / merge / create branch / reset / rebase / compare-with-'
+        'working-copy all explain themselves', () {
+      final List<GbmMenuItem> items = _items(count: 3);
+      for (final String label in <String>[
+        'Checkout',
+        'Merge',
+        'Create branch',
+        'Reset branch',
+        'Rebase onto',
+        'Compare with working copy',
+      ]) {
+        final GbmMenuItem item = _find(items, label);
+        expect(item.enabled, isFalse, reason: label);
+        expect(item.onTap, isNull, reason: label);
+        expect(item.tooltip, kSingleCommitOnlyTooltip, reason: label);
+      }
+    });
+
+    test('copy SHA and export stay live -- MULTIACTS lists both as '
+        'multi-capable', () {
+      final List<GbmMenuItem> items = _items(count: 3);
+      expect(_find(items, 'Copy').enabled, isTrue);
+      expect(_find(items, 'Export').enabled, isTrue);
+    });
+  });
+
+  group('MULTIACTS: contiguity gates cherry-pick and revert', () {
+    test('a contiguous multi-selection leaves both live', () {
+      final List<GbmMenuItem> items = _items(count: 3);
+      expect(_find(items, 'Cherry-pick').enabled, isTrue);
+      expect(_find(items, 'Revert').enabled, isTrue);
+    });
+
+    test('a gappy multi-selection disables both with the reason', () {
+      final List<GbmMenuItem> items = _items(count: 3, contiguous: false);
+      for (final String label in <String>['Cherry-pick', 'Revert']) {
+        final GbmMenuItem item = _find(items, label);
+        expect(item.enabled, isFalse, reason: label);
+        expect(item.onTap, isNull, reason: label);
+        expect(item.tooltip, kContiguousOnlyTooltip, reason: label);
+      }
+    });
+
+    test('contiguity is irrelevant to a single selection', () {
+      final List<GbmMenuItem> items = _items(contiguous: false);
+      expect(_find(items, 'Cherry-pick').enabled, isTrue);
+      expect(_find(items, 'Revert').enabled, isTrue);
+    });
+  });
+
+  group('Compare takes one or two commits', () {
+    test('one or two are fine', () {
+      expect(_find(_items(), 'Compare with…').enabled, isTrue);
+      expect(_find(_items(count: 2), 'Compare with…').enabled, isTrue);
+    });
+
+    test('three or more is disabled -- a comparison has two ends', () {
+      final GbmMenuItem compare = _find(_items(count: 3), 'Compare with…');
+      expect(compare.enabled, isFalse);
+      expect(compare.tooltip, kTwoCommitsAtMostTooltip);
+    });
+  });
+
+  group('spec page 07: mid-conflict', () {
+    test('every HEAD-moving item is disabled and says why', () {
+      final List<GbmMenuItem> items = _items(conflictActive: true);
+      for (final String label in <String>[
+        'Checkout',
+        'Merge',
+        'Cherry-pick',
+        'Create branch',
+        'Rebase onto',
+        'Reset branch',
+        'Revert',
+      ]) {
+        final GbmMenuItem item = _find(items, label);
+        expect(item.enabled, isFalse, reason: label);
+        expect(item.tooltip, kConflictActiveTooltip, reason: label);
+      }
+    });
+
+    test('read-only items stay live -- a conflict does not make reading '
+        'history unsafe', () {
+      final List<GbmMenuItem> items = _items(conflictActive: true);
+      expect(_find(items, 'Compare with…').enabled, isTrue);
+      expect(_find(items, 'Copy').enabled, isTrue);
+      expect(_find(items, 'Export').enabled, isTrue);
+    });
+  });
+}

--- a/app_flutter/test/features/history_graph/commit_selection_summary_test.dart
+++ b/app_flutter/test/features/history_graph/commit_selection_summary_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/list_selection.dart';
+import 'package:gbm_flutter/features/history_graph/commit_selection_summary.dart';
+
+void main() {
+  const List<String> snapshot = <String>['c5', 'c4', 'c3', 'c2', 'c1'];
+
+  ListSelection<String> selecting(List<String> items) =>
+      ListSelection<String>(items: items, anchor: items.lastOrNull);
+
+  group('commitSelectionSummary', () {
+    test('is null with nothing selected', () {
+      expect(
+        commitSelectionSummary(
+          selection: const ListSelection<String>(),
+          allOids: snapshot,
+        ),
+        isNull,
+      );
+    });
+
+    test('is null for a single commit', () {
+      // Deliberate: a lone commit has nothing to be contiguous with, so the
+      // status bar keeps showing branch/ahead/behind instead of filler.
+      expect(
+        commitSelectionSummary(
+          selection: selecting(<String>['c3']),
+          allOids: snapshot,
+        ),
+        isNull,
+      );
+    });
+
+    test('reports count and contiguity for an unbroken run', () {
+      expect(
+        commitSelectionSummary(
+          selection: selecting(<String>['c4', 'c3', 'c2']),
+          allOids: snapshot,
+        ),
+        '3 commits · contiguous',
+      );
+    });
+
+    test('reports a gap as not contiguous', () {
+      expect(
+        commitSelectionSummary(
+          selection: selecting(<String>['c5', 'c3']),
+          allOids: snapshot,
+        ),
+        '2 commits · not contiguous',
+      );
+    });
+
+    test('selection order does not decide contiguity', () {
+      // Ctrl-clicking bottom-up builds the selection in reverse insertion
+      // order; the run is still a run.
+      expect(
+        commitSelectionSummary(
+          selection: selecting(<String>['c2', 'c4', 'c3']),
+          allOids: snapshot,
+        ),
+        '3 commits · contiguous',
+      );
+    });
+
+    test('a commit missing from the snapshot is not contiguous', () {
+      // Matches ListSelection.isContiguousIn: an oid the snapshot no longer
+      // holds cannot be part of a replayable range, so the honest answer is
+      // no -- not a throw, and not a silent drop that would shrink the count.
+      expect(
+        commitSelectionSummary(
+          selection: selecting(<String>['c4', 'gone']),
+          allOids: snapshot,
+        ),
+        '2 commits · not contiguous',
+      );
+    });
+  });
+}

--- a/app_flutter/test/features/history_graph/widgets/commit_row_test.dart
+++ b/app_flutter/test/features/history_graph/widgets/commit_row_test.dart
@@ -88,7 +88,12 @@ void main() {
         expect(find.text('Copy SHA'), findsOneWidget);
       });
 
-      testWidgets('context menu omits merge and compare items', (tester) async {
+      testWidgets('merge and compare render disabled rather than omitted '
+          'when the caller offers no destination', (tester) async {
+        // Spec page 13 is explicit that an unavailable action is kept and
+        // disabled, not hidden: 「不隱藏 — 隱藏會讓人以為功能不存在」. This
+        // used to assert the opposite (findsNothing) back when 05-E was
+        // hand-written and short of the catalog.
         final row = _row();
         await pumpGbmWidget(
           tester,
@@ -107,8 +112,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Merge into current'), findsNothing);
-        expect(find.text('Compare with'), findsNothing);
+        expect(find.text('Merge into current'), findsOneWidget);
+        expect(find.text('Compare with…'), findsOneWidget);
       });
 
       testWidgets('cherry-pick callback is invoked when menu item tapped', (
@@ -161,6 +166,10 @@ void main() {
         );
         await tester.pumpAndSettle();
 
+        // Revert lives under "More actions" in the catalog, not at top
+        // level -- it moved there when 05-E was brought to parity.
+        await tester.tap(find.text('More actions'));
+        await tester.pumpAndSettle();
         expect(find.text('Revert commit'), findsOneWidget);
 
         await tester.tap(find.text('Revert commit'));
@@ -194,7 +203,8 @@ void main() {
         expect(find.text('Create branch here…'), findsOneWidget);
       });
 
-      testWidgets('context menu omitted actions do not appear', (tester) async {
+      testWidgets('actions with no callback render disabled, and Copy SHA '
+          'still works on its own', (tester) async {
         final row = _row();
         await pumpGbmWidget(
           tester,
@@ -214,11 +224,15 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Checkout this commit'), findsNothing);
-        expect(find.text('Cherry-pick'), findsNothing);
-        expect(find.text('Create branch here…'), findsNothing);
-        expect(find.text('Revert commit'), findsNothing);
-        // Copy SHA always appears
+        // Present, per the spec's keep-and-disable rule...
+        for (final String label in <String>[
+          'Checkout this commit',
+          'Cherry-pick',
+          'Create branch here…',
+        ]) {
+          expect(find.text(label), findsOneWidget, reason: label);
+        }
+        // ...and Copy SHA has a built-in fallback, so it is genuinely live.
         expect(find.text('Copy SHA'), findsOneWidget);
       });
     });

--- a/app_flutter/test/features/sidebar/branch_context_menu_test.dart
+++ b/app_flutter/test/features/sidebar/branch_context_menu_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/data/models/ref_snapshot.dart';
 import 'package:gbm_flutter/features/sidebar/widgets/branch_tree_item.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/local_branch_menu_items.dart';
 import 'package:gbm_flutter/theme/tokens.dart';
 
 import '../../support/pump_app.dart';
@@ -110,16 +111,19 @@ void main() {
       );
       await _rightClick(tester, find.byType(BranchTreeItem));
 
-      expect(find.text('Checkout feature/x'), findsOneWidget);
-      expect(find.text('New branch from here'), findsOneWidget);
-      expect(find.text('Rename branch'), findsOneWidget);
-      expect(find.text('Merge into current branch'), findsOneWidget);
+      expect(find.text('Checkout'), findsOneWidget);
+      expect(find.text('New branch from here…'), findsOneWidget);
+      expect(find.text('Rename…'), findsOneWidget);
+      expect(find.text('Merge into current'), findsOneWidget);
       expect(find.text('Copy branch name'), findsOneWidget);
-      expect(find.text('Delete branch'), findsOneWidget);
+      expect(find.text('Delete branch…'), findsOneWidget);
     },
   );
 
-  testWidgets('the HEAD branch has no Checkout entry', (tester) async {
+  testWidgets('the HEAD branch keeps Checkout but disables it', (tester) async {
+    // It used to be omitted, which left the HEAD row's menu one item short
+    // of the 05-B catalog. Spec page 13 is explicit that an unavailable
+    // action stays visible with a reason rather than disappearing.
     await _pump(
       tester,
       BranchTreeItem(
@@ -129,7 +133,12 @@ void main() {
       ),
     );
     await _rightClick(tester, find.byType(BranchTreeItem));
-    expect(find.textContaining('Checkout'), findsNothing);
+
+    expect(find.text('Checkout'), findsOneWidget);
+    final Tooltip tooltip = tester.widget<Tooltip>(
+      find.ancestor(of: find.text('Checkout'), matching: find.byType(Tooltip)),
+    );
+    expect(tooltip.message, kAlreadyOnBranchTooltip);
   });
 
   testWidgets('Delete branch is styled danger', (tester) async {
@@ -138,11 +147,11 @@ void main() {
       BranchTreeItem(ref: _branch(), onCheckout: () {}, onDelete: () {}),
     );
     await _rightClick(tester, find.byType(BranchTreeItem));
-    final Text label = tester.widget<Text>(find.text('Delete branch'));
+    final Text label = tester.widget<Text>(find.text('Delete branch…'));
     expect(label.style?.color, tokensFor(GbmThemeVariant.darkTechnical).danger);
   });
 
-  testWidgets('tapping Rename branch invokes onRename and closes the menu', (
+  testWidgets('tapping Rename… invokes onRename and closes the menu', (
     tester,
   ) async {
     bool renamed = false;
@@ -155,13 +164,13 @@ void main() {
       ),
     );
     await _rightClick(tester, find.byType(BranchTreeItem));
-    await tester.tap(find.text('Rename branch'));
+    await tester.tap(find.text('Rename…'));
     await tester.pumpAndSettle();
     expect(renamed, isTrue);
-    expect(find.text('Rename branch'), findsNothing);
+    expect(find.text('Rename…'), findsNothing);
   });
 
-  group('conflict gate on Rename branch (spec P13: "分支正在被 rebase/merge '
+  group('conflict gate on Rename… (spec P13: "分支正在被 rebase/merge '
       '佔用 -> 整個 dialog 不開啟")', () {
     testWidgets('renders dimmed while a sequencer operation is active', (
       tester,
@@ -176,7 +185,7 @@ void main() {
         ),
       );
       await _rightClick(tester, find.byType(BranchTreeItem));
-      final Text label = tester.widget<Text>(find.text('Rename branch'));
+      final Text label = tester.widget<Text>(find.text('Rename…'));
       expect(
         label.style?.color,
         tokensFor(GbmThemeVariant.darkTechnical).textTertiary,
@@ -197,7 +206,7 @@ void main() {
         ),
       );
       await _rightClick(tester, find.byType(BranchTreeItem));
-      await tester.tap(find.text('Rename branch'));
+      await tester.tap(find.text('Rename…'));
       await tester.pumpAndSettle();
       expect(
         renamed,
@@ -229,10 +238,10 @@ void main() {
         expect(find.text('Copy branch name'), findsOneWidget);
         expect(find.text('Prune this ref'), findsOneWidget);
         expect(find.text('Delete on remote…'), findsOneWidget);
-        expect(find.text('Rename branch'), findsNothing);
-        expect(find.text('Delete branch'), findsNothing);
-        expect(find.text('Merge into current branch'), findsNothing);
-        expect(find.text('New branch from here'), findsNothing);
+        expect(find.text('Rename…'), findsNothing);
+        expect(find.text('Delete branch…'), findsNothing);
+        expect(find.text('Merge into current'), findsNothing);
+        expect(find.text('New branch from here…'), findsNothing);
       },
     );
 
@@ -392,10 +401,10 @@ void main() {
       expect(find.text('Copy branch name'), findsOneWidget);
       expect(find.text('Prune this ref'), findsOneWidget);
       expect(find.text('Delete on remote…'), findsOneWidget);
-      expect(find.text('Rename branch'), findsNothing);
-      expect(find.text('Delete branch'), findsNothing);
-      expect(find.text('Merge into current branch'), findsNothing);
-      expect(find.text('New branch from here'), findsNothing);
+      expect(find.text('Rename…'), findsNothing);
+      expect(find.text('Delete branch…'), findsNothing);
+      expect(find.text('Merge into current'), findsNothing);
+      expect(find.text('New branch from here…'), findsNothing);
     });
 
     testWidgets(
@@ -516,9 +525,9 @@ void main() {
       expect(find.text('Compare with…'), findsOneWidget);
       expect(find.text('Copy tag name'), findsOneWidget);
       expect(find.text('Delete tag…'), findsOneWidget);
-      expect(find.text('Rename branch'), findsNothing);
-      expect(find.text('Delete branch'), findsNothing);
-      expect(find.text('Merge into current branch'), findsNothing);
+      expect(find.text('Rename…'), findsNothing);
+      expect(find.text('Delete branch…'), findsNothing);
+      expect(find.text('Merge into current'), findsNothing);
     });
 
     testWidgets('Delete tag… is styled danger', (tester) async {

--- a/app_flutter/test/features/sidebar/local_branch_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/local_branch_menu_items_test.dart
@@ -1,0 +1,99 @@
+// The 05-B gating rules the catalog itself does not describe: which items
+// spec page 07 disables mid-conflict, and the two reasons an item can be
+// kept-but-disabled. Catalog parity is asserted in
+// context_menu_parity_test.dart.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/local_branch_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+List<GbmMenuItem> _items({
+  bool isCurrent = false,
+  bool conflictActive = false,
+}) => localBranchMenuItems(
+  branchName: 'feature/x',
+  isCurrent: isCurrent,
+  conflictActive: conflictActive,
+  onCheckout: () {},
+  onNewBranchFromHere: () {},
+  onRename: () {},
+  onMerge: () {},
+  onRebaseOntoHere: () {},
+  onCompare: () {},
+  onDelete: () {},
+);
+
+GbmMenuItem _find(List<GbmMenuItem> items, String label) =>
+    items.firstWhere((GbmMenuItem i) => i.label == label);
+
+void main() {
+  test('a clean, non-current branch has everything enabled', () {
+    for (final GbmMenuItem item in _items()) {
+      if (item.separator) continue;
+      expect(item.enabled, isTrue, reason: item.label);
+    }
+  });
+
+  test('spec page 07: every ref-moving item is disabled mid-conflict, '
+      'including the three that were ungated before this extraction', () {
+    final List<GbmMenuItem> items = _items(conflictActive: true);
+    for (final String label in <String>[
+      'Checkout',
+      'New branch from here…',
+      'Rename…',
+      'Merge into current',
+      'Rebase current onto here',
+      'Delete branch…',
+    ]) {
+      final GbmMenuItem item = _find(items, label);
+      expect(item.enabled, isFalse, reason: label);
+      expect(
+        item.onTap,
+        isNull,
+        reason: '$label: enabled alone is only a visual signal',
+      );
+      expect(item.tooltip, kBranchConflictTooltip, reason: label);
+    }
+  });
+
+  test('the read-only items stay live mid-conflict', () {
+    final List<GbmMenuItem> items = _items(conflictActive: true);
+    expect(_find(items, 'Compare with…').enabled, isTrue);
+    expect(_find(items, 'Copy branch name').enabled, isTrue);
+  });
+
+  test('the current branch cannot be checked out, and says why', () {
+    final GbmMenuItem checkout = _find(_items(isCurrent: true), 'Checkout');
+    expect(checkout.enabled, isFalse);
+    expect(checkout.onTap, isNull);
+    expect(checkout.tooltip, kAlreadyOnBranchTooltip);
+  });
+
+  test('an item with no callback is still rendered, just disabled', () {
+    final List<GbmMenuItem> items = localBranchMenuItems(
+      branchName: 'feature/x',
+      isCurrent: false,
+      conflictActive: false,
+    );
+    expect(
+      items.where((GbmMenuItem i) => !i.separator).length,
+      8,
+      reason: 'all 8 catalog items render regardless of wiring',
+    );
+    expect(_find(items, 'Rebase current onto here').enabled, isFalse);
+    // Copy branch name has a built-in clipboard action, so it needs no
+    // caller and is always live.
+    expect(_find(items, 'Copy branch name').enabled, isTrue);
+  });
+
+  test('Delete branch… is the last item and is styled danger', () {
+    final List<GbmMenuItem> items = _items();
+    final GbmMenuItem last = items.lastWhere((GbmMenuItem i) => !i.separator);
+    expect(last.label, 'Delete branch…');
+    expect(last.danger, isTrue);
+    expect(
+      items[items.length - 2].separator,
+      isTrue,
+      reason: 'a danger item must be preceded by a separator',
+    );
+  });
+}

--- a/app_flutter/test/features/sidebar/multi_branch_menu_items_test.dart
+++ b/app_flutter/test/features/sidebar/multi_branch_menu_items_test.dart
@@ -1,0 +1,114 @@
+// Spec page 13's MULTIBRANCHMENU. The catalog in gbm_context_menus.dart
+// covers spec page *05* only, so there is no parity test to lean on here --
+// these assertions are the acceptance baseline for this menu.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/local_branch_menu_items.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/multi_branch_menu_items.dart';
+import 'package:gbm_flutter/widgets/gbm_menu.dart';
+
+List<GbmMenuItem> _items({
+  int count = 3,
+  bool conflictActive = false,
+  bool fetchable = true,
+  bool pushable = true,
+  bool comparable = false,
+}) => multiBranchMenuItems(
+  count: count,
+  conflictActive: conflictActive,
+  onCopyNames: () {},
+  onFetch: fetchable ? () {} : null,
+  onPush: pushable ? () {} : null,
+  fetchBlockedReason: fetchable ? null : 'no upstream',
+  pushBlockedReason: pushable ? null : 'no remote',
+  onCompare: comparable ? () {} : null,
+  onDelete: () {},
+);
+
+GbmMenuItem _find(List<GbmMenuItem> items, String label) =>
+    items.firstWhere((GbmMenuItem i) => i.label == label);
+
+void main() {
+  test('the item list matches MULTIBRANCHMENU, counted labels included', () {
+    expect(
+      _items()
+          .where((GbmMenuItem i) => !i.separator)
+          .map((GbmMenuItem i) => i.label)
+          .toList(),
+      <String>[
+        'Fetch 3 branches',
+        'Push 3 branches',
+        'Checkout',
+        'Rename…',
+        'Set upstream…',
+        'Compare',
+        'Copy branch names',
+        'Delete 3 branches…',
+      ],
+    );
+  });
+
+  test('the menu is a valid GbmMenu (8-item cap, danger last)', () {
+    expect(() => validateGbmMenuItems(_items()), returnsNormally);
+  });
+
+  test('the three 單項 items are kept, disabled and explained -- never '
+      'hidden, per spec page 13', () {
+    final List<GbmMenuItem> items = _items();
+    for (final String label in <String>[
+      'Checkout',
+      'Rename…',
+      'Set upstream…',
+    ]) {
+      final GbmMenuItem item = _find(items, label);
+      expect(item.enabled, isFalse, reason: label);
+      expect(
+        item.onTap,
+        isNull,
+        reason: '$label: enabled alone is only a visual signal',
+      );
+      expect(item.tooltip, kSingleBranchOnlyTooltip, reason: label);
+    }
+  });
+
+  test('Compare needs exactly two branches', () {
+    expect(_find(_items(count: 2, comparable: true), 'Compare').enabled, true);
+    final GbmMenuItem three = _find(_items(), 'Compare');
+    expect(three.enabled, isFalse);
+    expect(three.onTap, isNull);
+    expect(three.tooltip, 'Compare takes exactly two branches');
+  });
+
+  test('spec page 07: Push and Delete are off mid-conflict, Fetch and Copy '
+      'stay live', () {
+    final List<GbmMenuItem> items = _items(conflictActive: true);
+    for (final String label in <String>[
+      'Push 3 branches',
+      'Delete 3 branches…',
+    ]) {
+      final GbmMenuItem item = _find(items, label);
+      expect(item.enabled, isFalse, reason: label);
+      expect(item.onTap, isNull, reason: label);
+      expect(item.tooltip, kBranchConflictTooltip, reason: label);
+    }
+    expect(_find(items, 'Fetch 3 branches').enabled, isTrue);
+    expect(_find(items, 'Copy branch names').enabled, isTrue);
+  });
+
+  test(
+    'an unavailable Fetch/Push says why rather than going silently grey',
+    () {
+      final List<GbmMenuItem> items = _items(fetchable: false, pushable: false);
+      expect(_find(items, 'Fetch 3 branches').tooltip, 'no upstream');
+      expect(_find(items, 'Push 3 branches').tooltip, 'no remote');
+    },
+  );
+
+  test('mid-conflict, the conflict reason wins over the caller\'s Push '
+      'reason -- the sequencer is the blocker the user has to clear first', () {
+    final List<GbmMenuItem> items = _items(
+      conflictActive: true,
+      pushable: false,
+    );
+    expect(_find(items, 'Push 3 branches').tooltip, kBranchConflictTooltip);
+  });
+}

--- a/app_flutter/test/features/sidebar/sidebar_panel_multi_select_test.dart
+++ b/app_flutter/test/features/sidebar/sidebar_panel_multi_select_test.dart
@@ -1,0 +1,466 @@
+// Spec page 13 section B, sidebar half: MULTIKEYS' click semantics,
+// MULTIBRANCHMENU's right-click rule, and COMPARES 1's literal
+// 「同時選兩個分支 → 右鍵 Compare」.
+//
+// Driven through the real SidebarPanel / branchSelectionProvider /
+// repoSessionProvider / GoRouter seam rather than against BranchTreeItem in
+// isolation, for the reason CLAUDE.md's Testing tiers section gives: a
+// widget test proves the row renders a disabled item correctly, not that
+// the panel's own wiring ever produces one. Two of the actions asserted
+// here (Compare, Delete N branches…) dispatch by *navigation* and never
+// touch commandLog at all, so a commandLog-only test could not see them
+// regress.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/list_selection.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/models/remote_info.dart';
+import 'package:gbm_flutter/data/repositories/branch_repository.dart';
+import 'package:gbm_flutter/data/repositories/branch_selection_repository.dart';
+import 'package:gbm_flutter/data/repositories/compare_tabs_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/sidebar/sidebar_panel.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/branch_tree_item.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+final String _repoIdParam = Uri.encodeComponent(_identity.workDir);
+
+RefInfo _local(
+  String name, {
+  String upstream = '',
+  int ahead = 0,
+  bool isHead = false,
+}) => RefInfo(
+  fullName: 'refs/heads/$name',
+  shortName: name,
+  kind: RefKind.localBranch,
+  target: 'a' * 40,
+  upstream: upstream,
+  ahead: ahead,
+  behind: 0,
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: isHead,
+  isSymbolic: false,
+  worktreePath: '',
+);
+
+// Flat names with no `/`: branch_tree_builder groups `feature/x` under a
+// collapsible folder, so the row's text would be `x`, not the full name --
+// a dependency on tree rendering these tests have no business carrying.
+final RefInfo _main = _local(
+  'main',
+  upstream: 'refs/remotes/origin/main',
+  isHead: true,
+);
+final RefInfo _alpha = _local('alpha', upstream: 'refs/remotes/origin/alpha');
+final RefInfo _beta = _local('beta', upstream: 'refs/remotes/origin/beta');
+// No upstream: spec's `local` badge state, the case Push has to invent a
+// remote for.
+final RefInfo _gamma = _local('gamma');
+final RefInfo _delta = _local('delta');
+
+final RefSnapshot _refs = RefSnapshot(
+  head: HeadInfo(
+    kind: HeadKind.branch,
+    branchName: 'main',
+    fullRef: 'refs/heads/main',
+    target: 'a' * 40,
+  ),
+  refs: <RefInfo>[_main, _alpha, _beta, _gamma, _delta],
+  refCountGuardTripped: false,
+  totalRefCount: 5,
+);
+
+class _Harness {
+  _Harness({required this.fake, required this.container, required this.router});
+
+  final FakeRepoSessionController fake;
+  final ProviderContainer container;
+  final GoRouter router;
+
+  ListSelection<String> get selection =>
+      container.read(branchSelectionProvider(_identity));
+
+  set selection(ListSelection<String> value) =>
+      container.read(branchSelectionProvider(_identity).notifier).state = value;
+
+  List<FakeCommand> commands(String name) =>
+      fake.commandLog.where((FakeCommand c) => c.name == name).toList();
+}
+
+Future<_Harness> _pump(
+  WidgetTester tester, {
+  List<RemoteInfo> remotes = const <RemoteInfo>[],
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  final FakeRepoSessionController fake = FakeRepoSessionController(
+    _identity,
+    RepoSessionState(refs: _refs, remotes: remotes),
+  );
+
+  final GoRouter router = GoRouter(
+    initialLocation: '/repo/$_repoIdParam/history',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/repo/:repoId/history',
+        builder: (BuildContext context, GoRouterState state) => Scaffold(
+          body: SidebarPanel(identity: _identity, filterFocusNode: null),
+        ),
+      ),
+      GoRoute(
+        path: RoutePaths.deleteBranchesDialog,
+        builder: (BuildContext context, GoRouterState state) => Scaffold(
+          body: Text('delete-branches:${state.uri.queryParameters['names']}'),
+        ),
+      ),
+      GoRoute(
+        path: '/repo/:repoId/compare/:tabId',
+        builder: (BuildContext context, GoRouterState state) =>
+            const Scaffold(body: Text('compare-page')),
+      ),
+    ],
+  );
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoRefsProvider(_identity).overrideWithValue(_refs),
+      repoSessionProvider(_identity).overrideWith((Ref ref) => fake),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return _Harness(fake: fake, container: container, router: router);
+}
+
+Finder _row(String branch) =>
+    find.ancestor(of: find.text(branch), matching: find.byType(BranchTreeItem));
+
+/// Ctrl/Cmd-click: the modifier is read from `HardwareKeyboard` at tap
+/// time (`currentSelectionGesture()`), so the key has to be genuinely held
+/// across the tap rather than passed as a flag.
+Future<void> _modifierClick(
+  WidgetTester tester,
+  String branch,
+  LogicalKeyboardKey key,
+) async {
+  await tester.sendKeyDownEvent(key);
+  await tester.tap(_row(branch));
+  await tester.pumpAndSettle();
+  await tester.sendKeyUpEvent(key);
+}
+
+Future<void> _rightClick(WidgetTester tester, String branch) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(_row(branch)));
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+/// The labels of the menu that is currently open. Scoped to PopupMenuItem
+/// rather than the whole Overlay so the sidebar's own row text underneath
+/// does not leak in.
+List<String> _menuLabels(WidgetTester tester) => tester
+    .widgetList<Text>(
+      find.descendant(
+        of: find.byType(PopupMenuItem<void>),
+        matching: find.byType(Text),
+      ),
+    )
+    .map((Text t) => t.data ?? '')
+    .where((String s) => s.isNotEmpty)
+    .toList();
+
+void main() {
+  testWidgets('a plain click on a branch row is still a checkout, not a '
+      'selection -- MULTIKEYS is not applied to the sidebar\'s primary '
+      'interaction', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    await tester.tap(_row('alpha'));
+    await tester.pumpAndSettle();
+
+    expect(h.selection.items, isEmpty);
+    expect(h.commands('checkout'), hasLength(1));
+  });
+
+  testWidgets('Ctrl/Cmd-click toggles rows into the selection', (
+    WidgetTester tester,
+  ) async {
+    final _Harness h = await _pump(tester);
+    await _modifierClick(tester, 'alpha', LogicalKeyboardKey.controlLeft);
+    await _modifierClick(tester, 'beta', LogicalKeyboardKey.controlLeft);
+
+    expect(h.selection.items, <String>['alpha', 'beta']);
+    expect(
+      h.commands('checkout'),
+      isEmpty,
+      reason: 'a modifier click must not also check the branch out',
+    );
+
+    await _modifierClick(tester, 'alpha', LogicalKeyboardKey.controlLeft);
+    expect(h.selection.items, <String>['beta']);
+  });
+
+  testWidgets('Shift-click takes a range over the rendered rows', (
+    WidgetTester tester,
+  ) async {
+    final _Harness h = await _pump(tester);
+    await _modifierClick(tester, 'alpha', LogicalKeyboardKey.controlLeft);
+    await _modifierClick(tester, 'gamma', LogicalKeyboardKey.shiftLeft);
+
+    expect(h.selection.items, containsAll(<String>['alpha', 'beta', 'gamma']));
+    expect(
+      h.selection.items,
+      isNot(contains('main')),
+      reason: 'HEAD is excluded from the selectable rows',
+    );
+  });
+
+  testWidgets('right-clicking a selected row keeps the selection and opens '
+      'MULTIBRANCHMENU with a counted title', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'beta'],
+      anchor: 'beta',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'alpha');
+    expect(h.selection.items, <String>['alpha', 'beta']);
+    expect(find.text('2 branches selected'), findsOneWidget);
+    expect(_menuLabels(tester), contains('Delete 2 branches…'));
+  });
+
+  testWidgets('right-clicking an unselected row collapses onto it first, '
+      'then opens the ordinary 05-B menu', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'beta'],
+      anchor: 'beta',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'gamma');
+    expect(h.selection.items, <String>[
+      'gamma',
+    ], reason: 'spec page 13: 點在未選中的項目上先改為只選它，再開選單');
+    expect(_menuLabels(tester), contains('Rebase current onto here'));
+    expect(_menuLabels(tester), isNot(contains('Delete 2 branches…')));
+  });
+
+  testWidgets('Compare on a two-branch selection opens a tab with both '
+      'sides filled (COMPARES 1)', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'beta'],
+      anchor: 'beta',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'alpha');
+    await tester.tap(find.text('Compare'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('compare-page'), findsOneWidget);
+    final List<CompareTabSpec> tabs = h.container.read(
+      compareTabsProvider(_identity),
+    );
+    expect(tabs, hasLength(1));
+    expect(tabs.single.left, 'alpha');
+    expect(tabs.single.right, 'beta');
+  });
+
+  testWidgets('Delete N branches… routes to the confirmation instead of '
+      'deleting outright', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'beta'],
+      anchor: 'beta',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'alpha');
+    await tester.tap(find.text('Delete 2 branches…'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('delete-branches:alpha,beta'), findsOneWidget);
+    expect(
+      h.commands('deleteBranch'),
+      isEmpty,
+      reason: 'spec page 13 requires a per-branch confirmation first',
+    );
+  });
+
+  testWidgets('Fetch groups by the remote each upstream names', (
+    WidgetTester tester,
+  ) async {
+    final _Harness h = await _pump(tester);
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'beta'],
+      anchor: 'beta',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'alpha');
+    await tester.tap(find.text('Fetch 2 branches'));
+    await tester.pumpAndSettle();
+
+    final List<FakeCommand> fetches = h.commands('fetchRemote');
+    expect(fetches, hasLength(1), reason: 'both upstreams live on origin');
+    expect(fetches.single.args['remoteName'], 'origin');
+    expect(fetches.single.args['refs'], <String>['alpha', 'beta']);
+  });
+
+  testWidgets('Fetch is disabled, with a reason, when nothing selected has '
+      'an upstream', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    h.selection = const ListSelection<String>(
+      items: <String>['gamma', 'delta'],
+      anchor: 'delta',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'gamma');
+    // Asserted while the menu is still up: tapping the row dismisses it,
+    // taking the Tooltip with it.
+    expect(
+      find.byTooltip(
+        'None of the selected branches has an upstream to fetch from',
+      ),
+      findsOneWidget,
+      reason: 'spec page 13: a disabled row must say why, never go mute',
+    );
+
+    await tester.tap(find.text('Fetch 2 branches'));
+    await tester.pumpAndSettle();
+    expect(
+      h.commands('fetchRemote'),
+      isEmpty,
+      reason: 'no upstream means no remote-tracking ref to update',
+    );
+  });
+
+  testWidgets('Ctrl/Cmd+A selects every selectable row, and Esc collapses '
+      'back to the anchor (MULTIKEYS)', (WidgetTester tester) async {
+    final _Harness h = await _pump(tester);
+    await _modifierClick(tester, 'beta', LogicalKeyboardKey.controlLeft);
+
+    await _modifierClick(tester, 'beta', LogicalKeyboardKey.controlLeft);
+    h.selection = const ListSelection<String>(
+      items: <String>['beta'],
+      anchor: 'beta',
+    );
+    await tester.pumpAndSettle();
+
+    // Focus has to be inside the tree for the list-scoped binding to fire --
+    // that is the whole point of not registering it app-wide.
+    h.container.read(branchSelectionProvider(_identity).notifier).state =
+        const ListSelection<String>(items: <String>['beta'], anchor: 'beta');
+    await tester.tap(_row('beta'));
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(
+      h.selection.items,
+      containsAll(<String>['alpha', 'beta', 'gamma', 'delta']),
+    );
+    expect(h.selection.items, isNot(contains('main')));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(h.selection.items, <String>[
+      h.selection.anchor!,
+    ], reason: 'Esc collapses to the anchor, it does not clear');
+  });
+
+  testWidgets('Push sends one call per remote, and unpublished branches go '
+      'to the sole remote with --set-upstream', (WidgetTester tester) async {
+    final _Harness h = await _pump(
+      tester,
+      remotes: const <RemoteInfo>[
+        RemoteInfo(name: 'origin', fetchUrl: 'u', pushUrl: 'u'),
+      ],
+    );
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'beta', 'gamma'],
+      anchor: 'gamma',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'alpha');
+    await tester.tap(find.text('Push 3 branches'));
+    await tester.pumpAndSettle();
+
+    final List<FakeCommand> pushes = h.commands('pushChanges');
+    expect(pushes, hasLength(2));
+    expect(pushes[0].args['branches'], <String>['alpha', 'beta']);
+    expect(pushes[0].args['setUpstream'], isFalse);
+    expect(
+      pushes[1].args['branches'],
+      <String>['gamma'],
+      reason:
+          'kept in its own call: folding it into the origin group would '
+          'let push -u repoint a branch tracking a differently-named ref',
+    );
+    expect(pushes[1].args['setUpstream'], isTrue);
+  });
+
+  testWidgets('Push is disabled, with a reason, when an unpublished branch '
+      'has no single remote to go to', (WidgetTester tester) async {
+    final _Harness h = await _pump(
+      tester,
+      remotes: const <RemoteInfo>[
+        RemoteInfo(name: 'origin', fetchUrl: 'u', pushUrl: 'u'),
+        RemoteInfo(name: 'fork', fetchUrl: 'u', pushUrl: 'u'),
+      ],
+    );
+    h.selection = const ListSelection<String>(
+      items: <String>['alpha', 'gamma'],
+      anchor: 'gamma',
+    );
+    await tester.pumpAndSettle();
+
+    await _rightClick(tester, 'alpha');
+    await tester.tap(find.text('Push 2 branches'));
+    await tester.pumpAndSettle();
+
+    expect(
+      h.commands('pushChanges'),
+      isEmpty,
+      reason: 'the row is disabled, so its onTap is null (not merely grey)',
+    );
+  });
+}

--- a/app_flutter/test/features/status_bar/status_bar_test.dart
+++ b/app_flutter/test/features/status_bar/status_bar_test.dart
@@ -701,5 +701,107 @@ void main() {
       // Should show just the conflict count when no operation name
       expect(find.text('1 conflicted'), findsOneWidget);
     });
+    testWidgets('renders the selection summary alongside repo status', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+          home: Scaffold(
+            body: StatusBar(
+              currentBranch: 'main',
+              ahead: 0,
+              behind: 0,
+              commitCount: 42,
+              lastScanDuration: const Duration(milliseconds: 100),
+              graphLaneCapacity: 6,
+              backgroundTasks: const [],
+              hasUnreadLog: false,
+              onOpenLog: () {},
+              onCancelTask: (_) {},
+              selectionSummary: '4 commits \u00b7 contiguous',
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      // Additive, not a replacement: spec page 13 asks for the summary in the
+      // status bar without taking the repo status away.
+      expect(find.text('4 commits \u00b7 contiguous'), findsOneWidget);
+      expect(find.text('main'), findsOneWidget);
+      expect(find.text('42c'), findsOneWidget);
+    });
+
+    testWidgets('omits the selection summary when it is null', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+          home: Scaffold(
+            body: StatusBar(
+              currentBranch: 'main',
+              ahead: 0,
+              behind: 0,
+              commitCount: 42,
+              lastScanDuration: const Duration(milliseconds: 100),
+              graphLaneCapacity: 6,
+              backgroundTasks: const [],
+              hasUnreadLog: false,
+              onOpenLog: () {},
+              onCancelTask: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.textContaining('commits'), findsNothing);
+    });
+
+    testWidgets('a conflict takes zone 1 from the selection summary', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+          home: Scaffold(
+            body: StatusBar(
+              currentBranch: 'main',
+              ahead: 0,
+              behind: 0,
+              commitCount: 42,
+              lastScanDuration: const Duration(milliseconds: 100),
+              graphLaneCapacity: 6,
+              backgroundTasks: const [],
+              hasUnreadLog: false,
+              onOpenLog: () {},
+              onCancelTask: (_) {},
+              repoState: const RepoState(
+                flags: RepoStateFlags.merge,
+                isClean: false,
+                isSequencerOperation: true,
+                rebaseStep: 0,
+                rebaseTotal: 0,
+                rebaseOntoLabel: '',
+                indexLocked: false,
+                indexLockAgeSeconds: null,
+                describe: 'merging',
+              ),
+              workingCopyStatus: _createConflictedStatus(<String>['a.txt']),
+              conflictActive: true,
+              selectionSummary: '4 commits \u00b7 contiguous',
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      // The stopped sequencer is the thing that must be readable at a glance.
+      expect(find.text('MERGE \u00b7 1 conflicted'), findsOneWidget);
+      expect(find.text('4 commits \u00b7 contiguous'), findsNothing);
+    });
   });
 }

--- a/app_flutter/test/integration/sidebar_branch_compare_rebase_test.dart
+++ b/app_flutter/test/integration/sidebar_branch_compare_rebase_test.dart
@@ -1,0 +1,170 @@
+// 05-B's two previously-missing items, driven through the real
+// SidebarPanel/repoSessionProvider/GoRouter seam rather than against
+// BranchTreeItem in isolation.
+//
+// Both dispatch by navigation, not by a session command, so neither shows up
+// in FakeRepoSessionController.commandLog -- a commandLog-only assertion
+// could not see either of them regress. This checks where the router
+// actually lands and, for Compare, what CompareTabSpec was opened.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/ref_snapshot.dart';
+import 'package:gbm_flutter/data/repositories/compare_tabs_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/sidebar/sidebar_panel.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/branch_tree_item.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/theme_mode_provider.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/fake_repo_session.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+
+RefInfo _branch(String name, {bool isHead = false}) => RefInfo(
+  fullName: 'refs/heads/$name',
+  shortName: name,
+  kind: RefKind.localBranch,
+  target: 'a' * 40,
+  upstream: '',
+  ahead: 0,
+  behind: 0,
+  hasTrackingInfo: false,
+  isGone: false,
+  isHead: isHead,
+  isSymbolic: false,
+  worktreePath: '',
+);
+
+RepoSessionState _state() => RepoSessionState(
+  isOpen: true,
+  refs: RefSnapshot(
+    head: const HeadInfo(
+      kind: HeadKind.branch,
+      branchName: 'main',
+      fullRef: 'refs/heads/main',
+      target: 'a',
+    ),
+    refs: <RefInfo>[_branch('main', isHead: true), _branch('feature')],
+    refCountGuardTripped: false,
+    totalRefCount: 2,
+  ),
+);
+
+late ProviderContainer _container;
+late GoRouter _router;
+
+/// The `target` the rebase-onto route actually received -- asserted instead
+/// of the router's reported location, which for a pushed route still reads
+/// as the base path.
+String? _rebaseTarget;
+
+Future<void> _pump(WidgetTester tester) async {
+  _rebaseTarget = null;
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  _container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      repoSessionProvider(
+        _identity,
+      ).overrideWith((ref) => FakeRepoSessionController(_identity, _state())),
+    ],
+  );
+  addTearDown(_container.dispose);
+
+  _router = GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (_, _) => Scaffold(body: SidebarPanel(identity: _identity)),
+      ),
+      GoRoute(
+        path: RoutePaths.compare,
+        builder: (_, _) => const Scaffold(body: Text('compare-page')),
+      ),
+      GoRoute(
+        path: RoutePaths.rebaseOntoDialog,
+        builder: (_, GoRouterState state) {
+          _rebaseTarget = state.uri.queryParameters['target'];
+          return const Scaffold(body: Text('rebase-dialog'));
+        },
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: _container,
+      child: MaterialApp.router(
+        theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+        routerConfig: _router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openMenuOn(WidgetTester tester, String branch) async {
+  final Finder row = find.byWidgetPredicate(
+    (Widget w) => w is BranchTreeItem && w.ref.shortName == branch,
+  );
+  expect(row, findsOneWidget, reason: 'no row for $branch');
+  await tester.tap(row, buttons: kSecondaryMouseButton);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Compare with… opens a Compare tab with the branch on the '
+      'left and the right left to the picker', (tester) async {
+    await _pump(tester);
+    await _openMenuOn(tester, 'feature');
+
+    await tester.tap(find.text('Compare with…'));
+    await tester.pumpAndSettle();
+
+    final List<CompareTabSpec> tabs = _container.read(
+      compareTabsProvider(_identity),
+    );
+    expect(tabs, hasLength(1));
+    expect(tabs.single.left, 'feature');
+    expect(tabs.single.right, isNull);
+    expect(find.text('compare-page'), findsOneWidget);
+  });
+
+  testWidgets('Rebase current onto here opens the shared rebase dialog '
+      'pre-filled with that branch', (tester) async {
+    await _pump(tester);
+    await _openMenuOn(tester, 'feature');
+
+    await tester.tap(find.text('Rebase current onto here'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('rebase-dialog'), findsOneWidget);
+    expect(
+      _rebaseTarget,
+      'feature',
+      reason: 'the target query parameter is what pre-fills the dialog',
+    );
+  });
+
+  testWidgets('the current branch cannot be rebased onto itself', (
+    tester,
+  ) async {
+    await _pump(tester);
+    await _openMenuOn(tester, 'main');
+
+    await tester.tap(find.text('Rebase current onto here'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('rebase-dialog'), findsNothing);
+  });
+}

--- a/app_flutter/test/integration/workspace_rename_branch_flow_test.dart
+++ b/app_flutter/test/integration/workspace_rename_branch_flow_test.dart
@@ -253,7 +253,7 @@ void main() {
     // only one not routed through isActionEnabled(): BranchTreeItem takes a
     // plain `conflictActive` param, so it needs its own transition coverage
     // per CLAUDE.md's rule at the end of "Action availability state machine".
-    testWidgets('the sidebar\'s 05-B Rename branch opens the dialog seeded '
+    testWidgets('the sidebar\'s 05-B Rename… opens the dialog seeded '
         'with the clicked branch', (tester) async {
       await pumpWorkspace(
         tester,
@@ -263,7 +263,7 @@ void main() {
       );
 
       await _openBranchMenu(tester);
-      await tester.tap(find.text('Rename branch'));
+      await tester.tap(find.text('Rename…'));
       await tester.pumpAndSettle();
 
       expect(find.byType(RenameBranchDialogContent), findsOneWidget);
@@ -284,7 +284,7 @@ void main() {
       );
 
       await _openBranchMenu(tester);
-      await tester.tap(find.text('Rename branch'));
+      await tester.tap(find.text('Rename…'));
       await tester.pumpAndSettle();
       expect(
         find.byType(RenameBranchDialogContent),
@@ -299,7 +299,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await _openBranchMenu(tester);
-      await tester.tap(find.text('Rename branch'));
+      await tester.tap(find.text('Rename…'));
       await tester.pumpAndSettle();
       expect(find.byType(RenameBranchDialogContent), findsOneWidget);
     });

--- a/app_flutter/test/integration/workspace_select_all_dispatch_test.dart
+++ b/app_flutter/test/integration/workspace_select_all_dispatch_test.dart
@@ -1,0 +1,104 @@
+// The three-path invariant for GbmActionId.editSelectAll, plus the focus
+// routing that makes one Ctrl/Cmd+A mean two different things.
+//
+// CLAUDE.md's Intent / Action layer: keyboard, macOS system menu and the
+// in-window menu all read the ONE map WorkspaceScreen._buildActionHandlers()
+// builds. A null entry greys the macOS item and silently no-ops the
+// keyboard path while the in-window menu keeps working -- the shape a real
+// shipped bug already took once. Ctrl/Cmd+A is the riskiest id to get wrong
+// here, because it is also every TextField's "select all text": binding it
+// app-wide with a list-only handler would break typing everywhere.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/actions/gbm_action_id.dart';
+import 'package:gbm_flutter/actions/gbm_menu_model.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/features/workspace/widgets/menu_bar_row.dart';
+
+import '../support/pump_workspace.dart';
+
+void main() {
+  final RepoIdentity identity = RepoIdentity(
+    workDir: '/test/repo',
+    gitDir: '/test/repo/.git',
+  );
+
+  testWidgets('editSelectAll is a real, non-null entry in the one shared '
+      'handler map', (tester) async {
+    await pumpWorkspace(tester, identity: identity);
+
+    final MenuBarRow menuBar = tester.widget<MenuBarRow>(
+      find.byType(MenuBarRow),
+    );
+    expect(
+      menuBar.actionHandlers.containsKey(GbmActionId.editSelectAll),
+      isTrue,
+      reason: 'the map every dispatch path reads must carry the id',
+    );
+    expect(
+      menuBar.actionHandlers[GbmActionId.editSelectAll],
+      isNotNull,
+      reason:
+          'a null here greys the macOS menu item and no-ops the keyboard '
+          'path while the in-window menu still works',
+    );
+  });
+
+  testWidgets('Edit -> Select all renders in the in-window menu', (
+    tester,
+  ) async {
+    await pumpWorkspace(tester, identity: identity);
+
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Select all'), findsOneWidget);
+  });
+
+  testWidgets('the menu model lists it under Edit, right after Paste', (
+    tester,
+  ) async {
+    final GbmMenuModel edit = gbmMenus.firstWhere(
+      (GbmMenuModel menu) => menu.title == 'Edit',
+    );
+    final List<GbmActionId> ids = <GbmActionId>[
+      for (final GbmMenuItemModel item in edit.items) item.id,
+    ];
+    expect(
+      ids.indexOf(GbmActionId.editSelectAll),
+      ids.indexOf(GbmActionId.editPaste) + 1,
+    );
+  });
+
+  testWidgets('Ctrl+A over a focused text field still selects its text, '
+      'not anything else', (tester) async {
+    // The handler routes by focus rather than owning the key outright, so
+    // a field keeps the behaviour the OS trained the user to expect.
+    final TextEditingController controller = TextEditingController(
+      text: 'hello world',
+    );
+    addTearDown(controller.dispose);
+
+    await pumpWorkspace(
+      tester,
+      identity: identity,
+      historyBuilder: (BuildContext context, _) => Scaffold(
+        body: TextField(key: const Key('subject'), controller: controller),
+      ),
+    );
+
+    // By key, not by type: the sidebar's own branch filter is also a
+    // TextField, so `find.byType` matches two.
+    await tester.tap(find.byKey(const Key('subject')));
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.start, 0);
+    expect(controller.selection.end, controller.text.length);
+  });
+}

--- a/app_flutter/test/integration/workspace_selection_summary_test.dart
+++ b/app_flutter/test/integration/workspace_selection_summary_test.dart
@@ -1,0 +1,130 @@
+// Spec page 13's 「對既有頁面的連帶修改」 for P2 History: 「狀態列改為顯示
+// selection 摘要（數量、是否連續…）」.
+//
+// Integration tier rather than widget tier, because the two halves that can
+// go wrong are both above StatusBar: whether WorkspaceScreen computes
+// contiguity against the snapshot at all, and whether it stops rendering the
+// summary once History is no longer the visible tab. A widget test feeding
+// StatusBar a string proves the string renders -- which is already covered in
+// status_bar_test.dart -- not that anything ever produces it.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/graph_snapshot.dart';
+import 'package:gbm_flutter/data/models/list_selection.dart';
+import 'package:gbm_flutter/data/repositories/history_repository.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+final String _repoId = Uri.encodeComponent(_identity.workDir);
+
+/// Newest first, as History renders.
+final List<String> _oids = <String>[
+  for (final String seed in <String>['a', 'b', 'c', 'd']) seed * 40,
+];
+String _oid(String seed) => seed * 40;
+
+RepoSessionState get _state => RepoSessionState(
+  isOpen: true,
+  graph: GraphSnapshotView(
+    rows: <GraphRow>[
+      for (final _ in _oids)
+        const GraphRow(
+          parentOffset: 0,
+          edgeOffset: 0,
+          commitTime: 0,
+          lane: 0,
+          color: 0,
+          flags: 0,
+        ),
+    ],
+    oidsHex: _oids,
+    parentPool: const <int>[],
+    laneCount: 1,
+    complete: true,
+    truncated: false,
+  ),
+);
+
+void _select(PumpedWorkspace pumped, List<String> oids) {
+  pumped.container.read(commitSelectionProvider(_identity).notifier).state =
+      ListSelection<String>(items: oids, anchor: oids.last);
+}
+
+void main() {
+  testWidgets('History shows the count and contiguity of a selected run', (
+    tester,
+  ) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: _identity,
+      initialState: _state,
+    );
+
+    expect(find.textContaining('commits'), findsNothing);
+
+    _select(pumped, <String>[_oid('b'), _oid('c')]);
+    await tester.pump();
+
+    expect(find.text('2 commits · contiguous'), findsOneWidget);
+  });
+
+  testWidgets('a gap in the snapshot reads as not contiguous', (tester) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: _identity,
+      initialState: _state,
+    );
+
+    // a and c, with b between them: not a range git can replay, which is
+    // exactly why MULTIACTS disables cherry-pick/revert for it. The status
+    // bar is where the user finds out why.
+    _select(pumped, <String>[_oid('a'), _oid('c')]);
+    await tester.pump();
+
+    expect(find.text('2 commits · not contiguous'), findsOneWidget);
+  });
+
+  testWidgets('a single commit gets no summary', (tester) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: _identity,
+      initialState: _state,
+    );
+
+    _select(pumped, <String>[_oid('b')]);
+    await tester.pump();
+
+    expect(find.textContaining('commits'), findsNothing);
+  });
+
+  testWidgets('the summary hides on Working Copy and returns on History', (
+    tester,
+  ) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: _identity,
+      initialState: _state,
+    );
+
+    _select(pumped, <String>[_oid('b'), _oid('c')]);
+    await tester.pump();
+    expect(find.text('2 commits · contiguous'), findsOneWidget);
+
+    pumped.router.go(RoutePaths.workingCopyFor(_repoId));
+    await tester.pumpAndSettle();
+
+    // The selected rows are off screen; describing them would be describing
+    // something the user cannot see.
+    expect(find.textContaining('commits'), findsNothing);
+
+    pumped.router.go(RoutePaths.historyFor(_repoId));
+    await tester.pumpAndSettle();
+
+    // Selection survives the tab switch (「Selection 在切換分頁與重新整理後
+    // 保留」), so the summary comes back rather than being rebuilt empty.
+    expect(find.text('2 commits · contiguous'), findsOneWidget);
+  });
+}

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -353,6 +353,8 @@ class FakeRepoSessionController extends RepoSessionController {
       FakeCommand('deleteBranch', <String, Object?>{
         'names': names,
         'force': force,
+        'isRemote': isRemote,
+        'remoteName': remoteName,
       }),
     );
   }

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -320,13 +320,16 @@ class FakeRepoSessionController extends RepoSessionController {
   @override
   void pushChanges({
     String remoteName = '',
-    String branch = '',
+    List<String> branches = const <String>[],
     bool setUpstream = false,
     bool pushTags = false,
     bool forceWithLease = false,
   }) {
     commandLog.add(
       FakeCommand('pushChanges', <String, Object?>{
+        'remoteName': remoteName,
+        'branches': branches,
+        'setUpstream': setUpstream,
         'forceWithLease': forceWithLease,
       }),
     );

--- a/app_flutter/test/widgets/gbm_menu_test.dart
+++ b/app_flutter/test/widgets/gbm_menu_test.dart
@@ -348,4 +348,120 @@ void main() {
       expect(find.text('Second'), findsOneWidget);
     });
   });
+
+  group('multi-select affordances (spec page 13)', () {
+    testWidgets('showGbmContextMenu renders the title as a non-item header', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () => showGbmContextMenu(
+                    context,
+                    const Offset(20, 20),
+                    <GbmMenuItem>[GbmMenuItem(label: 'Copy SHA', onTap: () {})],
+                    title: '3 items',
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('3 items'), findsOneWidget);
+      expect(find.text('Copy SHA'), findsOneWidget);
+    });
+
+    testWidgets(
+      'a title does not consume any of the 8-item context-menu budget',
+      (tester) async {
+        // validateGbmMenuItems caps *actions* at 8 (spec page 05). A header
+        // that names the selection is not an action, so a full 8-item menu
+        // must still be legal with a title on top -- if the title were ever
+        // counted, this would trip the assert and fail.
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: ElevatedButton(
+                    onPressed: () => showGbmContextMenu(
+                      context,
+                      const Offset(20, 20),
+                      <GbmMenuItem>[
+                        for (int i = 0; i < 8; i++)
+                          GbmMenuItem(label: 'Item $i', onTap: () {}),
+                      ],
+                      title: '5 items',
+                    ),
+                    child: const Text('open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('5 items'), findsOneWidget);
+        expect(find.text('Item 7'), findsOneWidget);
+      },
+    );
+
+    testWidgets('a disabled item carries its tooltip', (tester) async {
+      await _openMenu(tester, GbmThemeVariant.darkTechnical, <GbmMenuItem>[
+        const GbmMenuItem(
+          label: 'Rename…',
+          enabled: false,
+          tooltip: 'Only one branch at a time',
+          onTap: null,
+        ),
+      ]);
+
+      final Tooltip tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, 'Only one branch at a time');
+    });
+
+    testWidgets('a submenu child keeps its tooltip through the re-wrap', (
+      tester,
+    ) async {
+      // The flyout rebuilds every child to graft on "close the parent
+      // first" (see _openSubmenu). A field left out of that rebuild is
+      // silently dropped, which is invisible until someone opens a submenu.
+      await _openMenu(tester, GbmThemeVariant.darkTechnical, <GbmMenuItem>[
+        GbmMenuItem.submenu(
+          label: 'More actions',
+          children: const <GbmMenuItem>[
+            GbmMenuItem(
+              label: 'Reset branch to here…',
+              enabled: false,
+              tooltip: 'Needs a single target commit',
+              onTap: null,
+            ),
+          ],
+        ),
+      ]);
+
+      await tester.tap(find.text('More actions'));
+      await tester.pumpAndSettle();
+
+      final Tooltip tooltip = tester.widget<Tooltip>(
+        find.ancestor(
+          of: find.text('Reset branch to here…'),
+          matching: find.byType(Tooltip),
+        ),
+      );
+      expect(tooltip.message, 'Needs a single target commit');
+    });
+  });
 }

--- a/docs/reports/spec-conformance-matrix.md
+++ b/docs/reports/spec-conformance-matrix.md
@@ -29,6 +29,16 @@ This report is descriptive only — no fixes are applied here. See
 > below without that marker was judged against the original 12 pages and
 > may have drifted. See the Tier 0c PR for the rename rows, which are the
 > only ones this round implemented.
+>
+> **P13 section B is now implemented** (Tier 2+3, issues #54–#57): the
+> `MULTIKEYS` / `MULTIACTS` / `MULTIBRANCHMENU` selection rules, the History
+> status-bar selection summary, and both `Edit → Select all` and the two
+> Compare entry points that depended on them. Rows it touched (Edit → Select
+> all, 05-B, 05-E, COMPARES 1, COMPARES 3) are corrected in place below.
+> **P13 section A** (the rename dialog) shipped earlier in Tier 0c. P14–P16
+> remain unaudited, and section B was not audited row-by-row before being
+> implemented — it was read from the source spec directly, so no matrix rows
+> exist for `MULTIKEYS`/`MULTIACTS`/`MULTIBRANCHMENU` themselves.
 
 ---
 
@@ -52,13 +62,21 @@ audit time**. P16's `REVISIONS` changes two things about this paragraph:
   this row was written — the audit had no shortcut to compare against.
   **措辭不符** on the binding. Not fixed in the Tier 0c PR; needs its own
   issue alongside the other two shortcut rows below.
-- **`Edit → Select all` is missing entirely.** REVISIONS adds it with
-  `Ctrl/Cmd+A` ("搭 P13 多選"), so the Edit menu should now have 9 items
-  and the app-wide total 53, not 52. `gbmMenus`' Edit menu has 8 and no
-  `editSelectAll` id exists in `GbmActionId`. **缺少** — and note it is
-  not independent of P13: `Ctrl/Cmd+A` is also `MULTIKEYS`' "全選當前清
-  單", so binding it before the multi-select work (#54) lands would give
-  it nothing to select. Sequence it after, not before.
+- ~~**`Edit → Select all` is missing entirely.**~~ → **符合** (fixed,
+  Tier 2 / #54). REVISIONS adds it with `Ctrl/Cmd+A` ("搭 P13 多選"), so
+  the Edit menu now has 9 items and the app-wide total is 53. The
+  sequencing note below held: it shipped *with* the multi-select work, in
+  the same branch, because `Ctrl/Cmd+A` is also `MULTIKEYS`' "全選當前清
+  單" and binding it first would have given it nothing to select.
+  `GbmActionId.editSelectAll`'s handler follows `_invokeTextIntent`'s
+  existing shape — non-null in the handler map (so all three dispatch
+  paths stay in agreement) and forwarding by focus: it invokes
+  `GbmSelectAllIntent` first and falls back to `SelectAllTextIntent`, so
+  the same key still selects text when a `TextField` holds focus. The
+  commit list and the branch tree each register their own
+  `GbmSelectAllIntent` action inside their own focus scope, which is also
+  what keeps the list binding from stealing `DefaultTextEditingShortcuts`'
+  select-all.
 
 **Keyboard shortcuts (`gbmActionShortcuts()`, 36/52 ids bound — 35/52 at audit time; F2 is the one added since, see the rename row below):**
 
@@ -99,6 +117,12 @@ function, because its items need the container's commit oid and its
 in-flight export state, which that template has nowhere to hold. **05-B and
 05-E are the only drifted groups left.**
 
+**Update (Tier 2+3, branch `feat/tier-2-3-multi-select-compare`, issues #54,
+#55, #56, #57).** 05-B and 05-E both landed, so **no group is skipped any
+more**. Both rows' premises were wrong in the same direction — each named a
+prerequisite that did not exist — and both are corrected in place below
+rather than edited away, since the correction is what moved the work.
+
 Two premises in the rows below were **wrong** and are corrected in place
 rather than silently edited away, because both changed where the fix had to
 go: 05-F pointed at a widget nothing in `lib/` ever built, and 05-G's
@@ -107,10 +131,10 @@ go: 05-F pointed at a widget nothing in `lib/` ever built, and 05-G's
 | Group | Verdict | Evidence | Detail |
 |---|---|---|---|
 | 05-A Repository | 符合 (deliberate reduction) + 1 minor 多出 | `repo_switcher_popover.dart:740-877` `RepoSwitcherRow._openContextMenu()` | Omits Fetch/Pull/Push vs. the catalog's 7 items — documented in the catalog's own comment: a repo row in the switcher list has no open session to act on. Renders: Open / Open in file manager / Open in terminal / Settings… / [separator] / Remove from list (5 items). The leading `Open` item is not in spec's 05-A list at all — low-severity addition (mirrors the row's own double-click action, a reasonable convenience), noted for completeness rather than flagged as something to remove. |
-| 05-B Local branch | **缺少** | `branch_tree_item.dart:321-387` `_buildMenuItems()` | Renders: Checkout / New branch from here / Rename branch / Merge into current branch / Copy branch name / Delete branch (6 items). Missing vs. spec's 8: `Rebase current onto here`, `Compare with…`. Also wording: `Rename branch` vs. spec `Rename…`, `Merge into current branch` vs. spec `Merge into current`. The file's own doc comment (lines 321-327) explains why: both omissions are deliberate, not oversights — "no per-branch entry point exists yet; a targeted rebase/compare would need the same UI as its repository-level peer, not yet surfaced." Classification **(i) with a prerequisite** — `gbm_rebase_start`/`gbm_request_compare_refs` exist in capi, but there's no per-branch rebase/compare UI to route to yet (same shape as the 05-E correction below: capi existing ≠ Dart-side wiring existing). |
+| 05-B Local branch | ~~**缺少**~~ → **符合** (Tier 3 / #57) | `sidebar/widgets/local_branch_menu_items.dart`, rendered by `branch_tree_item.dart` | **This row's premise — and #57's — was wrong about `Compare with…`.** It read as needing a new picker UI; it does not. `sidebar_panel.dart`'s `_compareStash()`/`_compareTag()` had already established the convention: open a Compare tab with only the left side filled (`compareTabsProvider.open(left: <ref>)`) and let `CompareRefPicker`, which the Compare page already renders, take the right. A branch copies that verbatim — zero new dialogs. `Rebase current onto here` was likewise not blocked on Dart-side plumbing: `RoutePaths.rebaseOntoDialogFor` gained a `target` query parameter (template: `renameBranchDialogFor`) and the existing dialog pre-selects it. **Fixed**: all 8 items now render with spec's exact labels — the render site is a pure `*_menu_items.dart` function asserted for **exact equality**, replacing the parity test's previous `startsWith` comparison, which is what let the two wording drifts (`Rename branch`, `Merge into current branch`) sit unreported. The `skip: true` is gone. Also closed while there: `New branch from here`, `Merge into current` and `Delete branch` were ungated mid-conflict despite spec page 07 disabling all three; they now go through `isActionEnabled()` like the rest. |
 | 05-C Remote-only / gone branch | 符合 (verify) | `branch_tree_item.dart` | CLAUDE.md's "Known gaps" section documents this as fixed (`_buildGoneMenuItems()`), matching spec's 05-C note that a gone row keeps only Prune+Copy. The *catalog file's* doc comment still says "not yet wired" — that comment is stale, not the implementation; flagged for correction in Phase 5. |
 | 05-D Tag | 符合 | `tag_menu_items.dart` | Labels and order match spec exactly (5 items). Reference-quality implementation. |
-| 05-E Commit | **缺少** | `commit_row.dart:226-259` menu build | Renders: Checkout this commit / Cherry-pick / Create branch here… / Copy SHA / Revert commit (5 items, no submenu). Missing vs. spec's 7 top-level + "More actions" submenu of 5: `Merge into current`, `Compare with…`, and the ENTIRE submenu (`Rebase onto here`, `Reset branch to here…`, `Revert commit`, `Export as patch…`, `Compare with working copy`). Note spec keeps `Revert commit` inside the submenu; code promotes it to top level. **Classification correction**: `commit_row.dart`'s own doc comment (lines 226-229) gives the real reason for each omission, and it's not uniformly "(i) trivial wiring" as first assumed from capi existing alone — `Merge into current` is omitted because `mergeBranch` takes a branch **name**, not a commit oid (needs either an API change or a name-resolution step, not just a UI hookup); `Compare items` are explicitly deferred as "M6" (a planned milestone, not an oversight); `rebase/reset` are noted "destructive, not wired" — meaning the *Dart-side* plumbing, not just the menu item, doesn't exist yet, so capi having the C function is necessary but not sufficient. Revised classification: `Compare with…` stays **(i)** (capi + Dart service both proven elsewhere); `Merge into current` and `Rebase/Reset` are **(i) with extra work** (need a name-resolution step or Dart-side wiring first, not pure UI); nothing here is **(ii)**. This is exactly the kind of per-site nuance the audit plan flagged as necessary to check before trusting a grep-derived classification. |
+| 05-E Commit | ~~**缺少**~~ → **符合** (Tier 3 / #56) | `history_graph/widgets/commit_menu_items.dart`, rendered by `commit_row.dart` | **The premise this row and #56 shared was wrong.** Both said `Merge into current` needed an oid→branch-name resolution step because `mergeBranch` takes a name. It does not: `gbm_merge_branch`'s `target` is pushed straight into `git merge <target>` (`src/core/git/ops/MergeOps.cpp:59,82`) and only an empty string is rejected — an oid is a perfectly legal committish, and `startRebase(upstream)` behaves the same way. So there was no prerequisite, only wiring. **Fixed**: all 7 top-level items plus the full `More actions` submenu of 5 now render, with `Revert commit` back inside the submenu where spec puts it. The submenu could only be built because Tier 4 had already made `GbmMenuItem.submenu`'s flyout actually open — before that its trigger row carried a permanently-null `onTap`. Multi-select changes the labels rather than the item set (`Cherry-pick 3 commits`, following 05-F's counted-label pattern), and the contiguity-gated trio (`Cherry-pick`/`Revert`, plus `Squash` which this app does not offer at all) renders `enabled: false` **and** `onTap: null` with spec's own tooltip 「選取需為連續 commit」 when the range has a gap. Contiguity is judged against the **unfiltered** snapshot, so three rows that look adjacent under a search filter are correctly refused. The `skip: true` is gone. |
 | 05-F Working copy file | ~~缺少~~ → **符合** (Tier 1 / #51) | `working_copy_view.dart:576` `_openContextMenu()` → `working_copy/widgets/working_copy_file_menu_items.dart` | **This row audited the wrong file — twice.** The first pass grepped `label: '...'` and so missed ternary-labelled items; the "corrected" second pass fixed that but still pointed at `changed_file_row.dart`, which **no file under `lib/` ever constructed**. `WorkingCopyBoard` (commit `39d6303`) replaced that row widget and commit `5581538` moved the 05-F menu into `working_copy_view.dart`; `ChangedFileRow` had been orphaned since, referenced only by `test/`. So the live menu already had `Open terminal here` and full multi-select pluralization, and the real gap was two items, not three. **Fixed**: `Open file` and `Show in file manager` added (`DesktopLauncher.openFile()` is new; `openInFileManager()` already existed, and both now normalize `/`→`\` on Windows, without which `explorer.exe /select,` silently opens Documents instead of revealing). The orphaned widget and its test file were deleted in their own commit. **Deliberate reduction**: `Blame…`/`File History…`/`Line History…` were dropped from this menu — they are beyond-spec, and 6 spec items + 3 extras is 9, over `showGbmContextMenu`'s asserted 8-item cap (spec page 05's own "最多 8 項"); `GbmMenuItem.submenu`'s flyout does not render yet, so nesting them was not available. All three stay reachable from `tab_row.dart`'s overflow menu, minus the pre-filled path. |
 | 05-G Diff line | ~~缺少~~ → **符合** (Tier 1 / #52) | `diff_line.dart:140` `_showContextMenu()` → `diff/widgets/diff_line_menu_items.dart` | **The gap was larger than the corrected second pass reported.** Reading spec's own 05-G block verbatim (`{ label: 'Stage 12 lines' }, { 'Stage hunk' }, { 'Unstage hunk' }, { 'Copy lines' }, { sep }, { 'Discard 12 lines…', danger }`) shows four differences, not one: the missing `Discard`, plus `Stage line` vs `Stage`/`Stage N lines`, `Copy line` vs `Copy lines`, and spec listing **both** hunk directions as separate entries where the code ternaried between them. **Fixed, all four.** Both hunk items now always render with the inapplicable direction disabled (`enabled: false` *and* `onTap: null` — `enabled` alone is a visual signal only, see `gbm_menu.dart`); the count comes from `_DiffHunkSection`'s checkbox selection using 05-F's own "right-click inside the selection keeps the batch" rule. `Discard` needed a **new capi** — `gbm_stage_lines`/`gbm_unstage_lines` are `git apply --cached` (index only), so `gbm_discard_lines` was added (`git apply --reverse` without `--cached`, patch built with `unstaging=true` since that flag means "will be reverse-applied, check the new side"). It is offered only on the unstaged side and always routes through the discard-changes dialog's new line mode, never straight to the controller. **Follow-up defect, found by writing the missing coverage rather than by reading the diff**: that new line mode reaches the dialog through a URL, and the router's inline parsing cross-nulled `hunk` against `line`, so a half-parsed line selection silently degraded to *whole-file* discard behind the same danger button. Parsing moved to `DiscardChangesRequest.fromQuery` (`features/dialogs/discard_changes/discard_changes_request.dart`); an unhonourable line request is now `isMalformed` and the dialog offers `Close` and no destructive button. |
 | 05-H Stash entry | 符合 | `stash_menu_items.dart` | Labels and order match spec exactly (6 items). Reference-quality. |
@@ -118,10 +142,16 @@ go: 05-F pointed at a widget nothing in `lib/` ever built, and 05-G's
 | 05-J Branch folder | 符合 | `branch_folder_menu_items.dart` | Matches spec's 4 items (aside from a possible deliberate omission — see pending device/widget-tier note in Phase 3). |
 | 05-K Commit file | ~~**部分修復**~~ → **符合** (Tier 4 / #58 + #59) | `changed_files_panel.dart` menu build | **Fixed in two rounds.** Tier 1 (#53) wired the two (i)-classified top-level items — `Compare with working copy` (opens a Compare tab via `compareTabsProvider.open(left: <oid>)` with a null `right`, then `context.go`, mirroring `sidebar_panel.dart`'s `_compareStash`; `push` would stack the tab over History rather than switch to it) and `Open terminal here` (the repository work dir, like 05-A/05-F — a historical commit's file has no directory of its own). Tier 4 closed the rest, and **both of that round's premises needed correcting**. (1) `Open file at this revision` / `Save this revision as…` were classified **(ii)** "no blob-read entry point", which was true, but the entry point they needed is not the one #58 sketched: neither displays content in-app, so `gbm_export_file_at_revision(session, revision, path, destPath)` writes raw bytes to a destination instead of returning content inline — binary-safe by construction, where a JSON string payload could not have carried an image at all. (2) `Restore and stage` / `Export as patch…` were blocked on `GbmMenuItem.submenu`'s flyout, which was the *real* blocker for the whole group and turned out to be a `gbm_menu.dart` change, not a 05-K one: the trigger row had a permanently-null `onTap`. Both landed; the parity test's 05-K group is now asserted against the full catalog with **no `skip`**. Two documented deliberate outcomes: `Restore file to this state` and `Restore and stage` open the same dialog (`restore_file_dialog.dart` has always offered both as two buttons, because the confirmation text is identical), and `Export as patch…` writes the whole commit's patch, since `gbm_patch_export` is `git format-patch -1 <commit>`. Remaining, not fixed: the *catalog's* own 05-K submenu lists four children where spec lists five — `Restore file to before this state` is absent from `gbm_context_menus.dart`. Left alone on purpose, since that catalog is this test's acceptance baseline — tracked as **#71**, which also notes that this audit's method (render site vs. catalog) could not have caught a catalog-vs-spec drift in any group. |
 
-**Net**: after Tier 4, 7 of 11 groups (05-D/F/G/H/I/J/K) are checked
-against the catalog with no `skip`; six of those are also
-reference-quality pure `*_menu_items.dart` functions and remain the template
-for the rest. 05-B and 05-E are the only unfixed groups left. The original
+**Net**: after Tier 3, **all 11 groups are checked against the catalog with
+no `skip`** — the parity test has no skipped assertions left, so H1's root
+cause (a catalog nothing under `lib/` imports) can no longer drift
+unnoticed in any group. Eight of the eleven are now pure
+`*_menu_items.dart` functions; 05-A, 05-C and 05-K keep private render-site
+builders for reasons recorded in their own rows. The post-Tier-4 text
+follows: 7 of 11 groups (05-D/F/G/H/I/J/K) are checked against the catalog
+with no `skip`; six of those are also reference-quality pure
+`*_menu_items.dart` functions and remain the template for the rest. 05-B and
+05-E are the only unfixed groups left. The original
 post-Tier-1 text follows: 6 of 11 groups (05-D/F/G/H/I/J) are
 reference-quality … 05-K is partially fixed (its two wireable items landed;
 the other four need capi or a submenu flyout).
@@ -390,13 +420,18 @@ dialog pair in F-B).
 | CHANGEVIEWS 2: Stash — inline expand on click | **缺少** | `sidebar_panel.dart:896-960` | Stash rows are not expandable in place; right-click "View diff" opens a dialog instead of the spec's inline-expand-then-click-file flow. |
 | CHANGEVIEWS 3: Working copy | 符合 | `working_copy_view.dart` | — |
 | CHANGEVIEWS 4: Between two refs — read-only 3-part view | 符合 | `compare_page.dart:209-403` | ref pickers / file list / diff pane, all present. |
-| COMPARES 1: Branch ↔ Branch (multi-select → right-click → Compare) | **缺少** | `commit_row.dart:25,229` | No multi-select path in History; consistent with the page-05 finding that 05-E's context menu is also missing "Compare with…" at the branch/commit level. |
+| COMPARES 1: Branch ↔ Branch (multi-select → right-click → Compare) | ~~**缺少**~~ → **符合** (Tier 3 / #55) | `sidebar_panel.dart` `_multiBranchMenuItems()` → `sidebar/widgets/multi_branch_menu_items.dart`; second entry point `GbmActionId.repositoryCompare` | **This row was partly out of date when written**: the *second* entry point for a branch↔branch compare — `Repository → Compare…`, `Ctrl/Cmd+Shift+C` — already existed and worked. Only spec's literal reading (「同時選兩個分支 → 右鍵 Compare」) was missing, and it needed sidebar branch multi-select, not History's. **Fixed** on the user's explicit "照字面做" ruling: `branchSelectionProvider` gives the branch tree the same `ListSelection` model History uses, and `MULTIBRANCHMENU` gained a `Compare` item that opens a tab with **both** sides filled. It is disabled with a stated reason for any count other than two, since a comparison has exactly two ends. |
 | COMPARES 2: Branch ↔ Tag | 符合 | `sidebar_panel.dart:201-207` | `_compareTag()`. |
-| COMPARES 3: Commit ↔ Commit (Ctrl/Cmd-click multi-select, merge-base + 2-dot/3-dot toggle) | **缺少 (entry point) / 符合 (once reached)** | no multi-select mechanism found in `history_graph/`; but `compare_page.dart:262-321` implements the 2-dot/3-dot toggle and merge-base labeling once a Compare tab IS open | The comparison *engine* correctly implements the harder half of this spec row (merge-base detection, 2-dot/3-dot); what's missing is entirely the *entry point* — there's no way to Ctrl/Cmd-click two commits in History to reach it. Same root cause as COMPARES 1 and 05-E. |
+| COMPARES 3: Commit ↔ Commit (Ctrl/Cmd-click multi-select, merge-base + 2-dot/3-dot toggle) | ~~**缺少 (entry point)**~~ → **符合** (Tier 2+3 / #54 + #55) | `commit_graph_view.dart` (MULTIKEYS gestures) → `commit_menu_items.dart`'s `Compare with…`; engine unchanged in `compare_page.dart:262-321` | The engine half was already right, as this row said. The entry point now exists: Ctrl/Cmd-click two commit rows, right-click either one, `Compare with…`. **left = the older side, right = the newer**, taken from the snapshot's own order rather than click order — the same direction convention `_compareStash()` set by always putting the stash on the right. A single selection still opens the tab with only `left` filled and leaves the right to `CompareRefPicker`, so the one-commit and two-commit cases share one item rather than two. |
 | COMPARES 4: Stash ↔ any ref, stash forced to the right side | 符合 | `sidebar_panel.dart:175-181`, `compare_page.dart:31-61` | `_compareStash()` places stash OID correctly. |
 | COMPARES 5: any ref ↔ Working copy, checkout-to-overwrite is the only writable path | 符合 | `compare_page.dart:143-175,342-349,536-600` | Confirmed as the sole writable comparison, with a confirmation dialog before `restorePaths()`. |
 
-**6/9 符合, 3 gaps that are all the SAME underlying cause**: History has no
+**Now 8/9 符合** (CHANGEVIEWS 2's inline stash expand is the one gap left).
+The prediction below held exactly: multi-select plus 05-E's `Compare with…`
+closed COMPARES 1 and COMPARES 3 together, in one branch. The one thing it
+got wrong is *which* multi-select COMPARES 1 needed — the branch tree's, not
+History's — which is why Tier 3 had to build both. Original text: **6/9
+符合, 3 gaps that are all the SAME underlying cause**: History has no
 multi-select mechanism, so every Compare flow that depends on selecting
 two commits (branch↔branch via commits, commit↔commit) has a working
 back-end but no front-door. This corroborates 05-E's finding that
@@ -435,10 +470,17 @@ verdict must rest on the spec's prose — and page 01's prose was explicit.
 The gaps cluster into a small number of root causes rather than being 24
 independent problems:
 1. **F1**: the context-menu catalog file is dead code — 7 of 11 groups
-   drifted from spec because nothing enforces they match it.
+   drifted from spec because nothing enforces they match it. *(Closed after
+   Tier 3: every group is now parity-asserted with no `skip`. The catalog is
+   still imported only by `test/`, which is the point — it is the acceptance
+   baseline, and eight render sites are now pure functions checked against
+   it for exact label equality.)*
 2. **History has no multi-select** — this alone explains 05-E's missing
    `Compare with…`/`Merge into current`, and both Compare-page entry-point
-   gaps (COMPARES 1 and 3).
+   gaps (COMPARES 1 and 3). *(Closed in Tier 2+3. One correction to the
+   diagnosis: COMPARES 1 needed the **sidebar branch tree's** multi-select,
+   not History's, so the root cause was one mechanism short of what this
+   line claims — both were built.)*
 3. **F-A**: `tab_row.dart`'s 18-item overflow menu is a spec-unsanctioned
    third entry surface for otherwise-legitimate features.
 4. **F-B**: the Log drawer and Operation Log dialog are two competing

--- a/src/capi/Remotes.cpp
+++ b/src/capi/Remotes.cpp
@@ -70,13 +70,14 @@ GBM_API void gbm_pull(GbmSessionHandle session,
 
 GBM_API void gbm_push(GbmSessionHandle session,
                       const char* remoteName,
-                      const char* branch,
+                      const char* const* branches,
+                      int32_t branchCount,
                       int32_t setUpstream,
                       int32_t pushTags,
                       int32_t forceWithLease) {
     PushRequest request;
     request.remoteName = remoteName != nullptr ? remoteName : "";
-    request.branch = branch != nullptr ? branch : "";
+    request.branches = toStringVector(branches, branchCount);
     request.setUpstream = setUpstream != 0;
     request.pushTags = pushTags != 0;
     request.force = forceWithLease != 0 ? PushForceMode::ForceWithLease : PushForceMode::None;

--- a/src/capi/gbm_capi.h
+++ b/src/capi/gbm_capi.h
@@ -801,13 +801,24 @@ GBM_API void gbm_pull(GbmSessionHandle session,
 
 /// `git push`, with `--force-with-lease` when `forceWithLease` is set --
 /// there is no plain `--force` in this app (see PushForceMode's doc
-/// comment). `branch` empty pushes the current branch. Async: fires
-/// GBM_EVENT_WORKING_COPY_OPERATION_FINISHED, and on success also triggers
-/// the same refresh gbm_history_refresh() would (the local remote-tracking
-/// ref moves).
+/// comment).
+///
+/// `branches`/`branchCount`: the branches to push. `branchCount` 0 pushes
+/// the current branch, the original behaviour. More than one is a
+/// multi-select push, expressed as one `git push <remote> a b c` rather
+/// than N separate calls -- same multi-name convention gbm_branch_delete
+/// already uses, and git's own per-ref reporting gives "carry on past a ref
+/// that failed" for free. Passing branches with an empty `remoteName` is
+/// accepted but the names are ignored, matching the pre-existing behaviour
+/// (git needs a remote before it can take refspecs).
+///
+/// Async: fires GBM_EVENT_WORKING_COPY_OPERATION_FINISHED, and on success
+/// also triggers the same refresh gbm_history_refresh() would (the local
+/// remote-tracking ref moves).
 GBM_API void gbm_push(GbmSessionHandle session,
                       const char* remoteName,
-                      const char* branch,
+                      const char* const* branches,
+                      int32_t branchCount,
                       int32_t setUpstream,
                       int32_t pushTags,
                       int32_t forceWithLease);

--- a/src/core/git/ops/RemoteOps.cpp
+++ b/src/core/git/ops/RemoteOps.cpp
@@ -141,7 +141,11 @@ public:
     explicit PushOperation(PushRequest request) : request_(std::move(request)) {}
 
     std::string describe() const override {
-        return "Push" +
+        std::string what = "Push";
+        if (request_.branches.size() > 1) {
+            what += " " + std::to_string(request_.branches.size()) + " branches";
+        }
+        return what +
                (request_.remoteName.empty() ? std::string() : " to " + request_.remoteName);
     }
 
@@ -161,8 +165,10 @@ public:
         }
         if (!request_.remoteName.empty()) {
             args.push_back(request_.remoteName);
-            if (!request_.branch.empty()) {
-                args.push_back(request_.branch);
+            for (const auto& branch : request_.branches) {
+                if (!branch.empty()) {
+                    args.push_back(branch);
+                }
             }
         }
 

--- a/src/core/git/ops/RemoteOps.cpp
+++ b/src/core/git/ops/RemoteOps.cpp
@@ -145,8 +145,7 @@ public:
         if (request_.branches.size() > 1) {
             what += " " + std::to_string(request_.branches.size()) + " branches";
         }
-        return what +
-               (request_.remoteName.empty() ? std::string() : " to " + request_.remoteName);
+        return what + (request_.remoteName.empty() ? std::string() : " to " + request_.remoteName);
     }
 
     OperationOutcome run(IProcessRunner& runner,

--- a/src/core/git/ops/RemoteOps.h
+++ b/src/core/git/ops/RemoteOps.h
@@ -83,7 +83,14 @@ enum class PushForceMode : std::uint8_t {
 
 struct PushRequest {
     std::string remoteName;
-    std::string branch;  ///< Empty pushes the current branch.
+    /// Refspecs to push. Empty pushes the current branch. More than one is
+    /// how a multi-select push is expressed: `git push <remote> a b c`
+    /// pushes each in turn and reports per-ref status, continuing past a
+    /// ref it could not update -- which is exactly the "依序執行，失敗項不
+    /// 中斷其餘" behaviour a batch push needs, without the caller having to
+    /// chain N separate operations (and emit N OPERATION_FINISHED events).
+    /// Mirrors the multi-name convention gbm_branch_delete already uses.
+    std::vector<std::string> branches;
     bool setUpstream = false;
     bool pushTags = false;
     PushForceMode force = PushForceMode::None;

--- a/tests/capi/RemoteApiTest.cpp
+++ b/tests/capi/RemoteApiTest.cpp
@@ -262,7 +262,14 @@ TEST_F(RemoteApiTest, PushUploadsLocalCommitsToTheRemote) {
     ASSERT_EQ(runGit({"add", "new-file.txt"}), 0);
     ASSERT_EQ(runGit({"commit", "--quiet", "-m", "New commit"}), 0);
 
-    gbm_push(session_, "origin", "main", /*setUpstream=*/0, /*pushTags=*/0, /*forceWithLease=*/0);
+    const char* branches[] = {"main"};
+    gbm_push(session_,
+             "origin",
+             branches,
+             /*branchCount=*/1,
+             /*setUpstream=*/0,
+             /*pushTags=*/0,
+             /*forceWithLease=*/0);
     ASSERT_TRUE(waitForWorkingCopyOperationFinished(log_));
 
     const std::string outcome = log_.lastPayloadOfType(GBM_EVENT_WORKING_COPY_OPERATION_FINISHED);

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -2314,13 +2314,67 @@ protected:
     std::filesystem::path remote_;
 };
 
+TEST_F(RemoteRepoTest, PushesSeveralBranchesInOneOperation) {
+    // Spec page 13's multi-select push. One `git push origin a b c`, not N
+    // operations: git updates each ref in turn and reports per-ref status,
+    // which is the "依序執行，失敗不中斷其餘" behaviour the batch needs, and
+    // one command means one background task (spec page 10) rather than N
+    // OPERATION_FINISHED events.
+    commitFile("a.txt", "1\n", "c1");
+    ASSERT_TRUE(run({"branch", "feature-one"}));
+    ASSERT_TRUE(run({"branch", "feature-two"}));
+
+    OperationRunner operations(*runner_, paths_);
+    PushRequest push;
+    push.remoteName = "origin";
+    push.branches = {"main", "feature-one", "feature-two"};
+    auto pushed = submitAndWait(operations, makePushOperation(push));
+    ASSERT_TRUE(pushed.succeeded) << (pushed.error ? pushed.error->detail : "");
+
+    for (const char* branch : {"main", "feature-one", "feature-two"}) {
+        auto listed = run({"ls-remote", remote_.string(), std::string("refs/heads/") + branch});
+        ASSERT_TRUE(listed);
+        EXPECT_FALSE(listed->out.empty()) << branch << " was not pushed";
+    }
+}
+
+TEST_F(RemoteRepoTest, PushWithNoBranchesStillPushesTheCurrentOne) {
+    // branchCount 0 keeps the pre-existing "let git decide" behaviour: no
+    // refspec is passed at all, so git pushes the current branch through its
+    // configured upstream. It is *not* equivalent to passing the current
+    // branch's name -- without an upstream git refuses outright, which is why
+    // the first push here has to name the branch and set one up.
+    commitFile("a.txt", "1\n", "c1");
+
+    OperationRunner operations(*runner_, paths_);
+    PushRequest first;
+    first.remoteName = "origin";
+    first.branches = {"main"};
+    first.setUpstream = true;
+    auto initial = submitAndWait(operations, makePushOperation(first));
+    ASSERT_TRUE(initial.succeeded) << (initial.error ? initial.error->detail : "");
+
+    commitFile("a.txt", "2\n", "c2");
+    auto local = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(local);
+
+    PushRequest followUp;
+    followUp.remoteName = "origin";
+    auto pushed = submitAndWait(operations, makePushOperation(followUp));
+    ASSERT_TRUE(pushed.succeeded) << (pushed.error ? pushed.error->detail : "");
+
+    auto remoteHead = run({"ls-remote", remote_.string(), "refs/heads/main"});
+    ASSERT_TRUE(remoteHead);
+    EXPECT_NE(remoteHead->out.find(local->out), std::string::npos);
+}
+
 TEST_F(RemoteRepoTest, PushesFetchesAndPulls) {
     commitFile("a.txt", "1\n", "c1");
 
     OperationRunner operations(*runner_, paths_);
     PushRequest push;
     push.remoteName = "origin";
-    push.branch = "main";
+    push.branches = {"main"};
     push.setUpstream = true;
     auto pushed = submitAndWait(operations, makePushOperation(push));
     ASSERT_TRUE(pushed.succeeded) << (pushed.error ? pushed.error->detail : "");
@@ -2382,7 +2436,7 @@ TEST_F(RemoteRepoTest, ForceWithLeaseRefusesAStalePushAndSucceedsAfterRefetching
     OperationRunner operations(*runner_, paths_);
     PushRequest push;
     push.remoteName = "origin";
-    push.branch = "main";
+    push.branches = {"main"};
     push.setUpstream = true;
     auto pushed = submitAndWait(operations, makePushOperation(push));
     ASSERT_TRUE(pushed.succeeded);
@@ -2417,7 +2471,7 @@ TEST_F(RemoteRepoTest, ForceWithLeaseRefusesAStalePushAndSucceedsAfterRefetching
 
     PushRequest forcePush;
     forcePush.remoteName = "origin";
-    forcePush.branch = "main";
+    forcePush.branches = {"main"};
     forcePush.force = PushForceMode::ForceWithLease;
     auto rejected = submitAndWait(operations, makePushOperation(forcePush));
     EXPECT_FALSE(rejected.succeeded)


### PR DESCRIPTION
Spec **P13 section B**（branch / commit 多選）與四個相依 issue 一起落地。

Fixes #54
Fixes #55
Fixes #56
Fixes #57

---

## 稽核前提更正

依本 repo #45 / #50 / #51 / #60 的慣例記錄，而非靜默套用。三個 issue 的前提被程式碼推翻，且**三處都改變了修法**：

| # | issue 原文主張 | 實際情況 |
|---|---|---|
| #56 | `Merge into current` 需要 oid → 分支名解析（`mergeBranch` 收名字不收 oid） | **錯**。`gbm_merge_branch` 的 `target` 直接組成 `git merge <target>`（`MergeOps.cpp:59,82`），只有空字串被拒；oid 是合法 committish。`startRebase(upstream)` 同理。沒有前置條件，只有接線。 |
| #57 | `Compare with…` 大概需要一個新的小 dialog | **錯**。`sidebar_panel.dart` 的 `_compareStash()` / `_compareTag()` 已立下慣例：只填左側開分頁，右側交給 Compare 頁既有的 `CompareRefPicker`。零新 dialog。 |
| #55 | 沒有 UI 路徑到達 Compare | **部分過時**。`Repository → Compare…`（`Ctrl/Cmd+Shift+C`）早已存在且可用。缺的只有規格字面的「同時選兩個分支 → 右鍵 Compare」。 |
| #54 | 沒有多選機制 | **部分過時**。sidebar 早有 checkbox 式多選（「刪除 gone 分支」那條）。缺的是 MULTIKEYS 的點擊語意與選單。 |

另外，`#55` 的字面讀法需要的是 **sidebar 分支樹**的多選，不是 History 的 —— 稽核報告把兩者的根因併為一條。兩套都做了。

## 主要內容

**選取模型**：`ListSelection<T>`（不可變的 `(ordered items, anchor)` + 五個轉換 + `isContiguousIn` / `orderedBy`），由 `commitSelectionProvider` 與 `branchSelectionProvider` 各持一份（規格：「選取狀態跨 scope 不混用」）。`selectedCommitProvider` 改為 anchor 衍生值，不再可獨立寫入 —— 語意等同舊的單選值，兩個 detail panel 未動。**checkbox 勾選與 Ctrl/Cmd-click 寫進同一份 state**。

**MULTIKEYS**：單擊 / Shift / Ctrl-Cmd / Shift+↑↓ / Ctrl-Cmd+A / Esc，History 與 sidebar 兩處都實作。右鍵兩半語意也都在：點已選中的列不改 selection、選單加計數標題；點未選中的列先收斂成只選它。

**選單**：05-B（8 項）與 05-E（7 項 + `More actions` 5 子項）重建為純函式並改為**精確相等**斷言 —— 舊的 `startsWith` 比對正是兩處用字漂移沒被驗出來的原因。**11 個 context menu 群組現已全數通過 parity 斷言，沒有任何 `skip`。**

**Compare 入口**：COMPARES 1（兩分支同選 → 右鍵 Compare，左右都填好）與 COMPARES 3（兩 commit 同選 → `Compare with…`，left = 較舊）。

**capi**：`gbm_push` 擴為多分支（`branches` / `branchCount`），對齊 `gbm_branch_delete` 既有的多名稱慣例。`git push <remote> a b c` 原生就是「依序執行、失敗不中斷其餘」，且是單一背景任務 —— Dart 端串接會產生 N 個 `OPERATION_FINISHED`，違反 spec page 10。

**狀態列**：History 顯示「N commits · contiguous / not contiguous」，只在 History 為當前分頁時渲染。

## 明確的縮減（記錄，不假造）

| spec 項目 | 處置 | 原因 |
|---|---|---|
| `MULTIACTS` 的 `Squash` | 不提供 | 沒有任何 capi 支撐「把選取的 N 個 commit squash 起來」。 |
| History 狀態列的「合計 diff」 | 只做數量 + 連續性 | `ChangedFile` 沒有增刪行數欄位；唯一有 `--numstat` 的路徑是 `CompareOps.cpp` 的 range diff，做總計等於每次選取變動就打一次 diff。 |
| `Set upstream…` | 永久 disabled | 本 app 沒有這個入口點。依規格「不隱藏」規則保留並附 tooltip。 |

## 幾件用「跑」而非「讀」發現的事

- **`branchCount 0` 不等於指名當前分支**：它完全不傳 refspec，git 走 configured upstream，沒有 upstream 時**直接拒絕**。第一版 C++ 測試就是這樣失敗的，理由已寫進該測試的註解。
- **點 `InkWell` 不會取得 focus**（可 traversal ≠ tap 會 requestFocus），所以分支樹的 Ctrl/Cmd+A 在點過某列之後沒有反應。`_onBranchSelect` 現在先 `requestFocus()`。
- **`Ctrl/Cmd+A` 只能綁在清單自己的 focus scope**：比 `DefaultTextEditingShortcuts` 更靠近焦點的 `Shortcuts` 會搶走文字全選，所以分支樹的綁定刻意只包住捲動區，把 filter `TextField` 留在外面。
- **連續性一律用未過濾的 snapshot 判斷**；每個*轉換*則對可見清單計算，兩者不能互換。

## 測試

- Flutter：`flutter analyze` 0 issues、`dart format --set-exit-if-changed .` 0 changed、`flutter test` **1162 passed**。
- C++：`ctest` 531/531（2 個 LFS 測試 skip），含兩個新的 `RemoteRepoTest`。
- 裝置層（唯一擋得住 FFI 簽章不同步的一層，`lookupFunction` 只比對符號名稱）：
  `flutter test integration_test/multi_push_flow_test.dart -d macos`、
  `flutter test integration_test/rename_branch_flow_test.dart -d macos` 皆通過。

## 相關但未關閉

- **#76** —— P13 B 區已在本 PR 實作（含上表兩項縮減）；P13 A 區稽核與 P14–P16 仍未做。`MULTIACTS` 的 file / stash 兩列也未對 MULTIKEYS 重新稽核。
- **#75** —— 其中 `Edit → Select all`（`Ctrl/Cmd+A`）已由本 PR 補上，其餘三列仍未解。
- **#74** —— `delete_branch_dialog.dart` 的 `_remoteOf()` 第一個斜線切分 bug 未動；本 PR 新增的程式碼一律走 `remoteBranchParts()`。
