### PR TITLE
test: 狀態機切換與突兀取消的整合測試（並修好三個從未運作的 dispose 安全網）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1573,3 +1573,96 @@ open on **hover after 120ms**; it opens on tap, because `showGbmMenu` is
 built on Material's `showMenu`, whose modal barrier makes a hover-opened
 child unhoverable from its own parent — Tier 4 documented this and it has
 not changed (**#87**).
+
+### Cancel-surface integration tests (test/cancel-surface-integration-tests)
+
+Integration coverage for the two halves of one question — *does the state
+machine stay clean when intents switch, and when an operation is cancelled
+abruptly?* Six sequential commits, each green and independently revertible.
+Four new files under `test/integration/`, plus one `lib/` fix the tests
+forced out into the open.
+
+**The defect: `ref` inside `dispose()` never worked, in any of the three
+interrupt dialogs.** `credential_dialog.dart`, `checkout_recovery_dialog.dart`
+and `delete_branch_recovery_dialog.dart` each carried a `_resolved` flag plus
+a `dispose()` that dispatched the cancel command when the dialog was popped
+unanswered — the safety net for a barrier tap, a back gesture, or a route
+change out from under it. It threw `StateError` every single time.
+flutter_riverpod's `ConsumerStatefulElement._assertNotDisposed()` gates every
+`ref` member on `context.mounted`, and by the time `State.dispose()` runs the
+element is already unmounted. So the guard is unconditional: **any `ref` use
+in a `ConsumerState.dispose()` throws.** Fixed by capturing the notifier in
+`initState()` into a field and calling that, guarded on
+`StateNotifier.mounted` in case the provider went first.
+
+The blast radius was real, not theoretical. For the credential dialog the
+net is what stops a blocked git subprocess hanging until `GBM_ASKPASS`'s own
+timeout — so every non-button dismissal of a credential prompt left git
+waiting.
+
+**Why it survived so long is the more useful lesson.**
+`workspace_interrupt_overlay_test.dart`'s header had *seen* the throw and
+written it down — but attributed it to test-harness mechanics ("throws if it
+fires after pumpWorkspace's ProviderContainer is already disposed by
+addTearDown") and worked around it by resolving every dialog before the test
+ended. A correct observation with a wrong cause becomes a permanent excuse:
+the workaround was carried into every later test in that file, and the real
+path was never exercised. That comment is corrected in place. **A note
+explaining why a test must avoid a code path deserves the same scrutiny as
+the code path itself.**
+
+**Three harness facts found by running, each of which would otherwise read
+as a bug in the code under test:**
+
+- **Never `pumpAndSettle()` while `isRefreshing` is true.** `TopBar` renders
+  an indeterminate `CircularProgressIndicator` for exactly that flag, and an
+  indeterminate spinner schedules frames forever — `pumpAndSettle` times out
+  instead of failing on the assertion under test, which looks like a hang in
+  the status bar rather than a harness misuse. Use `pump()` until the flag is
+  back off.
+- **`StatusBar` lingers a finished task for 3 seconds** (`_lingerTimer`), so
+  "the task cleared" cannot be asserted on the frame after the transition.
+  Drain with `pump(Duration(seconds: 3, ...))` — asserting too early would
+  pin the linger away by accident.
+- **A barrier tap is the right gesture for "dismissed without answering"**
+  (`dialogRoute`'s `barrierDismissible: true`); `router.pop()` reaches the
+  same path and is the recorded fallback. Esc/`DismissIntent` focus semantics
+  are not worth fighting.
+
+**Two fixture rules this round re-earned:**
+
+- **Do not borrow `workspace_conflict_transition_test.dart`'s `_mergeState()`.**
+  It sets `isSequencerOperation: true` for a merge; the core's flag excludes
+  merge on purpose (`gbm_sequencer_operation.dart`'s IMPORTANT block).
+  Harmless there — that file only needs `conflictActive`, which the
+  conflicted entry supplies — but `_backgroundTasks()` gates the status-bar
+  sequencer task on exactly that flag, so borrowing it manufactures a
+  "Merging" task and pins the *opposite* of the documented behaviour. The
+  faithful fixture is what makes "a merge conflict shows the banner but
+  contributes no status-bar task" meaningful, and mutation-checking confirmed
+  it: swap the fixture back and the test goes red. Same shape as Tier 0c's
+  `hasTrackingInfo` trap — a fixture that disagrees with its source cannot
+  falsify anything.
+- **Count, don't `any`.** Every "exactly once" assertion goes through
+  `commandLog.where((c) => c.name == ...).length`. `.any(...)` is blind to a
+  double dispatch, and a double dispatch is precisely what deleting
+  `_resolved` would cause — the button path would fire the cancel, then
+  `dispose()` would fire it again. The button-path tests are what pin that
+  flag; the barrier-path tests alone would not.
+
+**What the tests cover**, beyond the fix's own regression lock:
+`workspace_conflict_abort_dispatch_test.dart` closes the gap left by the
+existing revert-only case — all three dispatching arms of
+`_handleConflictAbort/Skip/Continue` through the real buttons, plus the two
+state-machine properties that motivated the batch: a mid-flight kind change
+must re-target the same Abort button without repeating the previous call, and
+`rebaseMerge | cherryPick` (a real on-disk state — a rebase on the merge
+backend leaves `CHERRY_PICK_HEAD` mid-step) must resolve to rebase per
+`activeSequencerOperation()`'s documented ladder. Mutation-checked by
+inverting that ladder.
+
+`FakeRepoSessionController` gained a `refreshHistory` override. Without it
+the status-bar Cancel test could not tell a dead button from a dispatched
+one — the unoverridden method hits the real `_session == nullptr` guard and
+silently no-ops, which is the fake's documented failure mode for anything it
+forgets to record.

--- a/app_flutter/lib/features/dialogs/checkout_recovery/checkout_recovery_dialog.dart
+++ b/app_flutter/lib/features/dialogs/checkout_recovery/checkout_recovery_dialog.dart
@@ -33,12 +33,26 @@ class _CheckoutRecoveryDialogContentState
     extends ConsumerState<CheckoutRecoveryDialogContent> {
   bool _resolved = false;
 
+  /// Captured up front because [dispose] cannot reach `ref`: by the time
+  /// `State.dispose()` runs the element is already unmounted, and
+  /// flutter_riverpod gates every `ref` member on `context.mounted`
+  /// (`ConsumerStatefulElement._assertNotDisposed`). A `ref.read(...)` there
+  /// therefore throws `StateError: Cannot use "ref" after the widget was
+  /// disposed` **unconditionally** -- which silently broke the
+  /// dispatch-on-the-way-out below for as long as it existed. Holding the
+  /// notifier is the supported way to dispatch during disposal.
+  late final RepoSessionController _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _session = ref.read(repoSessionProvider(widget.identity).notifier);
+  }
+
   @override
   void dispose() {
-    if (!_resolved) {
-      ref
-          .read(repoSessionProvider(widget.identity).notifier)
-          .dismissCheckoutChoices();
+    if (!_resolved && _session.mounted) {
+      _session.dismissCheckoutChoices();
     }
     super.dispose();
   }

--- a/app_flutter/lib/features/dialogs/credential/credential_dialog.dart
+++ b/app_flutter/lib/features/dialogs/credential/credential_dialog.dart
@@ -32,15 +32,29 @@ class _CredentialDialogContentState
   final TextEditingController _secretController = TextEditingController();
   bool _resolved = false;
 
+  /// Captured up front because [dispose] cannot reach `ref`: by the time
+  /// `State.dispose()` runs the element is already unmounted, and
+  /// flutter_riverpod gates every `ref` member on `context.mounted`
+  /// (`ConsumerStatefulElement._assertNotDisposed`). A `ref.read(...)` there
+  /// therefore throws `StateError: Cannot use "ref" after the widget was
+  /// disposed` **unconditionally** -- which silently broke the
+  /// dispatch-on-the-way-out below for as long as it existed. Holding the
+  /// notifier is the supported way to dispatch during disposal.
+  late final RepoSessionController _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _session = ref.read(repoSessionProvider(widget.identity).notifier);
+  }
+
   @override
   void dispose() {
     // Popped some other way (e.g. Esc via the barrier) without answering --
     // treat that the same as Cancel, so the blocked git subprocess does not
     // hang until GBM_ASKPASS's own timeout.
-    if (!_resolved) {
-      ref
-          .read(repoSessionProvider(widget.identity).notifier)
-          .cancelCredential();
+    if (!_resolved && _session.mounted) {
+      _session.cancelCredential();
     }
     _secretController.dispose();
     super.dispose();

--- a/app_flutter/lib/features/dialogs/delete_branch_recovery/delete_branch_recovery_dialog.dart
+++ b/app_flutter/lib/features/dialogs/delete_branch_recovery/delete_branch_recovery_dialog.dart
@@ -32,12 +32,26 @@ class _DeleteBranchRecoveryDialogContentState
     extends ConsumerState<DeleteBranchRecoveryDialogContent> {
   bool _resolved = false;
 
+  /// Captured up front because [dispose] cannot reach `ref`: by the time
+  /// `State.dispose()` runs the element is already unmounted, and
+  /// flutter_riverpod gates every `ref` member on `context.mounted`
+  /// (`ConsumerStatefulElement._assertNotDisposed`). A `ref.read(...)` there
+  /// therefore throws `StateError: Cannot use "ref" after the widget was
+  /// disposed` **unconditionally** -- which silently broke the
+  /// dispatch-on-the-way-out below for as long as it existed. Holding the
+  /// notifier is the supported way to dispatch during disposal.
+  late final RepoSessionController _session;
+
+  @override
+  void initState() {
+    super.initState();
+    _session = ref.read(repoSessionProvider(widget.identity).notifier);
+  }
+
   @override
   void dispose() {
-    if (!_resolved) {
-      ref
-          .read(repoSessionProvider(widget.identity).notifier)
-          .dismissDeleteBranchChoices();
+    if (!_resolved && _session.mounted) {
+      _session.dismissDeleteBranchChoices();
     }
     super.dispose();
   }

--- a/app_flutter/test/integration/workspace_conflict_abort_dispatch_test.dart
+++ b/app_flutter/test/integration/workspace_conflict_abort_dispatch_test.dart
@@ -1,0 +1,302 @@
+// Integration coverage for the other half of the "sudden cancel" story:
+// ConflictBanner's Abort/Skip/Continue, which are how a user bails out of a
+// sequencer operation that has stopped on a conflict.
+//
+// WorkspaceScreen._handleConflictAbort/_handleConflictSkip/
+// _handleConflictContinue each switch exhaustively over
+// activeSequencerOperation(session.repoState) and dispatch a *different*
+// backend call per kind. Only one branch of that had coverage before this
+// file: workspace_conflict_transition_test.dart's revert case, which proves
+// the null/revert arms no-op. The three arms that actually dispatch --
+// merge, cherry-pick, rebase -- were untested through the real buttons.
+//
+// Two properties here are specifically about the state machine *changing*
+// underneath a live banner, which is the thing this batch exists for:
+//
+//   * when the kind switches mid-flight, the same Abort button must
+//     re-target the new kind and never repeat the old one's call, and
+//   * when two flags are set at once, the documented priority ladder
+//     (rebase > cherry-pick > revert > merge) decides -- a real on-disk
+//     state, because a rebase using the merge backend leaves CHERRY_PICK_HEAD
+//     lying around mid-step.
+//
+// Buttons are found through `find.descendant(of: find.byType(ConflictBanner))`
+// rather than bare text: ConflictResolveWindow and the status bar render
+// overlapping vocabulary, and the whole WorkspaceScreen is mounted here.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/repo_state.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/workspace/workspace_screen.dart'
+    show ConflictBanner;
+
+import '../support/fake_repo_session.dart';
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/repo',
+  gitDir: '/test/repo/.git',
+);
+
+const WorkingCopyEntry _conflictEntry = WorkingCopyEntry(
+  path: 'conflict.txt',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+/// A conflicted session whose sequencer kind is decided purely by [flags].
+///
+/// `isSequencerOperation` mirrors the core's own predicate, which excludes
+/// merge (src/core/git/RepoState.h) -- it plays no part in which kind
+/// [activeSequencerOperation] derives, and `conflictActive` is satisfied by
+/// the conflicted entry either way, so getting it right costs nothing and
+/// keeps the fixture honest.
+RepoSessionState _conflicted(int flags) => RepoSessionState(
+  isOpen: true,
+  repoState: RepoState(
+    flags: flags,
+    isClean: false,
+    isSequencerOperation: flags != RepoStateFlags.merge,
+    rebaseStep: 1,
+    rebaseTotal: 3,
+    rebaseOntoLabel: 'main',
+    indexLocked: false,
+    indexLockAgeSeconds: null,
+    describe: '',
+  ),
+  workingCopyStatus: const WorkingCopyStatus(
+    entries: <WorkingCopyEntry>[_conflictEntry],
+  ),
+);
+
+Finder _bannerButton(String label) => find.descendant(
+  of: find.byType(ConflictBanner),
+  matching: find.widgetWithText(TextButton, label),
+);
+
+Future<void> _tapBanner(WidgetTester tester, String label) async {
+  await tester.tap(_bannerButton(label));
+  await tester.pumpAndSettle();
+}
+
+int _countOf(FakeRepoSessionController controller, String name) =>
+    controller.commandLog.where((c) => c.name == name).length;
+
+void main() {
+  group('ConflictBanner dispatch by sequencer kind', () {
+    testWidgets('merge: Abort reaches mergeAbort; Skip and Continue are '
+        'disabled', (tester) async {
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflicted(RepoStateFlags.merge),
+      );
+
+      expect(
+        tester.widget<TextButton>(_bannerButton('Skip')).onPressed,
+        isNull,
+        reason:
+            'SequencerOperationKind.merge.canSkip is false -- git has no '
+            'notion of skipping one file\'s conflict during a merge.',
+      );
+      expect(
+        tester.widget<TextButton>(_bannerButton('Continue')).onPressed,
+        isNull,
+        reason:
+            'There is no gbm_merge_continue(); a plain commit finishes a '
+            'merge.',
+      );
+
+      await _tapBanner(tester, 'Abort');
+
+      expect(_countOf(pumped.controller, 'mergeAbort'), 1);
+      expect(_countOf(pumped.controller, 'abortRebase'), 0);
+      expect(_countOf(pumped.controller, 'cherryPickAbort'), 0);
+    });
+
+    testWidgets('cherry-pick: Abort, Skip and Continue each reach their own '
+        'backend call', (tester) async {
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflicted(RepoStateFlags.cherryPick),
+      );
+
+      await _tapBanner(tester, 'Skip');
+      await _tapBanner(tester, 'Continue');
+      await _tapBanner(tester, 'Abort');
+
+      expect(_countOf(pumped.controller, 'cherryPickSkip'), 1);
+      expect(_countOf(pumped.controller, 'cherryPickContinue'), 1);
+      expect(_countOf(pumped.controller, 'cherryPickAbort'), 1);
+      expect(
+        _countOf(pumped.controller, 'skipRebase') +
+            _countOf(pumped.controller, 'continueRebase') +
+            _countOf(pumped.controller, 'abortRebase'),
+        0,
+        reason:
+            'A cherry-pick must never be dispatched to rebase\'s entry '
+            'points -- the implicit "anything else -> rebase" fallback these '
+            'switches replaced would have done exactly that.',
+      );
+    });
+
+    testWidgets('rebase: Abort, Skip and Continue each reach their own '
+        'backend call', (tester) async {
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflicted(RepoStateFlags.rebaseApply),
+      );
+
+      await _tapBanner(tester, 'Skip');
+      await _tapBanner(tester, 'Continue');
+      await _tapBanner(tester, 'Abort');
+
+      expect(_countOf(pumped.controller, 'skipRebase'), 1);
+      expect(_countOf(pumped.controller, 'continueRebase'), 1);
+      expect(_countOf(pumped.controller, 'abortRebase'), 1);
+      expect(
+        _countOf(pumped.controller, 'cherryPickSkip') +
+            _countOf(pumped.controller, 'cherryPickContinue') +
+            _countOf(pumped.controller, 'cherryPickAbort'),
+        0,
+      );
+    });
+
+    testWidgets(
+      'rebaseMerge + cherryPick set at once: the priority ladder picks '
+      'rebase',
+      (tester) async {
+        // Not a synthetic combination: a conflicted `git rebase` on the
+        // merge backend leaves CHERRY_PICK_HEAD on disk mid-step, so both
+        // flags really are set at the same time. activeSequencerOperation()
+        // documents rebase > cherry-pick > revert > merge as a deliberate
+        // behaviour correction over the old merge-first ladders.
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: _conflicted(
+            RepoStateFlags.rebaseMerge | RepoStateFlags.cherryPick,
+          ),
+        );
+
+        await _tapBanner(tester, 'Abort');
+
+        expect(_countOf(pumped.controller, 'abortRebase'), 1);
+        expect(
+          _countOf(pumped.controller, 'cherryPickAbort'),
+          0,
+          reason:
+              'Reading the flags in the wrong order would abort the '
+              'cherry-pick half of a rebase, leaving the rebase itself in '
+              'progress.',
+        );
+      },
+    );
+  });
+
+  group('ConflictBanner dispatch follows a mid-flight kind change', () {
+    testWidgets(
+      'merge -> rebase: the same Abort button re-targets and does not repeat '
+      'the previous call',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: _conflicted(RepoStateFlags.merge),
+        );
+
+        await _tapBanner(tester, 'Abort');
+        expect(_countOf(pumped.controller, 'mergeAbort'), 1);
+
+        pumped.controller.emit(_conflicted(RepoStateFlags.rebaseApply));
+        await tester.pumpAndSettle();
+
+        await _tapBanner(tester, 'Abort');
+
+        expect(_countOf(pumped.controller, 'abortRebase'), 1);
+        expect(
+          _countOf(pumped.controller, 'mergeAbort'),
+          1,
+          reason:
+              'The banner\'s closures are rebuilt from the new session on '
+              'every build; a stale capture would keep aborting the merge '
+              'that is no longer in progress.',
+        );
+      },
+    );
+
+    testWidgets(
+      'merge -> cherry-pick: Skip and Continue go from disabled to live and '
+      'dispatch the new kind',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: _conflicted(RepoStateFlags.merge),
+        );
+
+        expect(
+          tester.widget<TextButton>(_bannerButton('Skip')).onPressed,
+          isNull,
+        );
+
+        pumped.controller.emit(_conflicted(RepoStateFlags.cherryPick));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.widget<TextButton>(_bannerButton('Skip')).onPressed,
+          isNotNull,
+          reason:
+              'canSkip flips with the kind, so the button must flip with it '
+              '-- a gate that only reads the initial state would leave Skip '
+              'permanently dead for the rest of the session.',
+        );
+
+        await _tapBanner(tester, 'Skip');
+        expect(_countOf(pumped.controller, 'cherryPickSkip'), 1);
+      },
+    );
+
+    testWidgets(
+      'conflict -> clean: the banner goes away and its buttons take nothing '
+      'with them',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: _conflicted(RepoStateFlags.cherryPick),
+        );
+
+        await _tapBanner(tester, 'Abort');
+        expect(_countOf(pumped.controller, 'cherryPickAbort'), 1);
+
+        pumped.controller.emit(const RepoSessionState(isOpen: true));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ConflictBanner), findsNothing);
+        expect(
+          pumped.controller.commandLog.where((c) => c.name.contains('Abort')),
+          hasLength(1),
+          reason:
+              'Clearing the conflict must not replay the abort -- the '
+              'operation is already over.',
+        );
+      },
+    );
+  });
+}

