### PR TITLE
feat: 補上 spec P02 item 2 的 History 工具列（Fetch/Pull/Push + Branch/Stash）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,12 @@ you are touching, not by when it was learned.
   parallel load) — read the failure text before picking a family.
 - `StatusBar` lingers a finished task for 3 seconds (`_lingerTimer`), so
   "the task cleared" cannot be asserted on the next frame.
+- **Real async inside `testWidgets` needs `tester.runAsync()`.**
+  `Picture.toImage()` (and asset decoding through `vg.loadPicture`) never
+  completes in flutter_test's fake-async zone: no output, no timeout of its
+  own, just a hang — eight minutes of silence in the recorded case. This is
+  how an asset-rendering check is written when a string-level "it ships and
+  parses" assertion is not enough (`docs/ledger.md`, P02 item 2's toolbar).
 - **The fake seam fails loudly on purpose.** `FakeGbmBindings` /
   `FakeRecentsRepository` throw via `noSuchMethod` for anything not
   explicitly implemented, so a provider a test forgot to override never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,9 @@ lib/
   features/
     welcome/         WelcomeScreen (route `/`, no repository open)
     repo_switcher/   RepoSwitcherButton (sidebar top) + popover + RepoSwitcherList
-    workspace/       WorkspaceScreen (shell) + widgets/ (MenuBarRow, TopBar,
-                      TabRow — presentational, no Riverpod dependency)
+    workspace/       WorkspaceScreen (shell) + widgets/ (MenuBarRow,
+                      ActionToolbar, TopBar, TabRow — presentational, no
+                      Riverpod dependency)
     history_graph/   CommitGraphView, commit_row.dart
     working_copy/    WorkingCopyView
     sidebar/         SidebarPanel