--- a/app_flutter/test/integration/workspace_dialog_teardown_test.dart
+++ b/app_flutter/test/integration/workspace_dialog_teardown_test.dart
@@ -1,0 +1,272 @@
+// Integration coverage for what happens to an interrupt dialog when the
+// thing underneath it moves: the state it was opened for resolves itself,
+// or the route it sits on is replaced.
+//
+// These are the two "sudden" endings that are not a user gesture on the
+// dialog at all, and each pins a decision that is easy to get backwards:
+//
+//   * A dialog does NOT close just because its backing field went null.
+//     CredentialDialogContent's doc comment is explicit that the dialog
+//     pops itself once answered or cancelled, "not by the controller going
+//     back to null" -- a credential handshake routinely clears and re-sets
+//     the prompt for the follow-up (username, then password), and closing
+//     on the intermediate null would blink the dialog away mid-handshake.
+//   * A route change out from under an unanswered dialog must still reach
+//     the cancel path, or the blocked git subprocess hangs.
+//
+// Both then have to leave the state machine re-armable: WorkspaceScreen
+// pushes each interrupt dialog only on the null->non-null (or
+// empty->non-empty) edge, so anything that ends a dialog without the field
+// being cleared silences every later prompt.
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/repo_state.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/credential/credential_dialog.dart';
+import 'package:gbm_flutter/features/workspace/workspace_screen.dart'
+    show ConflictBanner;
+import 'package:gbm_flutter/routing/dialog_route.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/widgets/gbm_button.dart';
+import 'package:go_router/go_router.dart';
+
+import '../support/fake_repo_session.dart';
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/repo',
+  gitDir: '/test/repo/.git',
+);
+
+final String _repoId = Uri.encodeComponent(_identity.workDir);
+
+final List<RouteBase> _credentialRoute = <RouteBase>[
+  dialogRoute(
+    path: RoutePaths.credentialDialog,
+    builder: (context, state) => CredentialDialogContent(identity: _identity),
+  ),
+];
+
+const WorkingCopyEntry _conflictEntry = WorkingCopyEntry(
+  path: 'conflict.txt',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+RepoSessionState _cherryPickConflict() => RepoSessionState(
+  isOpen: true,
+  repoState: const RepoState(
+    flags: RepoStateFlags.cherryPick,
+    isClean: false,
+    isSequencerOperation: true,
+    rebaseStep: 1,
+    rebaseTotal: 3,
+    rebaseOntoLabel: '',
+    indexLocked: false,
+    indexLockAgeSeconds: null,
+    describe: '',
+  ),
+  workingCopyStatus: const WorkingCopyStatus(
+    entries: <WorkingCopyEntry>[_conflictEntry],
+  ),
+);
+
+int _countOf(FakeRepoSessionController controller, String name) =>
+    controller.commandLog.where((c) => c.name == name).length;
+
+Future<void> _pressCtrlShiftF(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyF);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyF);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('interrupt dialog vs the state resolving underneath it', () {
+    testWidgets('credentialPrompt going back to null leaves the dialog open', (
+      tester,
+    ) async {
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        topLevelRoutes: _credentialRoute,
+      );
+
+      pumped.controller.emit(
+        pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(CredentialDialogContent), findsOneWidget);
+
+      pumped.controller.emit(
+        pumped.controller.state.copyWith(clearCredentialPrompt: true),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(CredentialDialogContent),
+        findsOneWidget,
+        reason:
+            'The dialog pops itself once answered or cancelled, never on '
+            'the field clearing -- an askpass handshake clears and re-sets '
+            'the prompt between username and password, and auto-closing '
+            'would blink the dialog away mid-handshake.',
+      );
+      expect(
+        _countOf(pumped.controller, 'cancelCredential'),
+        0,
+        reason: 'Nothing has been cancelled yet.',
+      );
+
+      await tester.tap(find.widgetWithText(GbmButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CredentialDialogContent), findsNothing);
+      expect(_countOf(pumped.controller, 'cancelCredential'), 1);
+    });
+  });
+
+  group('interrupt dialog vs the route changing under it', () {
+    testWidgets(
+      'navigating to another tab pops the dialog and cancels exactly once',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _credentialRoute,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(CredentialDialogContent), findsOneWidget);
+
+        pumped.router.go(RoutePaths.workingCopyFor(_repoId));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CredentialDialogContent), findsNothing);
+        expect(
+          _countOf(pumped.controller, 'cancelCredential'),
+          1,
+          reason:
+              'A dialog torn down by navigation is still an unanswered '
+              'prompt; without this the git subprocess waits for '
+              "GBM_ASKPASS's timeout.",
+        );
+      },
+    );
+
+    testWidgets(
+      're-arm after a navigation teardown: a fresh prompt opens the dialog '
+      'again from the new tab',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _credentialRoute,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+        );
+        await tester.pumpAndSettle();
+        pumped.router.go(RoutePaths.workingCopyFor(_repoId));
+        await tester.pumpAndSettle();
+
+        // What the real cancelCredential() publishes; the fake records
+        // rather than mutating, so the test stands in for it.
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(clearCredentialPrompt: true),
+        );
+        await tester.pumpAndSettle();
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Password'),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(CredentialDialogContent),
+          findsOneWidget,
+          reason:
+              'The auto-push listener lives on WorkspaceScreen, which is the '
+              'ShellRoute builder and survives the tab change -- so the '
+              'null -> non-null edge must still fire from the new tab.',
+        );
+
+        await tester.tap(find.widgetWithText(GbmButton, 'Cancel'));
+        await tester.pumpAndSettle();
+      },
+    );
+  });
+
+  group('conflict state vs tab changes', () {
+    testWidgets(
+      'the banner and its gates survive a History <-> Working Copy round '
+      'trip with no residue',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: _cherryPickConflict(),
+        );
+
+        expect(find.byType(ConflictBanner), findsOneWidget);
+        await _pressCtrlShiftF(tester);
+        expect(
+          _countOf(pumped.controller, 'fetchRemote'),
+          0,
+          reason: 'Fetch is gated off mid-conflict (spec page 07 STATES).',
+        );
+
+        pumped.router.go(RoutePaths.workingCopyFor(_repoId));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(ConflictBanner),
+          findsOneWidget,
+          reason:
+              'The banner is rendered by the shell, not the tab, so it must '
+              'neither vanish nor duplicate across a tab change.',
+        );
+        await _pressCtrlShiftF(tester);
+        expect(_countOf(pumped.controller, 'fetchRemote'), 0);
+
+        pumped.router.go(RoutePaths.historyFor(_repoId));
+        await tester.pumpAndSettle();
+        expect(find.byType(ConflictBanner), findsOneWidget);
+
+        // And the gate lifts on the way back out, from whichever tab.
+        pumped.controller.emit(const RepoSessionState(isOpen: true));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ConflictBanner), findsNothing);
+        await _pressCtrlShiftF(tester);
+        expect(
+          _countOf(pumped.controller, 'fetchRemote'),
+          1,
+          reason:
+              'Clean again: the shortcut must work, or the conflict gate has '
+              'left residue behind.',
+        );
+      },
+    );
+  });
+}

--- a/app_flutter/test/integration/workspace_interrupt_abrupt_dismiss_test.dart
+++ b/app_flutter/test/integration/workspace_interrupt_abrupt_dismiss_test.dart
@@ -366,30 +366,27 @@ void main() {
   });
 
   group('delete-branch recovery dialog -- abrupt dismissal', () {
-    testWidgets(
-      'a barrier tap pops the dialog and dispatches '
-      'dismissDeleteBranchChoices exactly once',
-      (tester) async {
-        final pumped = await pumpWorkspace(
-          tester,
-          identity: _identity,
-          topLevelRoutes: _interruptDialogRoutes,
-        );
+    testWidgets('a barrier tap pops the dialog and dispatches '
+        'dismissDeleteBranchChoices exactly once', (tester) async {
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        topLevelRoutes: _interruptDialogRoutes,
+      );
 
-        pumped.controller.emit(
-          pumped.controller.state.copyWith(
-            deleteBranchChoices: _deleteBranchChoices,
-          ),
-        );
-        await tester.pumpAndSettle();
-        expect(find.byType(DeleteBranchRecoveryDialogContent), findsOneWidget);
+      pumped.controller.emit(
+        pumped.controller.state.copyWith(
+          deleteBranchChoices: _deleteBranchChoices,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(DeleteBranchRecoveryDialogContent), findsOneWidget);
 
-        await _dismissViaBarrier(tester);
+      await _dismissViaBarrier(tester);
 
-        expect(find.byType(DeleteBranchRecoveryDialogContent), findsNothing);
-        expect(_countOf(pumped.controller, 'dismissDeleteBranchChoices'), 1);
-      },
-    );
+      expect(find.byType(DeleteBranchRecoveryDialogContent), findsNothing);
+      expect(_countOf(pumped.controller, 'dismissDeleteBranchChoices'), 1);
+    });
 
     testWidgets(
       'resolving via Cancel dispatches dismissDeleteBranchChoices exactly '

--- a/app_flutter/test/integration/workspace_interrupt_abrupt_dismiss_test.dart
+++ b/app_flutter/test/integration/workspace_interrupt_abrupt_dismiss_test.dart
@@ -1,0 +1,478 @@
+// Integration coverage for the "cancel suddenly" half of the state-machine
+// batch: what happens when one of WorkspaceScreen's three auto-pushed
+// interrupt dialogs is closed *without* going through its own Cancel
+// button -- a barrier tap, a system back gesture, a route change out from
+// under it.
+//
+// All three dialogs carry the same safety net: a `_resolved` bool plus a
+// `dispose()` that dispatches the cancel command when the dialog is popped
+// unanswered (credential_dialog.dart:36, checkout_recovery_dialog.dart:37,
+// delete_branch_recovery_dialog.dart:36). For the credential dialog that
+// net is load-bearing -- without it the blocked git subprocess hangs until
+// GBM_ASKPASS's own timeout.
+//
+// That net had no behavioural coverage at any tier before this file.
+// workspace_interrupt_overlay_test.dart drives only the Cancel *button*,
+// and mentions dispose() solely as a test-authoring hazard ("resolve before
+// the test ends"), never as a thing that is asserted to work.
+//
+// Two properties are pinned per dialog, and the pair only works together:
+//
+//   * abrupt dismissal dispatches the cancel command EXACTLY ONCE, and
+//   * resolving via the button dispatches it EXACTLY ONCE TOO.
+//
+// The second is what actually pins `_resolved`. Delete that flag and the
+// button path fires twice (once from the handler, once from dispose) --
+// invisible to a `commandLog.any(...)` assertion, which is why every count
+// below goes through `.where(...).length`. `.any` cannot fail on a double
+// dispatch.
+//
+// A third property covers the state machine's re-arm edge: WorkspaceScreen
+// pushes each dialog only on the null->non-null (or empty->non-empty)
+// transition, so if a dismissal left the field populated the *next* prompt
+// would never surface. The fake never mutates state on its own (see
+// FakeRepoSessionController's doc comment), so each test emits the cleared
+// state explicitly -- exactly what the real controller's cancelCredential()
+// does via `copyWith(clearCredentialPrompt: true)` -- and then asserts a
+// fresh value re-opens the dialog.
+//
+// Finder scoping follows workspace_interrupt_overlay_test.dart's header:
+// these dialogs are non-opaque (dialog_route.dart's `opaque: false`), so the
+// WorkspaceScreen underneath stays mounted and a bare `find.text(...)` is
+// ambiguous.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/operation_choice.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/dialogs/checkout_recovery/checkout_recovery_dialog.dart';
+import 'package:gbm_flutter/features/dialogs/credential/credential_dialog.dart';
+import 'package:gbm_flutter/features/dialogs/delete_branch_recovery/delete_branch_recovery_dialog.dart';
+import 'package:gbm_flutter/routing/dialog_route.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
+import 'package:gbm_flutter/widgets/gbm_button.dart';
+import 'package:go_router/go_router.dart';
+
+import '../support/fake_repo_session.dart';
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/repo',
+  gitDir: '/test/repo/.git',
+);
+
+final List<RouteBase> _interruptDialogRoutes = <RouteBase>[
+  dialogRoute(
+    path: RoutePaths.credentialDialog,
+    builder: (context, state) => CredentialDialogContent(identity: _identity),
+  ),
+  dialogRoute(
+    path: RoutePaths.checkoutRecoveryDialog,
+    builder: (context, state) =>
+        CheckoutRecoveryDialogContent(identity: _identity),
+  ),
+  dialogRoute(
+    path: RoutePaths.deleteBranchRecoveryDialog,
+    builder: (context, state) =>
+        DeleteBranchRecoveryDialogContent(identity: _identity),
+  ),
+];
+
+const List<OperationChoice> _checkoutChoices = <OperationChoice>[
+  OperationChoice(
+    kind: OperationChoiceKind.stashAndRetry,
+    label: 'Stash changes and checkout',
+    explanation: '',
+    destructive: false,
+  ),
+];
+
+const List<OperationChoice> _deleteBranchChoices = <OperationChoice>[
+  OperationChoice(
+    kind: OperationChoiceKind.forceDiscard,
+    label: 'Force delete',
+    explanation: 'This branch is not fully merged.',
+    destructive: true,
+  ),
+];
+
+/// Closes the topmost dialog the way a user who never touched its buttons
+/// would: a tap on the modal barrier (`dialogRoute`'s
+/// `barrierDismissible: true`). The offset is the top-left corner, which is
+/// always barrier rather than dialog -- GbmDialogShell is centred.
+///
+/// This is the real gesture, so it is what the tests use. `router.pop()`
+/// reaches the same `dispose()`-with-`_resolved == false` path and is the
+/// recorded fallback if a future Flutter/go_router version stops honouring
+/// `barrierDismissible` on a `CustomTransitionPage`.
+Future<void> _dismissViaBarrier(WidgetTester tester) async {
+  await tester.tapAt(const Offset(10, 10));
+  await tester.pumpAndSettle();
+}
+
+/// Taps the action-bar [GbmButton] carrying [label] -- not the matching
+/// plain-text row the recovery dialogs repeat in their body.
+Future<void> _tapActionButton(WidgetTester tester, String label) async {
+  await tester.tap(find.widgetWithText(GbmButton, label));
+  await tester.pumpAndSettle();
+}
+
+int _countOf(FakeRepoSessionController controller, String name) =>
+    controller.commandLog.where((c) => c.name == name).length;
+
+void main() {
+  group('credential dialog -- abrupt dismissal', () {
+    testWidgets(
+      'a barrier tap pops the dialog and dispatches cancelCredential exactly '
+      'once',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(CredentialDialogContent), findsOneWidget);
+
+        await _dismissViaBarrier(tester);
+
+        expect(find.byType(CredentialDialogContent), findsNothing);
+        expect(
+          _countOf(pumped.controller, 'cancelCredential'),
+          1,
+          reason:
+              'CredentialDialogContent.dispose() must treat an unanswered '
+              'pop as a Cancel, otherwise the blocked git subprocess hangs '
+              "until GBM_ASKPASS's own timeout.",
+        );
+      },
+    );
+
+    testWidgets(
+      'resolving via the Cancel button dispatches cancelCredential exactly '
+      'once -- dispose must not fire a second copy',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+        );
+        await tester.pumpAndSettle();
+
+        await _tapActionButton(tester, 'Cancel');
+
+        expect(
+          _countOf(pumped.controller, 'cancelCredential'),
+          1,
+          reason:
+              'The `_resolved` flag exists precisely to stop dispose() from '
+              'repeating what the button already dispatched. Removing it '
+              'would answer the same askpass handshake twice.',
+        );
+      },
+    );
+
+    testWidgets(
+      'Submit then dispose: provideCredential once, no stray cancelCredential',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.descendant(
+            of: find.byType(CredentialDialogContent),
+            matching: find.byType(TextField),
+          ),
+          'octocat',
+        );
+        await _tapActionButton(tester, 'Submit');
+
+        expect(_countOf(pumped.controller, 'provideCredential'), 1);
+        expect(
+          _countOf(pumped.controller, 'cancelCredential'),
+          0,
+          reason:
+              'An answered prompt must not also be cancelled on the way out '
+              '-- that would tell the capi to abandon a handshake it has '
+              'already been given a secret for.',
+        );
+      },
+    );
+
+    testWidgets(
+      're-arm: after an abrupt dismissal a fresh prompt opens the dialog '
+      'again',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Username'),
+        );
+        await tester.pumpAndSettle();
+        await _dismissViaBarrier(tester);
+
+        // What the real cancelCredential() publishes (repo_session_
+        // repository.dart:2208). The fake records instead of mutating, so
+        // the test stands in for it.
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(clearCredentialPrompt: true),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(CredentialDialogContent), findsNothing);
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(credentialPrompt: 'Password'),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(CredentialDialogContent),
+          findsOneWidget,
+          reason:
+              'WorkspaceScreen pushes this dialog only on the null -> '
+              'non-null edge, so a dismissal that left credentialPrompt '
+              'populated would silence every later prompt.',
+        );
+
+        await _tapActionButton(tester, 'Cancel');
+      },
+    );
+  });
+
+  group('checkout recovery dialog -- abrupt dismissal', () {
+    testWidgets(
+      'a barrier tap pops the dialog and dispatches dismissCheckoutChoices '
+      'exactly once',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(checkoutChoices: _checkoutChoices),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(CheckoutRecoveryDialogContent), findsOneWidget);
+
+        await _dismissViaBarrier(tester);
+
+        expect(find.byType(CheckoutRecoveryDialogContent), findsNothing);
+        expect(_countOf(pumped.controller, 'dismissCheckoutChoices'), 1);
+      },
+    );
+
+    testWidgets(
+      'resolving via Cancel dispatches dismissCheckoutChoices exactly once',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(checkoutChoices: _checkoutChoices),
+        );
+        await tester.pumpAndSettle();
+
+        await _tapActionButton(tester, 'Cancel');
+
+        expect(_countOf(pumped.controller, 'dismissCheckoutChoices'), 1);
+      },
+    );
+
+    testWidgets(
+      'picking a choice retries once and does not also dismiss on the way out',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(checkoutChoices: _checkoutChoices),
+        );
+        await tester.pumpAndSettle();
+
+        await _tapActionButton(tester, 'Stash changes and checkout');
+
+        expect(_countOf(pumped.controller, 'retryCheckoutWithChoice'), 1);
+        expect(
+          _countOf(pumped.controller, 'dismissCheckoutChoices'),
+          0,
+          reason:
+              'A retry in flight must not be followed by a dismiss -- the '
+              'controller would drop the choices the retry is still using.',
+        );
+      },
+    );
+
+    testWidgets(
+      're-arm: a second refused checkout re-opens the recovery dialog',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(checkoutChoices: _checkoutChoices),
+        );
+        await tester.pumpAndSettle();
+        await _dismissViaBarrier(tester);
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            checkoutChoices: const <OperationChoice>[],
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(CheckoutRecoveryDialogContent), findsNothing);
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(checkoutChoices: _checkoutChoices),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CheckoutRecoveryDialogContent), findsOneWidget);
+
+        await _tapActionButton(tester, 'Cancel');
+      },
+    );
+  });
+
+  group('delete-branch recovery dialog -- abrupt dismissal', () {
+    testWidgets(
+      'a barrier tap pops the dialog and dispatches '
+      'dismissDeleteBranchChoices exactly once',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            deleteBranchChoices: _deleteBranchChoices,
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(DeleteBranchRecoveryDialogContent), findsOneWidget);
+
+        await _dismissViaBarrier(tester);
+
+        expect(find.byType(DeleteBranchRecoveryDialogContent), findsNothing);
+        expect(_countOf(pumped.controller, 'dismissDeleteBranchChoices'), 1);
+      },
+    );
+
+    testWidgets(
+      'resolving via Cancel dispatches dismissDeleteBranchChoices exactly '
+      'once',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            deleteBranchChoices: _deleteBranchChoices,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await _tapActionButton(tester, 'Cancel');
+
+        expect(_countOf(pumped.controller, 'dismissDeleteBranchChoices'), 1);
+      },
+    );
+
+    testWidgets(
+      'Force delete retries once and does not also dismiss on the way out',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            deleteBranchChoices: _deleteBranchChoices,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await _tapActionButton(tester, 'Force delete');
+
+        expect(_countOf(pumped.controller, 'retryDeleteBranchWithChoice'), 1);
+        expect(_countOf(pumped.controller, 'dismissDeleteBranchChoices'), 0);
+      },
+    );
+
+    testWidgets(
+      're-arm: a second refused delete re-opens the recovery dialog',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          topLevelRoutes: _interruptDialogRoutes,
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            deleteBranchChoices: _deleteBranchChoices,
+          ),
+        );
+        await tester.pumpAndSettle();
+        await _dismissViaBarrier(tester);
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            deleteBranchChoices: const <OperationChoice>[],
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(DeleteBranchRecoveryDialogContent), findsNothing);
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(
+            deleteBranchChoices: _deleteBranchChoices,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DeleteBranchRecoveryDialogContent), findsOneWidget);
+
+        await _tapActionButton(tester, 'Cancel');
+      },
+    );
+  });
+}