@@ -146,9 +147,9 @@ lib/
     dialogs/         The 34 repo-scoped dialog contents listed above, plus the 4 app-wide ones
 ```
 
-Presentational/container split: `MenuBarRow`, `TopBar`, `TabRow`
-(`features/workspace/widgets/`) take plain callbacks/values and hold no
-Riverpod dependency, so they're tested directly against a bare `GoRouter`
+Presentational/container split: `MenuBarRow`, `ActionToolbar`, `TopBar`,
+`TabRow` (`features/workspace/widgets/`) take plain callbacks/values and hold
+no Riverpod dependency, so they're tested directly against a bare `GoRouter`
 (see `test/features/workspace/*_test.dart`). `WorkspaceScreen` is the
 container: it watches `repoSessionProvider` and wires the callbacks in.
 
@@ -341,8 +342,9 @@ RepoSessionState)` is the single source of truth for which actions a
 state-dependent gate disables — every other call site (`workspace_screen.dart`'s
 `_buildActionHandlers()`, `sidebar_panel.dart`'s `BranchTreeItem.conflictActive`,
 `working_copy_view.dart`'s commit-box `canCommit`, `MenuBarRow`'s
-`GbmMenuItem.enabled` grey-out) reads through this function rather than
-re-deriving `session.conflictActive` locally.
+`GbmMenuItem.enabled` grey-out, and `ActionToolbar`'s five buttons, which take
+their `null`-means-disabled straight out of the handler map) reads through this
+function rather than re-deriving `session.conflictActive` locally.
 
 Twelve ids are gated straight off spec page 07's STATES table — disabled
 whenever `RepoSessionState.conflictActive` is true, because each would move
@@ -511,8 +513,12 @@ you are touching, not by when it was learned.
   test whose subject contradicts yours (`_mergeState()`'s
   `isSequencerOperation`, cancel-surface round); one that *cannot express*
   the case at all (a single shared `GraphRow` instance, graph-edge round);
-  and one that *cannot shrink* (a `repoRefsProvider` override pinned to one
-  snapshot, so no selected branch can ever vanish).
+  one that *cannot shrink* (a `repoRefsProvider` override pinned to one
+  snapshot, so no selected branch can ever vanish); and one whose *two
+  subjects are indistinguishable to the assertion* — `ActionToolbar`'s Branch
+  and Stash share a gate and both only `context.push(...)`, so asserting
+  `onPressed != null` stayed green with the two handlers swapped (P02-2
+  round). Sentinel `dialogRoute`s are what told them apart.
 - **Mutation-check every new test**, and check the red is *narrow* — a broad
   red means the test is pinning something else. Copy the file to the
   scratchpad first (`cp file "$SCRATCH/x.bak"` → mutate → `cp` back);
@@ -714,6 +720,14 @@ you are touching, not by when it was learned.
   `REVISIONS` table revises earlier pages**, so check whether a later page
   overrules a verdict written before it — two issues went stale exactly that
   way. P13 B and P14–P16 remain unaudited (**#76**), as do P17–P21.
+- **A conformance cell whose evidence is `isActionEnabled()` proves the gate
+  exists, never the gated surface.** P02 item 2 and P07's `Toolbar` row both
+  read 符合 off `gbm_action_availability.dart` while the toolbar they describe
+  was drawn by nothing — Fetch/Pull/Push had only a shortcut and a menu item
+  (feat/p02-action-toolbar). Items 11, 12 and 14 on the same page fell the same
+  way. Check the row's *title* against the spec's own wording before trusting
+  its evidence: 「三顆同組。Push 為主要樣式。」 describes buttons, and the
+  disabled-during-conflict clause hangs off them.
 - **When an issue's premise does not survive the source, correct the issue
   text in place and record the evidence** — close as not-planned rather than
   quietly retitle (#45/#50/#51/#60 precedent). Several rounds found the
@@ -766,9 +780,12 @@ you are touching, not by when it was learned.
 - `lfs_pattern_match.dart` is an **approximation** of gitattributes matching,
   not a port of `wildmatch()`; a pattern it cannot parse matches nothing, so
   a group reads 0 rather than a wrong number.
+- **No pull dialog route exists**, so P17's 「選單的 Pull… 或 Alt + 點工具列才
+  開」 has nothing to open: `ActionToolbar`'s Pull only runs `pullChanges()`
+  with the configured default (**#109**).
 - **Open issues**: **#62** (TabRow overflow menu), **#67**–**#71**,
   **#74**–**#76**, **#84**–**#89** (Tier 6 spec blockers), **#92**–**#95**
-  (capi with no spec entry point), **#99**, **#101**, **#102**. `gh issue
+  (capi with no spec entry point), **#99**, **#101**, **#102**, **#109**. `gh issue
   list` is authoritative; the ledger's mentions are historical.
 
 ## Engineering ledger

--- a/app_flutter/assets/icons/arrow-down-to-line.svg
+++ b/app_flutter/assets/icons/arrow-down-to-line.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#000000"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 17V3" />
+  <path d="m6 11 6 6 6-6" />
+  <path d="M19 21H5" />
+</svg>

--- a/app_flutter/assets/icons/arrow-up-from-line.svg
+++ b/app_flutter/assets/icons/arrow-up-from-line.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#000000"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m18 9-6-6-6 6" />
+  <path d="M12 3v14" />
+  <path d="M5 21h14" />
+</svg>

--- a/app_flutter/assets/icons/git-branch-plus.svg
+++ b/app_flutter/assets/icons/git-branch-plus.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#000000"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 3v12" />
+  <path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" />
+  <path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" />
+  <path d="M15 6a9 9 0 0 0-9 9" />
+  <path d="M18 15v6" />
+  <path d="M21 18h-6" />
+</svg>

--- a/app_flutter/assets/icons/inbox.svg
+++ b/app_flutter/assets/icons/inbox.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#000000"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+  <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+</svg>

--- a/app_flutter/lib/features/workspace/widgets/action_toolbar.dart
+++ b/app_flutter/lib/features/workspace/widgets/action_toolbar.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+
+import '../../../theme/gbm_theme.dart';
+import '../../../theme/tokens.dart';
+import '../../../widgets/gbm_button.dart';
+import '../../../widgets/lucide_icon.dart';
+
+/// Spec page 02's numbered item 2: the 38px toolbar row directly under the
+/// menu bar. Fetch / Pull / Push as one group with Push carrying the primary
+/// emphasis (「三顆同組。Push 為主要樣式。」), then a divider, then Branch /
+/// Stash. The spec's own icon choices name what the last two do:
+/// `git-branch-plus` is New branch, `inbox` is Stash changes.
+///
+/// Purely presentational, like [MenuBarRow] and [TabRow] beside it: every
+/// action arrives as a plain [VoidCallback] so this widget carries no
+/// Riverpod/FFI dependency and is testable without a container (see
+/// action_toolbar_test.dart). `workspace_screen.dart` wires all five out of
+/// the one `Map<GbmActionId, VoidCallback?>` that the keyboard, the macOS
+/// system menu and the in-window menu already dispatch through -- reaching
+/// past that map for a "toolbar-only" handler is the exact shape of the bug
+/// `workspace_intent_dispatch_parity_test.dart` exists to catch.
+///
+/// A null callback *is* the disabled state -- there is deliberately no
+/// separate `enabled` flag that could disagree with it. Conflict gating
+/// therefore arrives for free: `isActionEnabled()` already returns false for
+/// all five of these ids mid-sequencer (spec page 07's STATES table,
+/// 「三顆停用，改由 banner 提供 Abort / Skip / Continue / Resolve…」), so
+/// `_buildActionHandlers()` puts null in the map and these grey out without
+/// this file knowing what a conflict is.
+class ActionToolbar extends StatelessWidget {
+  const ActionToolbar({
+    super.key,
+    required this.onFetch,
+    required this.onPull,
+    required this.onPush,
+    required this.onBranch,
+    required this.onStash,
+  });
+
+  /// `Repository -> Fetch`. Null disables the button.
+  final VoidCallback? onFetch;
+
+  /// `Repository -> Pull`. Spec P17 wants Alt+click to open a Pull dialog
+  /// with the apply mode pre-selected; there is no pull dialog route in
+  /// `route_paths.dart`, so only the plain click (「直接用 Preferences 的預設
+  /// 套用方式走」) is wired -- a recorded reduction, not an oversight.
+  final VoidCallback? onPull;
+
+  /// `Repository -> Push`.
+  final VoidCallback? onPush;
+
+  /// `Branch -> New branch…`.
+  final VoidCallback? onBranch;
+
+  /// `Branch -> Stash changes…`.
+  final VoidCallback? onStash;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    return Container(
+      height: 38,
+      padding: const EdgeInsets.symmetric(horizontal: GbmSpacing.space2),
+      decoration: BoxDecoration(
+        color: colors.surfacePanel,
+        border: Border(bottom: BorderSide(color: colors.borderSubtle)),
+      ),
+      // The same guard MenuBarRow uses, and the one the ledger records
+      // TopBar as lacking: five buttons plus a divider do not fit an
+      // arbitrarily narrow window, and a RenderFlex overflow is a thrown
+      // error in debug/test builds rather than a visual clip. Scrolling
+      // keeps every button reachable instead.
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: <Widget>[
+                  _ToolbarButton(
+                    label: 'Fetch',
+                    // Spec names `download-cloud`; Lucide renames it
+                    // `cloud-download`, which is the copy already bundled.
+                    iconName: 'cloud-download',
+                    onPressed: onFetch,
+                  ),
+                  _ToolbarButton(
+                    label: 'Pull',
+                    iconName: 'arrow-down-to-line',
+                    onPressed: onPull,
+                  ),
+                  _ToolbarButton(
+                    label: 'Push',
+                    iconName: 'arrow-up-from-line',
+                    kind: GbmButtonKind.primary,
+                    onPressed: onPush,
+                  ),
+                  Container(
+                    width: 1,
+                    height: 16,
+                    color: colors.borderSubtle,
+                    margin: const EdgeInsets.symmetric(
+                      horizontal: GbmSpacing.space1,
+                    ),
+                  ),
+                  _ToolbarButton(
+                    label: 'Branch',
+                    iconName: 'git-branch-plus',
+                    onPressed: onBranch,
+                  ),
+                  _ToolbarButton(
+                    label: 'Stash',
+                    iconName: 'inbox',
+                    onPressed: onStash,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One `.gbm-btn-sm` in the row, with the 6px gap the mockup puts between
+/// them and the icon tinted to match its own kind's foreground.
+class _ToolbarButton extends StatelessWidget {
+  const _ToolbarButton({
+    required this.label,
+    required this.iconName,
+    required this.onPressed,
+    this.kind = GbmButtonKind.secondary,
+  });
+
+  final String label;
+  final String iconName;
+  final VoidCallback? onPressed;
+  final GbmButtonKind kind;
+
+  @override
+  Widget build(BuildContext context) {
+    final GbmColors colors = context.gbmColors;
+    final Color foreground = kind == GbmButtonKind.primary
+        ? colors.textOnAccent
+        : colors.textSecondary;
+    return Padding(
+      padding: const EdgeInsets.only(right: 6),
+      child: GbmButton(
+        label: label,
+        kind: kind,
+        size: GbmButtonSize.sm,
+        icon: LucideIcon(
+          iconName,
+          size: 12,
+          color: onPressed == null
+              ? foreground.withValues(alpha: 0.45)
+              : foreground,
+        ),
+        onPressed: onPressed,
+      ),
+    );
+  }
+}

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -40,6 +40,7 @@ import '../sidebar/gone_marking.dart';
 import '../sidebar/sidebar_panel.dart';
 import '../status_bar/background_task.dart';
 import '../status_bar/status_bar.dart';
+import 'widgets/action_toolbar.dart';
 import 'widgets/menu_bar_row.dart';
 import 'widgets/platform_menu_bar_host.dart';
 import 'widgets/tab_row.dart';
@@ -359,6 +360,25 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
               // state agrees with what those two paths will actually do.
               actionHandlers: actionHandlers,
             ),
+          // Spec page 02's numbered item 2. Unlike MenuBarRow above, this
+          // row is drawn on all three platforms -- page 01 says only the
+          // menu bar's *position* follows the system, and macOS moving its
+          // menus to the system bar says nothing about the toolbar.
+          //
+          // Every callback is read back out of the same actionHandlers map
+          // the keyboard, the macOS system menu and the in-window menu
+          // dispatch through. Reaching past it for a toolbar-only handler
+          // is precisely the bug workspace_intent_dispatch_parity_test.dart
+          // exists to catch, and null here (from isActionEnabled()) is what
+          // greys a button out mid-conflict -- spec page 07's STATES row
+          // 「三顆停用，改由 banner 提供 Abort / Skip / Continue / Resolve…」.
+          ActionToolbar(
+            onFetch: actionHandlers[GbmActionId.repositoryFetch],
+            onPull: actionHandlers[GbmActionId.repositoryPull],
+            onPush: actionHandlers[GbmActionId.repositoryPush],
+            onBranch: actionHandlers[GbmActionId.branchNewBranch],
+            onStash: actionHandlers[GbmActionId.branchStashChanges],
+          ),
           TopBar(
             repoName: _displayName(identity.workDir),
             repoState: session.repoState,

--- a/app_flutter/test/features/workspace/action_toolbar_test.dart
+++ b/app_flutter/test/features/workspace/action_toolbar_test.dart
@@ -1,0 +1,245 @@
+// Spec page 02's numbered item 2: the toolbar row under the menu bar --
+// Fetch / Pull / Push (Push primary), a divider, then Branch / Stash.
+//
+// This is the widget tier, so it proves the row renders and dispatches;
+// that the *real* WorkspaceScreen hands it the same handler map every other
+// dispatch path reads, and that conflict state greys it out, is
+// workspace_conflict_transition_test.dart's job (a widget test feeds the
+// callbacks in directly and so can never see that seam -- CLAUDE.md's
+// testing-tiers note).
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/workspace/widgets/action_toolbar.dart';
+import 'package:gbm_flutter/theme/gbm_theme.dart';
+import 'package:gbm_flutter/theme/tokens.dart';
+import 'package:gbm_flutter/widgets/gbm_button.dart';
+
+/// [width] null means "the full test canvas" (800 logical px, the default
+/// surface -- a SizedBox wider than it is silently clamped, so a layout
+/// assertion has to be made at or below that number to mean anything).
+Future<void> _pump(
+  WidgetTester tester, {
+  VoidCallback? onFetch,
+  VoidCallback? onPull,
+  VoidCallback? onPush,
+  VoidCallback? onBranch,
+  VoidCallback? onStash,
+  double? width,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: buildGbmTheme(GbmThemeVariant.darkTechnical),
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: width,
+            child: ActionToolbar(
+              onFetch: onFetch,
+              onPull: onPull,
+              onPush: onPush,
+              onBranch: onBranch,
+              onStash: onStash,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/// A no-op that still reads as "enabled" to [GbmButton] -- distinct from
+/// null, which is what disables it.
+void _noop() {}
+
+GbmButton _button(WidgetTester tester, String label) =>
+    tester.widget<GbmButton>(find.widgetWithText(GbmButton, label));
+
+void main() {
+  const List<String> labels = <String>[
+    'Fetch',
+    'Pull',
+    'Push',
+    'Branch',
+    'Stash',
+  ];
+
+  testWidgets('renders the five buttons spec P02-2 draws', (tester) async {
+    await _pump(
+      tester,
+      onFetch: _noop,
+      onPull: _noop,
+      onPush: _noop,
+      onBranch: _noop,
+      onStash: _noop,
+    );
+
+    for (final String label in labels) {
+      expect(
+        find.widgetWithText(GbmButton, label),
+        findsOneWidget,
+        reason: '$label is one of P02 item 2\'s toolbar buttons',
+      );
+    }
+    expect(find.byType(GbmButton), findsNWidgets(labels.length));
+  });
+
+  testWidgets('Push is the primary button and the rest are secondary', (
+    tester,
+  ) async {
+    // 「三顆同組。Push 為主要樣式。」-- the emphasis is the spec's, and it is
+    // the only thing distinguishing the push button from its neighbours.
+    await _pump(
+      tester,
+      onFetch: _noop,
+      onPull: _noop,
+      onPush: _noop,
+      onBranch: _noop,
+      onStash: _noop,
+    );
+
+    expect(_button(tester, 'Push').kind, GbmButtonKind.primary);
+    for (final String label in <String>['Fetch', 'Pull', 'Branch', 'Stash']) {
+      expect(
+        _button(tester, label).kind,
+        GbmButtonKind.secondary,
+        reason: '$label must not compete with Push for emphasis',
+      );
+    }
+  });
+
+  testWidgets('every button is sm-sized, matching the mockup', (tester) async {
+    await _pump(
+      tester,
+      onFetch: _noop,
+      onPull: _noop,
+      onPush: _noop,
+      onBranch: _noop,
+      onStash: _noop,
+    );
+
+    for (final String label in labels) {
+      expect(_button(tester, label).size, GbmButtonSize.sm);
+    }
+  });
+
+  testWidgets('a null callback disables only its own button', (tester) async {
+    // The disabled state is GbmButton's own `onPressed == null` rendering --
+    // there is deliberately no separate `enabled` flag to fall out of sync
+    // with it (the GbmMenuItem.enabled trap, CLAUDE.md).
+    await _pump(
+      tester,
+      onFetch: null,
+      onPull: _noop,
+      onPush: _noop,
+      onBranch: _noop,
+      onStash: _noop,
+    );
+
+    expect(_button(tester, 'Fetch').onPressed, isNull);
+    for (final String label in <String>['Pull', 'Push', 'Branch', 'Stash']) {
+      expect(
+        _button(tester, label).onPressed,
+        isNotNull,
+        reason: 'one null handler must not disable the whole row',
+      );
+    }
+  });
+
+  testWidgets('all five disabled when every handler is null', (tester) async {
+    await _pump(tester);
+
+    for (final String label in labels) {
+      expect(_button(tester, label).onPressed, isNull);
+    }
+  });
+
+  group('dispatch', () {
+    // Counts, not `.any()`: a double dispatch (e.g. an InkWell nested inside
+    // another tappable) is exactly the regression this shape hides.
+    for (final String label in labels) {
+      testWidgets('tapping $label calls its own callback exactly once', (
+        tester,
+      ) async {
+        final Map<String, int> calls = <String, int>{
+          for (final String l in labels) l: 0,
+        };
+        await _pump(
+          tester,
+          onFetch: () => calls['Fetch'] = calls['Fetch']! + 1,
+          onPull: () => calls['Pull'] = calls['Pull']! + 1,
+          onPush: () => calls['Push'] = calls['Push']! + 1,
+          onBranch: () => calls['Branch'] = calls['Branch']! + 1,
+          onStash: () => calls['Stash'] = calls['Stash']! + 1,
+        );
+
+        await tester.tap(find.widgetWithText(GbmButton, label));
+        await tester.pump();
+
+        expect(calls[label], 1);
+        for (final MapEntry<String, int> e in calls.entries) {
+          if (e.key == label) continue;
+          expect(e.value, 0, reason: 'tapping $label must not fire ${e.key}');
+        }
+      });
+    }
+  });
+
+  group('narrow window', () {
+    testWidgets('the whole row fits the default 800px canvas', (tester) async {
+      await _pump(
+        tester,
+        onFetch: _noop,
+        onPull: _noop,
+        onPush: _noop,
+        onBranch: _noop,
+        onStash: _noop,
+      );
+
+      expect(tester.takeException(), isNull);
+      // "No exception" alone would also pass on a row scrolled so far that
+      // the last button sits off-screen, so assert the trailing edge -- the
+      // app's own default window is 1280 wide and this row must not need
+      // scrolling anywhere near it.
+      expect(tester.getRect(find.text('Stash')).right, lessThanOrEqualTo(800));
+    });
+
+    testWidgets('scrolls instead of overflowing at 320px', (tester) async {
+      // Below any real window, but this is the guard MenuBarRow already has
+      // and TopBar (per the ledger) does not: a RenderFlex overflow is a
+      // thrown error in debug/test builds, not a visual clip.
+      await _pump(
+        tester,
+        onFetch: _noop,
+        onPull: _noop,
+        onPush: _noop,
+        onBranch: _noop,
+        onStash: _noop,
+        width: 320,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(GbmButton), findsNWidgets(labels.length));
+    });
+
+    testWidgets('the first button stays visible at 320px', (tester) async {
+      // Expanded satisfies "no overflow" while collapsing its child to zero
+      // (ledger, History column round), so the absence of an exception is
+      // not the same claim as "Fetch is reachable".
+      await _pump(
+        tester,
+        onFetch: _noop,
+        onPull: _noop,
+        onPush: _noop,
+        onBranch: _noop,
+        onStash: _noop,
+        width: 320,
+      );
+
+      final Rect fetch = tester.getRect(find.text('Fetch'));
+      expect(fetch.width, greaterThan(0));
+      expect(fetch.left, greaterThanOrEqualTo(0));
+      expect(fetch.right, lessThanOrEqualTo(320));
+    });
+  });
+}

--- a/app_flutter/test/integration/workspace_conflict_transition_test.dart
+++ b/app_flutter/test/integration/workspace_conflict_transition_test.dart
@@ -17,14 +17,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:gbm_flutter/data/models/git_error.dart';
 import 'package:gbm_flutter/data/models/ref_snapshot.dart';
 import 'package:gbm_flutter/data/models/repo_state.dart';
 import 'package:gbm_flutter/data/models/working_copy_status.dart';
 import 'package:gbm_flutter/data/repositories/repo_identity.dart';
 import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/workspace/widgets/action_toolbar.dart';
 import 'package:gbm_flutter/features/workspace/workspace_screen.dart'
     show ConflictBanner;
+import 'package:gbm_flutter/widgets/gbm_button.dart';
+import 'package:gbm_flutter/routing/dialog_route.dart';
+import 'package:gbm_flutter/routing/route_paths.dart';
 import 'package:gbm_flutter/theme/gbm_theme.dart';
 import 'package:gbm_flutter/theme/tokens.dart';
 
@@ -152,9 +157,60 @@ Future<void> _pressCtrlShiftF(WidgetTester tester) async {
 /// through, `colors.textPrimary`/hover color otherwise. Leaves the menu
 /// open; callers only need one read per pumped tree.
 Color _repositoryMenuItemColor(WidgetTester tester, String label) {
-  final Text text = tester.widget<Text>(find.text(label));
+  // The P02-2 toolbar renders 'Fetch'/'Pull'/'Push' as well, so an unscoped
+  // find.text() matches two widgets once the menu is open. The menu row is
+  // the one that is *not* inside ActionToolbar -- _GbmMenuPanel/_GbmMenuRow
+  // are both private, so there is no public type to scope to positively.
+  final Set<Element> inToolbar = find
+      .descendant(of: find.byType(ActionToolbar), matching: find.text(label))
+      .evaluate()
+      .toSet();
+  final Text text =
+      find
+              .text(label)
+              .evaluate()
+              .firstWhere((Element e) => !inToolbar.contains(e))
+              .widget
+          as Text;
   return text.style!.color!;
 }
+
+/// The [ActionToolbar] button labelled [label]. Scoped to the toolbar
+/// because the Repository / Branch menus carry the same words, and an
+/// unscoped finder would silently start matching one of those instead the
+/// moment a menu is open.
+GbmButton _toolbarButton(WidgetTester tester, String label) =>
+    tester.widget<GbmButton>(
+      find.descendant(
+        of: find.byType(ActionToolbar),
+        matching: find.widgetWithText(GbmButton, label),
+      ),
+    );
+
+const List<String> _toolbarLabels = <String>[
+  'Fetch',
+  'Pull',
+  'Push',
+  'Branch',
+  'Stash',
+];
+
+/// Sentinel destinations for the two toolbar buttons that navigate rather
+/// than dispatch a command. Branch and Stash are gated identically and both
+/// only `context.push(...)`, so asserting `onPressed != null` alone cannot
+/// tell them apart -- swapping the two handlers would leave every such
+/// assertion green (verified by mutation). These routes are what makes the
+/// two distinguishable.
+List<RouteBase> _branchAndStashDialogRoutes() => <RouteBase>[
+  dialogRoute(
+    path: RoutePaths.newBranchDialog,
+    builder: (context, state) => const Text('NEW-BRANCH-DIALOG'),
+  ),
+  dialogRoute(
+    path: RoutePaths.stashChangesDialog,
+    builder: (context, state) => const Text('STASH-CHANGES-DIALOG'),
+  ),
+];
 
 void main() {
   final GbmColors colors = buildGbmTheme(
@@ -414,5 +470,161 @@ void main() {
         );
       },
     );
+  });
+
+  // Spec P02 item 2 is the toolbar row itself, and spec P07's STATES table
+  // gates it: 「Fetch / Pull / Push 全部可用」when clean, 「三顆停用，改由
+  // banner 提供 Abort / Skip / Continue / Resolve…」when not. Until this
+  // round the row did not exist, so every check of that rule -- including
+  // this file's own header, which already claimed to drive "Toolbar
+  // Fetch·Pull·Push" -- was really checking isActionEnabled(), the gate,
+  // rather than the surface being gated. These tests go through the real
+  // buttons.
+  group('spec P02-2 toolbar', () {
+    testWidgets('clean: all five buttons are enabled', (tester) async {
+      await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _cleanSession(),
+      );
+
+      for (final String label in _toolbarLabels) {
+        expect(
+          _toolbarButton(tester, label).onPressed,
+          isNotNull,
+          reason: '$label must be pressable while the work tree is clean',
+        );
+      }
+    });
+
+    testWidgets('clean: tapping Fetch/Pull/Push dispatches exactly once each', (
+      tester,
+    ) async {
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _cleanSession(),
+      );
+
+      for (final (String label, String command) in <(String, String)>[
+        ('Fetch', 'fetchRemote'),
+        ('Pull', 'pullChanges'),
+        ('Push', 'pushChanges'),
+      ]) {
+        await tester.tap(
+          find.descendant(
+            of: find.byType(ActionToolbar),
+            matching: find.widgetWithText(GbmButton, label),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Counted, not `.any()` -- a second tappable layered over the button
+        // would double-dispatch, and `.any()` cannot see that.
+        expect(
+          pumped.controller.commandLog.where((c) => c.name == command).length,
+          1,
+          reason: 'the toolbar $label button must reach $command() once',
+        );
+      }
+    });
+
+    testWidgets(
+      'conflict: all five buttons are disabled and dispatch nothing',
+      (tester) async {
+        final pumped = await pumpWorkspace(
+          tester,
+          identity: _identity,
+          initialState: _conflictSession(),
+        );
+
+        for (final String label in _toolbarLabels) {
+          expect(
+            _toolbarButton(tester, label).onPressed,
+            isNull,
+            reason:
+                '$label moves HEAD or starts a second sequencer operation, so '
+                'spec P07 disables it while conflictActive is true',
+          );
+        }
+
+        final int before = pumped.controller.commandLog.length;
+        for (final String label in _toolbarLabels) {
+          await tester.tap(
+            find.descendant(
+              of: find.byType(ActionToolbar),
+              matching: find.widgetWithText(GbmButton, label),
+            ),
+            warnIfMissed: false,
+          );
+          await tester.pumpAndSettle();
+        }
+        expect(
+          pumped.controller.commandLog.length,
+          before,
+          reason: 'a greyed button must also be inert, not merely grey',
+        );
+      },
+    );
+
+    testWidgets('conflict -> clean reopens every toolbar button', (
+      tester,
+    ) async {
+      // The round trip, not just the conflict half: a gate that latches
+      // closed looks identical to a correct one until the conflict clears.
+      final pumped = await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _conflictSession(),
+      );
+      expect(_toolbarButton(tester, 'Fetch').onPressed, isNull);
+
+      pumped.controller.emit(_cleanSession());
+      await tester.pumpAndSettle();
+
+      for (final String label in _toolbarLabels) {
+        expect(
+          _toolbarButton(tester, label).onPressed,
+          isNotNull,
+          reason: '$label must come back once the conflict is resolved',
+        );
+      }
+    });
+
+    testWidgets('Branch and Stash open their own dialogs, not each other\'s', (
+      tester,
+    ) async {
+      await pumpWorkspace(
+        tester,
+        identity: _identity,
+        initialState: _cleanSession(),
+        topLevelRoutes: _branchAndStashDialogRoutes(),
+      );
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(ActionToolbar),
+          matching: find.widgetWithText(GbmButton, 'Branch'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('NEW-BRANCH-DIALOG'), findsOneWidget);
+      expect(find.text('STASH-CHANGES-DIALOG'), findsNothing);
+
+      // Back to the workspace before the second half, or the first dialog
+      // stays on the stack and the second assertion reads a stale tree.
+      Navigator.of(tester.element(find.text('NEW-BRANCH-DIALOG'))).pop();
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(ActionToolbar),
+          matching: find.widgetWithText(GbmButton, 'Stash'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('STASH-CHANGES-DIALOG'), findsOneWidget);
+      expect(find.text('NEW-BRANCH-DIALOG'), findsNothing);
+    });
   });
 }

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -2430,3 +2430,114 @@ assertion to work taught two things:
   previous round's rule ("never run it wholesale") still holds for everything
   that does not.
 
+
+### P02 item 2's toolbar (feat/p02-action-toolbar)
+
+Spec page 02's numbered item **2** is the toolbar row directly under the menu
+bar: `Fetch` / `Pull` / `Push` with Push carrying the primary emphasis, a
+divider, then `Branch` / `Stash` (`spec_raw.html:1245-1255`). **None of it
+existed under `lib/`.** Fetch/Pull/Push had exactly two entry points — the
+keyboard shortcut and the Repository menu — and `top_bar.dart` held only the
+back button, the repository name, the state label, `Refresh` and the three
+theme swatches.
+
+#### The premise that did not survive: what row 2 of the matrix was measuring
+
+`docs/reports/spec-conformance-matrix.md` recorded P02 item 2 as **符合**,
+titled 「Fetch/Pull/Push disabled during conflict」, with
+`gbm_action_availability.dart:33-45` as its evidence. Both halves of that are
+about the *gate*. Item 2 is about the *surface*: 「三顆同組。Push 為主要樣式。」
+describes buttons, and 「conflict 狀態全部停用（見 07）」 is a clause attached to
+them, not the item itself. So the row proved that three action ids would be
+greyed out, in a bar nothing drew. The P07 STATES section carried the identical
+defect one screen further down (「Toolbar Fetch/Pull/Push disabled」, same
+evidence, same 符合).
+
+This is the fourth time on this page alone that a row passed by checking a
+different claim than the one written next to it — items 11, 12 and 14 were all
+overturned the same way in earlier rounds. The distilled form is now in
+CLAUDE.md: **a matrix cell whose evidence is `isActionEnabled()` proves the
+gate exists, never the gated surface.**
+
+#### Three vs five buttons
+
+Only Fetch/Pull/Push have prose behind them — item 2's own note, P07's STATES
+row (「三顆停用」) and P16's REVISIONS (「工具列 F / P / P 三顆同組，不能拆」).
+Branch and Stash appear only in the mockup, which by this repo's own rule
+(「A mockup shows what the user sees, not who draws it」) is not by itself a
+requirement.
+
+Built all five anyway, and the reasoning matters more than the outcome: the
+prose-wins rule exists to settle **contradictions** (P10's `--prune` mockup vs
+its own 「尚未 prune」 prose is the recorded case). Here there is nothing to
+overrule — the prose is silent about Branch/Stash rather than against them, and
+the spec's own icon choices name what they do: `git-branch-plus` is New branch,
+`inbox` is Stash changes. Both handlers (`branchNewBranch`,
+`branchStashChanges`) already existed in `_buildActionHandlers()`.
+
+#### Why a new row rather than folding it into TopBar
+
+`TopBar` occupies the same slot the spec gives the toolbar, so merging was the
+obvious-looking move. It was rejected for two reasons already written down
+here: `TopBar` is the one piece of chrome with **no** `Expanded >
+SingleChildScrollView` guard (the narrow-window round found that by grepping
+all four rows for the pattern the other three shared), and its ~327px non-flex
+floor is a **measured** number carried in a source comment — anything added
+upstream of it obliges a re-measurement. A separate `ActionToolbar` copies
+`menu_bar_row.dart:97`'s guard, leaves `top_bar.dart` and its four
+narrow-window tests untouched, and stays independently testable like
+`MenuBarRow`/`TabRow`. Cost: one more 38px chrome row (three on macOS, where
+`MenuBarRow` is not drawn). The extra row does not disturb
+`workspace_narrow_window_test.dart`'s 800×600 chrome control.
+
+`ActionToolbar` is drawn on **all three platforms**. Page 01 says only the menu
+bar's *position* follows the system; macOS moving its menus into the system bar
+says nothing about a toolbar.
+
+#### The assertion that could not fail, and the one that replaced it
+
+Branch and Stash are gated by the identical predicate and both do nothing but
+`context.push(...)`. So the natural integration assertion — `onPressed` is
+non-null when clean, null when conflicted, for all five — **stays green when
+the two handlers are swapped**. Mutation-checking caught it: wiring `onStash`
+to `GbmActionId.branchNewBranch` produced no red at all. That is the
+「fixture that cannot disagree with the code」 shape again, in its fifth recorded
+form: *two subjects the assertion cannot tell apart*. Registering sentinel
+`dialogRoute`s for `newBranchDialog` and `stashChangesDialog` and asserting
+which one opens is what makes the swap visible.
+
+Three more mutations behaved: `onFetch: null` reddened the three clean-state
+tests; `onFetch` bypassing the handler map straight to
+`RepoSessionController.fetchRemote` (the orphan-wiring shape
+`workspace_intent_dispatch_parity_test.dart` exists for) reddened both
+conflict-state tests; removing the scroll guard reddened only the two 320px
+tests.
+
+#### Smaller things
+
+- **The four new Lucide SVGs were fetched, not hand-authored.** The standalone
+  spec renders them through `window.lucide.icons` (`spec_logic.js:706-715`) and
+  embeds no path data (grep: 0 hits), so there was nothing to copy out of it.
+  The normalisation applied to `lucide-static` v1.34.0 (drop the `@license`
+  comment and the `class` attribute, `stroke` → `#000000`) was **verified by
+  running it on `cloud-download.svg` and diffing against the copy already in
+  the repo** — byte-identical, which is also how the version was pinned.
+  Recalling a path from memory would have been a coin flip on
+  `git-branch-plus` specifically.
+- **Spec's `download-cloud` is Lucide's `cloud-download`**, already bundled;
+  Fetch reuses it rather than adding a second copy of the same glyph.
+- Icons go into `app_flutter/assets/icons/` only. `resources/icons/` is a stale
+  16-file copy — `cloud-off`, `columns-3` and `grip-vertical` exist only on the
+  app side, and `pubspec.yaml` packages only the app side.
+- **Adding a widget can break an unscoped `find.text` two files away.**
+  `_repositoryMenuItemColor()` in `workspace_conflict_transition_test.dart` read
+  `find.text('Fetch')` with no scope, which was unambiguous only while the menu
+  was the sole place that word appeared. `_GbmMenuPanel`/`_GbmMenuRow` are both
+  private, so there is no type to scope to positively; the helper now excludes
+  the `ActionToolbar` subtree instead.
+- **Recorded reduction — Alt+click on toolbar Pull.** P17's Pull dialog note
+  says 「這張預設不出現 — 工具列的 Pull 直接用 Preferences 的預設套用方式走。
+  只有選單的 Pull… 或 Alt + 點工具列才開。」 `route_paths.dart` has no pull
+  dialog route at all, so there is nothing for Alt+click to open. The plain
+  click implements the first half (`pullChanges()` with the configured default);
+  the modifier path is absent and tracked on **#109**, not faked.

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -2541,3 +2541,41 @@ tests.
   dialog route at all, so there is nothing for Alt+click to open. The plain
   click implements the first half (`pullChanges()` with the configured default);
   the modifier path is absent and tracked on **#109**, not faked.
+
+#### What the verification does and does not cover
+
+The plan's 驗證 section ended with 「實機：`flutter run -d macos`…肉眼確認工具列
+位置/樣式/圖示」. **That human visual pass was not performed, and is recorded here
+rather than left implied by the green suite.** Two substitutes were run instead,
+and they cover different halves of the risk:
+
+- **Device-tier finder ambiguity: checked, nothing to do.** Adding five
+  permanently-rendered words (`Fetch`, `Pull`, `Push`, `Branch`, `Stash`) is
+  exactly what broke `_repositoryMenuItemColor()` in the widget tier, and
+  `flutter test` never runs `integration_test/`, so its green says nothing about
+  the device tier. Grepping every finder in `integration_test/` for those five
+  words and for un-scoped `byType(GbmButton)` / `byType(LucideIcon)` returned
+  one hit — `rename_branch_flow_test.dart:137`'s `find.text('Rename Branch')`,
+  which is a dialog title and does not collide (`find.text` is exact-match, so
+  `'Rename Branch'` never matches `'Branch'`). No device file needed rerunning.
+- **Icon rendering: rasterised, not just bundled.** The earlier check only
+  proved the four SVGs ship in the asset bundle and parse as strings — which a
+  file drawing nothing would also pass. A temporary test (run, mutation-checked,
+  then deleted) loaded each of the five toolbar icons through
+  `vg.loadPicture(SvgAssetLoader(...))` — the exact path `LucideIcon` uses —
+  called `Picture.toImage()`, and counted non-transparent pixels. All five
+  painted. Replacing `inbox.svg` with a well-formed but empty `<svg/>` reddened
+  that one test and only that one, so the assertion is falsifiable and narrow.
+
+What neither covers, and what the deferred pass would have: that each glyph is
+the *intended* one (a rasterised heart passes a "painted something" test), and
+that the row's position, height and spacing look right in a real 1280×720
+window. The first is mitigated by provenance rather than by assertion — the
+files came from `lucide-static` v1.34.0 and the transform was proven
+byte-identical on an icon already in the repo — and the second is what the
+800×600 and 320px widget tests approximate.
+
+One trap worth carrying: **`Picture.toImage()` inside `testWidgets` hangs
+forever without `tester.runAsync()`**, with no output and no timeout of its
+own — the first attempt was killed at eight minutes having printed nothing.
+flutter_test's fake-async zone never completes it.

--- a/docs/reports/spec-conformance-matrix.md
+++ b/docs/reports/spec-conformance-matrix.md
@@ -335,7 +335,7 @@ flex ratio verbatim. Persistence goes through
 | # | Item | Verdict | Evidence | Reason |
 |---|---|---|---|---|
 | 1 | Menu bar (Alt/Ctrl+F2 opens first menu) | 符合 | `workspace_screen.dart:385` | — |
-| 2 | Fetch/Pull/Push disabled during conflict | 符合 | `gbm_action_availability.dart:33-45` | All 3 gated on `!conflictActive`. |
+| 2 | Toolbar: Fetch/Pull/Push (Push primary) + Branch/Stash, all disabled during conflict | ~~符合~~ → **符合** (feat/p02-action-toolbar) | `features/workspace/widgets/action_toolbar.dart`, `workspace_screen.dart`, `gbm_action_availability.dart:33-45` | **This row checked the gate and passed for it, while the surface being gated did not exist.** The old verdict's title ("Fetch/Pull/Push disabled during conflict") is not what item 2 says: item 2 *is* the toolbar row under the menu bar (`spec_raw.html:1245-1255`), and 「三顆同組。Push 為主要樣式。」describes buttons, not a permission rule. Nothing under `lib/` rendered them — Fetch/Pull/Push had exactly two entry points, the keyboard shortcut and the Repository menu — so `gbm_action_availability.dart` was greying out a bar that was never drawn. Same shape as rows 11, 12 and 14 below. `ActionToolbar` now renders all five buttons on all three platforms, wired from the same `Map<GbmActionId, VoidCallback?>` the keyboard/system-menu/in-window-menu paths dispatch through, so the conflict gate arrives through `isActionEnabled()` with no second source. Branch/Stash are mockup-only (no prose names them) but the spec's own icon choices — `git-branch-plus`, `inbox` — name their actions, and no prose contradicts them, so the prose-wins rule had nothing to overrule. **Recorded reduction**: P17 wants Alt+click on toolbar Pull to open a Pull dialog with the apply mode pre-selected; `route_paths.dart` has no pull dialog route, so only the plain click (「直接用 Preferences 的預設套用方式走」) is wired. |
 | 3 | Search commits (Ctrl/Cmd+F) | 符合 | `commit_search.dart:8-28` | message/author/hash-prefix. |
 | 4 | Sidebar: 3 sections, branches merged into ONE tree | 符合 | `sidebar_panel.dart:32-38,417-420`, `branch_tree_builder.dart:127-171` | `mergeLocalAndRemoteBranches()`. |
 | 5 | Splitter A | 符合 | `workspace_screen.dart:326-331` | — |
@@ -351,7 +351,7 @@ flex ratio verbatim. Persistence goes through
 | 15 | Repo switcher popover | 符合 | `repo_switcher_popover.dart` | — |
 | 16 | Graph column picker, Date hybrid format + ISO tooltip | 符合 | `graph_columns_selector.dart:56,61`, `graph_date_format.dart:5-26` | Graph/Message locked; relative/absolute date switch + full-ISO tooltip both present. |
 
-**15/16 符合, 1 real rendering gap (item 6's chip-merge rule).**
+**15/16 符合, 1 real rendering gap (item 6's chip-merge rule).** Item 2's original 符合 was withdrawn and re-earned by feat/p02-action-toolbar; the count is unchanged because the row was already counted as passing when it was not.
 
 ---
 
@@ -378,7 +378,7 @@ context-menu labels (05-F) reachable at all.
 |---|---|---|---|
 | 判定條件 | 符合 | `repo_session_repository.dart`'s `conflictActive` getter (documented in CLAUDE.md) | — |
 | Banner | 符合 | `workspace_screen.dart:289-296` | `ConflictBanner` shown only when `conflictActive`. |
-| Toolbar Fetch/Pull/Push disabled | 符合 | `gbm_action_availability.dart:33-45` | — |
+| Toolbar Fetch/Pull/Push disabled | ~~符合~~ → **符合** (feat/p02-action-toolbar) | `action_toolbar.dart`, `gbm_action_availability.dart:33-45` | **Same defect as P02 row 2, and for the same reason**: this row's evidence proved the three ids were gated, not that a toolbar existed to gate. It did not. The row now names the widget that renders 「三顆」, and `workspace_conflict_transition_test.dart`'s `spec P02-2 toolbar` group asserts the buttons themselves flip across the conflict↔clean transition (and back), rather than asserting the predicate that decides it. |
 | 切分支 disabled | 符合 | `gbm_action_availability.dart:40` | `branchCheckout` gated same way. |
 | Working copy gains a Conflicted section | **符合 — corrected** | `working_copy_view.dart:136-138,171-245` | The discovery agent initially reported this as missing. Direct spot-check disproves that: `_buildConflictedSection()` exists, is pinned at the top, rendered only `if (status.conflicted.isNotEmpty)`, capped-height scrolling list with a count badge — matches spec exactly. Recorded here as a concrete example of why this audit spot-checks agent output rather than transcribing it verbatim. |
 | Commit disabled until resolved | 符合 | `gbm_action_availability.dart:37` | — |


### PR DESCRIPTION
規格 P02（主視窗 — History）的第 **2** 號標註，指的是 menu bar 底下那一條工具列：`Fetch` / `Pull` / `Push`（Push 為 primary 樣式），分隔線，再接 `Branch` / `Stash`。

**這條工具列在 `app_flutter/lib/` 裡完全不存在。** Fetch/Pull/Push 過去只有兩個入口：鍵盤快捷鍵與 menu bar 的 Repository 選單。

## 稽核為什麼漏掉它

`docs/reports/spec-conformance-matrix.md` 的 P02 row 2 判為「符合」，證據是 `gbm_action_availability.dart:33-45` —— 那檢查的是「衝突時三顆會不會停用」這個**閘門**，不是「那三顆到底存不存在」這個**表面**。同檔 P07 STATES 的「Toolbar Fetch/Pull/Push disabled」列是同一個問題。

這和同頁 items 11 / 12 / 14 被推翻的形狀一模一樣。兩格判定已就地更正並附證據（依 repo 慣例：不靜默改標題），並蒸餾成一條 invariant 進 CLAUDE.md：

> A conformance cell whose evidence is `isActionEnabled()` proves the gate exists, never the gated surface.

## 做了什麼

五個可獨立 revert 的 commit：

| Commit | 內容 |
|---|---|
| `2d61338` | 四個 Lucide SVG（`arrow-down-to-line`、`arrow-up-from-line`、`git-branch-plus`、`inbox`）。Fetch 沿用既有的 `cloud-download.svg` |
| `af60333` | `ActionToolbar` 呈現層元件 + 13 個 widget 測試 |
| `76d5cd2` | 接上 `WorkspaceScreen._buildActionHandlers()` 的 handler map + 6 個整合測試 |
| `11d5143` | 更正兩格稽核判定、ledger 敘事、CLAUDE.md 蒸餾條目 |
| `df4ff3b` | 記下本輪驗證的邊界與 `runAsync` 的坑 |

### 三顆還是五顆：五顆

prose 只點名 Fetch/Pull/Push，但 mockup 另外畫了 Branch / Stash，且規格自己挑的圖示（`git-branch-plus`、`inbox`）指向 New branch 與 Stash changes 的意圖。prose 在這裡對後兩顆是**沉默**而不是牴觸，所以 repo 的「prose 勝出」規則在此沒有要否決的東西。兩個 handler 也都已存在。

### 另開一列，不併進 TopBar

`TopBar` 是四條 chrome 裡**唯一沒有 `Expanded > SingleChildScrollView` 護欄**的一條，而且帶著一段實測註解（非彈性殘餘約需 327 邏輯像素）。CLAUDE.md：「A comment claiming its bounds are measured must be re-measured when anything upstream of the measurement moves」——不動它就不用重測。新列直接抄 `menu_bar_row.dart:97` 已驗證的護欄。

### 停用邏輯零新增

`isActionEnabled()` 本來就涵蓋這五個 id，衝突停用是免費拿到的。`onPressed: null` 由 `GbmButton` 自己畫成停用態，**沒有另外加 `enabled` 旗標**（`GbmMenuItem.enabled: false` 只是視覺訊號那條教訓的同型）。

## Mutation 抓到一個測試黑洞

把 `onStash` 接到 `GbmActionId.branchNewBranch`（即兩顆按鈕互換）——**完全沒有紅**。

Branch 與 Stash 共用同一個閘門，而且兩者都只 `context.push(...)`，所以任何 `onPressed != null` 的斷言都分不出它們。這是「fixture 無法與程式碼相左」的**第五種形態：兩個主體對斷言而言無法區分**，已補進 CLAUDE.md。

補救方式是註冊 sentinel `dialogRoute`，斷言「開的是哪一個 dialog」而不是「按鈕能不能按」。重跑 mutation 後正確地只紅那一條。

其餘三個 mutation 都表現正常：`onFetch: null` 紅三條 clean-state；`onFetch` 繞過 handler map 直接呼叫 controller（orphan wiring 形狀）紅兩條 conflict-state；拿掉捲動護欄只紅兩條 320px。

## 驗證

```
flutter test      → 1948 passed
flutter analyze   → No issues found!
dart format --output=none --set-exit-if-changed .  → 416 files, 0 changed
```

**Device tier 撞名掃描：無事可做。** 新增五個永遠會渲染的字正是先前打壞 `_repositoryMenuItemColor()` 的形狀，而 `flutter test` 不跑 `integration_test/`。掃過 device tier 全部 finder，只有 `rename_branch_flow_test.dart:137` 的 `find.text('Rename Branch')`，exact match 不會命中 `'Branch'`。

**圖示是 rasterise 驗過的，不只是「有進 bundle」。** 一個什麼都不畫的 SVG 也能通過字串層級的檢查。用 `LucideIcon` 走的同一條路徑 `vg.loadPicture(SvgAssetLoader(...))` 載入五個圖示、`Picture.toImage()` 後數不透明像素，五個都有畫；換成格式正確但空的 `<svg/>` 只紅那一條。（此測試為臨時性質，跑完即刪。）

**沒做的：`flutter run -d macos` 肉眼確認未執行，明寫在 ledger。** 自動檢查涵蓋不到「每個字形是不是該長那樣」與「真實 1280×720 視窗裡的位置與間距」。前者靠來源可信度處理——檔案取自 `lucide-static` v1.34.0，轉換規則在 repo 既有的 `cloud-download.svg` 上驗到 byte-identical；後者由 800×600 與 320px 的 widget 測試近似。

## 有意識的縮減

P17 的 Pull dialog 註記說「只有選單的 Pull… 或 Alt + 點工具列才開」。`route_paths.dart` 裡**沒有任何 pull dialog 路由**，所以 Alt+click 沒有可開的東西。工具列 Pull 直接跑 `pullChanges()`（規格前半句），modifier 路徑缺席並追蹤在 **#109**，不是靜默省略。

## Test plan

- [x] `flutter test` 全綠（1948）
- [x] `flutter analyze` 0 issues（CI 對 info 級也零容忍）
- [x] `dart format --set-exit-if-changed .` 無變動
- [x] 每個新測試都 mutation-check 過，且紅得夠窄
- [x] `workspace_narrow_window_test.dart` / `workspace_states_table_test.dart` / `top_bar_test.dart` 不受多出的 38px 影響
- [x] device tier finder 撞名掃描
- [x] 五個圖示 rasterise 後有可見像素（可證偽：空 `<svg/>` 只紅該條）
- [ ] 實機肉眼確認（未執行，理由已寫入 `docs/ledger.md`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VLRSW3redPspEoxEN3AWt