--- a/app_flutter/test/integration/workspace_interrupt_abrupt_dismiss_test.dart
+++ b/app_flutter/test/integration/workspace_interrupt_abrupt_dismiss_test.dart
@@ -44,7 +44,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/data/models/operation_choice.dart';
 import 'package:gbm_flutter/data/repositories/repo_identity.dart';
-import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
 import 'package:gbm_flutter/features/dialogs/checkout_recovery/checkout_recovery_dialog.dart';
 import 'package:gbm_flutter/features/dialogs/credential/credential_dialog.dart';
 import 'package:gbm_flutter/features/dialogs/delete_branch_recovery/delete_branch_recovery_dialog.dart';

--- a/app_flutter/test/integration/workspace_interrupt_overlay_test.dart
+++ b/app_flutter/test/integration/workspace_interrupt_overlay_test.dart
@@ -114,11 +114,16 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.byType(CredentialDialogContent), findsOneWidget);
 
-        // Resolve before the test ends -- CredentialDialogContent.dispose()
-        // calls cancelCredential() via `ref` when popped unanswered, which
-        // throws if it fires after pumpWorkspace's ProviderContainer is
-        // already disposed by addTearDown. Every other test below resolves
-        // its dialog before finishing for the same reason.
+        // Resolve before the test ends. This used to be load-bearing for
+        // the wrong reason: the comment here blamed pumpWorkspace's
+        // ProviderContainer being disposed by addTearDown, but
+        // CredentialDialogContent.dispose() reached for `ref` and
+        // flutter_riverpod gates every `ref` member on `context.mounted`,
+        // so it threw on *any* unanswered pop, teardown or not -- the
+        // safety net never worked. Fixed by capturing the notifier in
+        // initState; workspace_interrupt_abrupt_dismiss_test.dart now
+        // covers that path directly. Resolving here is kept because these
+        // tests are about the answered path anyway.
         await _tapActionButton(tester, 'Cancel');
       },
     );

--- a/app_flutter/test/integration/workspace_status_bar_cancel_test.dart
+++ b/app_flutter/test/integration/workspace_status_bar_cancel_test.dart
@@ -1,0 +1,304 @@
+// Integration coverage for the status bar's background-task Cancel button,
+// driven through the real WorkspaceScreen rather than a hand-fed callback.
+//
+// status_bar_test.dart already covers StatusBar as a widget -- given a list
+// of BackgroundTasks and an `onCancelTask` closure, does the right button
+// appear and fire. What nothing covered is the layer above it: whether
+// WorkspaceScreen._backgroundTasks() derives the right tasks from
+// RepoSessionState in the first place, and whether _cancelTask() actually
+// reaches the session. That seam is where a dead button hides -- exactly
+// the shape of the dispatch-parity bug workspace_intent_dispatch_parity_test
+// exists for.
+//
+// Cancelling the history scan has no dedicated capi entry point: it works by
+// re-requesting the current snapshot (`refreshHistory()`), keeping the rows
+// already loaded per spec page 10 ("取消保留已載入的部分，不清空畫面").
+// FakeRepoSessionController records that call rather than no-opping on its
+// null-session guard, which is what lets these tests tell a dispatched
+// Cancel apart from a dead one.
+//
+// Harness note: never `pumpAndSettle()` while `isRefreshing` is true.
+// TopBar renders an indeterminate `CircularProgressIndicator` for exactly
+// that flag, and an indeterminate spinner animates forever -- pumpAndSettle
+// waits for frames to stop being scheduled and therefore times out rather
+// than failing on the assertion under test. Use `pump()` until the flag is
+// back off.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/repo_state.dart';
+import 'package:gbm_flutter/data/models/working_copy_status.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/status_bar/status_bar.dart';
+import 'package:gbm_flutter/features/workspace/workspace_screen.dart'
+    show ConflictBanner;
+
+import '../support/fake_repo_session.dart';
+import '../support/pump_workspace.dart';
+
+final RepoIdentity _identity = RepoIdentity(
+  workDir: '/test/repo',
+  gitDir: '/test/repo/.git',
+);
+
+const WorkingCopyEntry _conflictEntry = WorkingCopyEntry(
+  path: 'conflict.txt',
+  oldPath: '',
+  untracked: false,
+  staged: false,
+  indexStatus: FileChangeKind.modified,
+  hasUnstagedChange: true,
+  worktreeStatus: FileChangeKind.modified,
+  conflict: ConflictKind.bothModified,
+  ancestorBlob: '',
+  oursBlob: 'ours-hash',
+  theirsBlob: 'theirs-hash',
+  similarity: 0,
+  isSubmodule: false,
+  isConflicted: true,
+);
+
+/// A cherry-pick mid-sequence. `isSequencerOperation: true` is correct here
+/// -- cherry-pick genuinely writes a `sequencer/todo` file, which is what
+/// the core's flag reports (src/core/git/RepoState.h).
+RepoState _cherryPickState() => const RepoState(
+  flags: RepoStateFlags.cherryPick,
+  isClean: false,
+  isSequencerOperation: true,
+  rebaseStep: 2,
+  rebaseTotal: 5,
+  rebaseOntoLabel: '',
+  indexLocked: false,
+  indexLockAgeSeconds: null,
+  describe: '',
+);
+
+/// A merge conflict, built faithfully rather than copied from
+/// workspace_conflict_transition_test.dart's `_mergeState()`.
+///
+/// That fixture sets `isSequencerOperation: true` for a merge, which the
+/// core does **not**: `gbm::RepoState::isSequencerOperation()` excludes
+/// merge on purpose (a plain `git commit` finishes a merge -- no todo file
+/// is involved). It is harmless there, because that file only needs
+/// `conflictActive`, which the conflicted entry alone satisfies. Copying it
+/// here would not be harmless: `_backgroundTasks()` gates the sequencer task
+/// on exactly that flag, so the borrowed fixture would manufacture a
+/// "Merging" task and let the test below pin the opposite of the documented
+/// behaviour.
+RepoState _mergeState() => const RepoState(
+  flags: RepoStateFlags.merge,
+  isClean: false,
+  isSequencerOperation: false,
+  rebaseStep: 0,
+  rebaseTotal: 0,
+  rebaseOntoLabel: '',
+  indexLocked: false,
+  indexLockAgeSeconds: null,
+  describe: '',
+);
+
+Finder _statusBarCancel() => find.descendant(
+  of: find.byType(StatusBar),
+  matching: find.widgetWithText(TextButton, 'Cancel'),
+);
+
+int _countOf(FakeRepoSessionController controller, String name) =>
+    controller.commandLog.where((c) => c.name == name).length;
+
+void main() {
+  group('status bar background-task Cancel', () {
+    testWidgets(
+      'a history scan in flight shows a cancellable task whose Cancel '
+      'reaches refreshHistory',
+      (tester) async {
+        final pumped = await pumpWorkspace(tester, identity: _identity);
+
+        expect(
+          find.descendant(
+            of: find.byType(StatusBar),
+            matching: find.text('Reading history'),
+          ),
+          findsNothing,
+          reason: 'Nothing is scanning yet.',
+        );
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(isRefreshing: true),
+        );
+        await tester.pump();
+
+        expect(
+          find.descendant(
+            of: find.byType(StatusBar),
+            matching: find.text('Reading history'),
+          ),
+          findsOneWidget,
+        );
+
+        final TextButton cancel = tester.widget<TextButton>(_statusBarCancel());
+        expect(
+          cancel.onPressed,
+          isNotNull,
+          reason:
+              'The history scan is built with cancellable: true '
+              '(_backgroundTasks), so its Cancel must be live.',
+        );
+
+        await tester.tap(_statusBarCancel());
+        await tester.pump();
+
+        expect(
+          _countOf(pumped.controller, 'refreshHistory'),
+          1,
+          reason:
+              'Cancelling the scan re-requests the current snapshot -- there '
+              'is no separate cancel entry point in the capi, so a Cancel '
+              'that reaches nothing is indistinguishable from a dead button '
+              'without this assertion.',
+        );
+      },
+    );
+
+    testWidgets(
+      'a sequencer operation shows a non-cancellable task: Cancel renders '
+      'but is disabled',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: RepoSessionState(
+            isOpen: true,
+            repoState: _cherryPickState(),
+            workingCopyStatus: const WorkingCopyStatus(
+              entries: <WorkingCopyEntry>[_conflictEntry],
+            ),
+          ),
+        );
+
+        expect(
+          find.descendant(
+            of: find.byType(StatusBar),
+            matching: find.text('Cherry-picking'),
+          ),
+          findsOneWidget,
+        );
+
+        final TextButton cancel = tester.widget<TextButton>(_statusBarCancel());
+        expect(
+          cancel.onPressed,
+          isNull,
+          reason:
+              'Spec page 10\'s TASKS table marks Checkout/Merge/Rebase '
+              '"不可取消" -- interrupting a sequencer midway is more '
+              'dangerous than letting it finish, so _backgroundTasks builds '
+              'it with cancellable: false.',
+        );
+
+        expect(
+          _countOf(pumped.controller, 'refreshHistory'),
+          0,
+          reason: 'A disabled Cancel must not have dispatched anything.',
+        );
+      },
+    );
+
+    testWidgets(
+      'a merge conflict shows the banner but contributes no status-bar task',
+      (tester) async {
+        await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: RepoSessionState(
+            isOpen: true,
+            repoState: _mergeState(),
+            workingCopyStatus: const WorkingCopyStatus(
+              entries: <WorkingCopyEntry>[_conflictEntry],
+            ),
+          ),
+        );
+
+        // activeSequencerOperation() *includes* merge, so the banner (and
+        // its Abort) is present...
+        expect(find.byType(ConflictBanner), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(ConflictBanner),
+            matching: find.text('Abort'),
+          ),
+          findsOneWidget,
+        );
+
+        // ...while RepoState.isSequencerOperation excludes it, so
+        // _backgroundTasks() adds nothing. The two predicates are
+        // deliberately different (gbm_sequencer_operation.dart's "IMPORTANT"
+        // block); this test exists so a future dedup cannot quietly collapse
+        // them into one.
+        expect(
+          _statusBarCancel(),
+          findsNothing,
+          reason:
+              'No background task means no progress zone, hence no Cancel '
+              'button at all.',
+        );
+        expect(
+          find.descendant(
+            of: find.byType(StatusBar),
+            matching: find.text('Merging'),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'once the scan ends the task clears with no residue in the status bar',
+      (tester) async {
+        final pumped = await pumpWorkspace(tester, identity: _identity);
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(isRefreshing: true),
+        );
+        await tester.pump();
+        await tester.tap(_statusBarCancel());
+        await tester.pump();
+
+        pumped.controller.emit(
+          pumped.controller.state.copyWith(isRefreshing: false),
+        );
+        await tester.pumpAndSettle();
+
+        // StatusBar deliberately lingers the finished task for 3 seconds
+        // (its `_lingerTimer`), so the row is still on screen right after
+        // the transition. Drain that before asserting it is gone, otherwise
+        // this would pin the linger away by accident.
+        expect(
+          find.descendant(
+            of: find.byType(StatusBar),
+            matching: find.text('Reading history'),
+          ),
+          findsOneWidget,
+          reason: 'Still inside the 3s linger window.',
+        );
+
+        await tester.pump(const Duration(seconds: 3, milliseconds: 100));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: find.byType(StatusBar),
+            matching: find.text('Reading history'),
+          ),
+          findsNothing,
+        );
+        expect(_statusBarCancel(), findsNothing);
+        expect(
+          _countOf(pumped.controller, 'refreshHistory'),
+          1,
+          reason:
+              'The scan ending must not re-dispatch the cancel a second '
+              'time.',
+        );
+      },
+    );
+  });
+}

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -288,6 +288,17 @@ class FakeRepoSessionController extends RepoSessionController {
     );
   }
 
+  /// Recorded rather than left to the null-session no-op because the status
+  /// bar's Cancel button dispatches through here: `_cancelTask('history-scan')`
+  /// (workspace_screen.dart) cancels the incremental scan by re-requesting
+  /// the current snapshot, there being no separate cancel entry point in the
+  /// capi. Without this override a test could not tell a dead Cancel button
+  /// apart from a dispatched one.
+  @override
+  void refreshHistory() {
+    commandLog.add(const FakeCommand('refreshHistory'));
+  }
+
   @override
   void fetchRemote({
     String remoteName = '',


### PR DESCRIPTION
## 摘要

補上同一個問題兩半的整合覆蓋：**intent／kind 之間切換時狀態機要乾淨**，以及**操作被突兀取消時狀態機要收乾淨**。

寫測試的過程中揪出一個真實的產品缺陷，依既有慣例（Tier 0/1）先落 RED commit、再獨立可回退的 fix commit，成因回寫 `CLAUDE.md`。

新增 27 條測試（12 + 4 + 7 + 4），四個新檔全在 `app_flutter/test/integration/`。

## 揪出的缺陷：`ConsumerState.dispose()` 裡的 `ref` 必然拋錯

`flutter_riverpod` 的 `ConsumerStatefulElement._assertNotDisposed()` 對每個 `ref` 成員都檢查 `context.mounted`，而 `State.dispose()` 從 `StatefulElement.unmount()` 執行時 element 已經 unmount。所以 `dispose()` 內的 `ref.read(...)` **無條件**拋 `StateError`。

受害的是三張「非按鈕關閉時補送取消」的安全網：

- `credential_dialog.dart`
- `checkout_recovery_dialog.dart`
- `delete_branch_recovery_dialog.dart`

三者各有 `_resolved` 旗標 + `dispose()`，用意是使用者點 barrier、按返回、或路由被切走時仍把取消命令送出去。**它從未運作過。** 以 credential 對話框而言，這張網正是用來避免被 askpass 擋住的 git 子行程一路懸著直到 `GBM_ASKPASS` 自己逾時 —— 於是每一次非按鈕關閉的憑證提示，git 都真的懸著。

修法：在 `initState()` 先把 notifier 捕獲進欄位，`dispose()` 改呼叫它，並以 `StateNotifier.mounted` 守衛 provider 先被銷毀的情況。

**它為何能存活這麼久**，比缺陷本身更值得記：`workspace_interrupt_overlay_test.dart` 的檔頭註解其實**看見過**這個拋錯，但把成因歸給測試 harness 的 teardown 機制（「在 `pumpWorkspace` 的 ProviderContainer 被 `addTearDown` 銷毀後才觸發就會拋」），於是繞開的寫法被沿用進該檔後續每一條測試，真正的路徑從此沒人走過。正確的觀察配上錯誤的成因，就成了永久的迴避藉口。該註解已就地更正。

## Commits

| commit | 內容 |
|---|---|
| `3043865` | `FakeRepoSessionController` 補 `refreshHistory` override |
| `88e21db` | 中斷對話框突兀關閉的整合測試（6 條預期 RED） |
| `ccf0682` | **fix**：三個中斷對話框的 dispose 安全網改為預先捕獲 notifier |
| `49206ae` | 狀態列背景任務 Cancel 的整合測試 |
| `97c497c` | ConflictBanner Abort/Skip/Continue 依 kind 分派的整合測試 |
| `1b48985` | 對話框開啟中狀態自解與切走 teardown 的整合測試 |
| `75957ca` | 成因、harness 事實與 fixture 規則回寫 `CLAUDE.md` |

依序、各自獨立可回退。

## 覆蓋的四個取消面向

1. **三個 auto-push 中斷對話框** — barrier 關閉派送取消、按鈕關閉不重複派送（這條才真正釘住 `_resolved`）、關閉後 listener 能重新武裝（推送只發生在 `null → non-null` 邊緣，殘值會讓下一次提示永遠不再彈出）。
2. **狀態列背景任務 Cancel** — 首次穿過 `_backgroundTasks()`／`_cancelTask()` 這一層，證明按鈕真的接到 session；sequencer 任務的 `cancellable: false` 也一併釘住。
3. **ConflictBanner Abort/Skip/Continue** — 三種 kind 的真實按鈕分派、kind 中途改變後分派要跟著換（舊分派不得殘留）、以及 `rebaseMerge | cherryPick` 同時成立時要走 rebase 的優先權階梯。
4. **開啟中被切走／狀態自解** — `credentialPrompt` 轉 null 刻意**不**關窗（askpass 在 username 與 password 之間會清空再設值）；`router.go(...)` 切走仍恰好取消一次；切走後仍能重新武裝。

## 非空轉的證據

沒有只憑「綠了」就收工，三處做了突變驗證：

- 把狀態列的 merge fixture 換回不忠實版本（`isSequencerOperation: true`）→ 該測試轉紅。
- 把 `activeSequencerOperation()` 的 rebase／cherryPick 順序對調 → 優先權階梯測試轉紅。
- teardown 那條「切走分頁恰好取消一次」實測過修復前為紅（`git checkout ccf0682~1 -- credential_dialog.dart` 後跑，確認拋 `Bad state: Cannot use "ref" after the widget was disposed`），不是靠推理宣稱。

## 三個靠「跑」才發現的 harness 事實（已寫進 `CLAUDE.md`）

- **`isRefreshing` 為真時絕不可 `pumpAndSettle()`** —— `TopBar` 對該旗標渲染不定量 `CircularProgressIndicator`，會無限排程 frame，於是 `pumpAndSettle` 逾時，看起來像狀態列卡住而不是被測斷言失敗。
- **`StatusBar` 對完成的任務有 3 秒 linger**（`_lingerTimer`），所以「任務清掉了」不能在轉換後的下一 frame 斷言，得先排空，否則會不小心把 linger 本身釘死。
- **barrier 點擊是「未回答就關閉」的正確手勢**（`dialogRoute` 的 `barrierDismissible: true`）；`router.pop()` 走到同一條路徑，記為退路。Esc／`DismissIntent` 的 focus 語意不值得纏鬥。

## Fixture 規則

- **不可借用 `workspace_conflict_transition_test.dart` 的 `_mergeState()`** —— 它對 merge 設了 `isSequencerOperation: true`，而 core 的同名旗標對 merge 刻意是 false。在原檔無害（`conflictActive` 由衝突檔案撐著），抄過來會憑空生出「Merging」背景任務，把斷言釘成與文件**相反**的行為。與 Tier 0c 的 `hasTrackingInfo` 陷阱同型：與來源語意不一致的 fixture 無法證偽任何推導。
- **要數，不要 `any`** —— 每個「恰好一次」都走 `commandLog.where((c) => c.name == ...).length`。`.any(...)` 對「送了兩次」完全盲，而送兩次正是刪掉 `_resolved` 會造成的後果。

## Test plan

- [x] `flutter test` → **1338 passed**（base 1311）
- [x] `flutter analyze` → `No issues found!`
- [x] `dart format --output=none --set-exit-if-changed .` → `Formatted 344 files (0 changed)`
- [x] 上述三項在 rebase 到 `main` 之後重跑過一次，非只在原 base 上綠
- [x] CI 綠（capi job 若紅，先讀失敗文字再判斷是否為已知的 #70 逾時型 flake）

## 備註

- 本分支原本開在本機的 `feature/miscellaneous` 上，該分支帶著一個與本輪無關的 `feat: Update gitignore`。已把七個 commit rebase 到 `main`，PR 只含本輪工作。
- 不動 `integration_test/` 裝置層；四個新檔都跑在一般 `flutter test` 與 PR CI 裡。