### PR TITLE
feat: Changed files 每列補上 +N/−N 行數 badge（規格 P02-10）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,7 +525,10 @@ you are touching, not by when it was learned.
   **never `git checkout -- <file>`** to revert a mutation, which once
   discarded an entire uncommitted implementation. Have the mutation script
   assert `count(old) == 1` before writing — two mutations in one round
-  silently matched nothing after a formatter reflowed an argument list.
+  silently matched nothing after a formatter reflowed an argument list, and a
+  `JsonCodec.cpp` anchor named only by its field matched **two** serializers
+  (`DiffFile`'s and `ChangedFile`'s both emit `addedLines`). Anchor on a
+  neighbouring line that is actually unique.
 - **Count, don't `any`.** `commandLog.where((c) => c.name == …).length` —
   `.any(...)` is blind to a double dispatch, which is exactly what several
   of these fixes could regress into.
@@ -533,7 +536,10 @@ you are touching, not by when it was learned.
   it is silently clamped. A widget test that sizes its own canvas proves
   nothing about layout under real constraints, and a placement bug is
   invisible to any tier whose canvas is bigger than the real window (the
-  column-picker popover shipped off-screen for exactly this reason).
+  column-picker popover shipped off-screen for exactly this reason; later, a
+  deliberate overflow in the Changed files row was caught **only** by the one
+  test sized to `GbmLayout.splitterMainFiles.defaultExtent` — three others on
+  the default canvas passed with the broken layout).
 - **`RenderFlex` reports only main-axis overflow**, so a `takeException()`
   test cannot see a cross-axis defect. Check which axis the defect is on
   before writing a no-exception test.
@@ -667,6 +673,20 @@ you are touching, not by when it was learned.
   `diff.renames` while `git diff-tree --raw` ignores it entirely, so the
   rename flag is passed **explicitly on both** from one shared
   `rawRenameFlag()`.
+- **git's diff output-format is a single slot**: `--raw` and `--numstat`
+  cannot both take effect in one invocation, so a file list that needs kinds
+  *and* line counts runs two commands and joins them by path
+  (`DiffService::attachLineCounts()`, `CompareOps.cpp`'s `readFiles()`). The
+  second command must repeat **every** flag the first passed — drop `--root`
+  and root commits return nothing, drop `--diff-merges=first-parent` and
+  merges return nothing, use a different rename flag and the two disagree
+  about which paths exist. All three land as a row with no count and no error
+  anywhere. Under `-z`, numstat spends **three** records on a rename (empty
+  path field, old path, new path) where every other kind spends one, so a
+  one-record-per-entry loop mis-reads every count after the first rename. Join
+  on `path`, the only field `parseRawRecords()` fills for all kinds; `oldPath`
+  is empty except for renames and copies. `-` means binary, not a number.
+  Ledger: "Changed files line counts".
 - `git log --no-walk` sorts by commit date, not by the order the oids were
   given, so a batch reply must echo each oid rather than be index-aligned.
   And **absent is not zero**: a commit git never answered for is omitted, not
@@ -759,15 +779,35 @@ you are touching, not by when it was learned.
 - **Nothing is silently dropped.** A capability removed for spec conformance
   gets its reason recorded (the operation-log dialog's `Clear`, the
   per-remote Pull/Push), and a reduction made for a cap or a missing capi is
-  written down rather than left for the next audit to file as a bug.
+  written down rather than left for the next audit to file as a bug. But
+  **a reduction note names one victim of a missing capability, not all of
+  them**: `commit_selection_summary.dart` recorded P13's 合計 diff as absent
+  because `ChangedFile` had no line counts, and P02-10's badge — same missing
+  field, no running total needed — went unfiled for rounds. Grep for other
+  readers of whatever a note calls absent before trusting its blast radius
+  (ledger: "Changed files line counts").
 - **A note explaining why a test avoids a code path deserves the same
   scrutiny as the code path itself** — one correct observation with a wrong
   cause became a permanent workaround and hid a real defect for months.
+  A mutation is how you check one: **a mutation that fails to land where the
+  comment predicted means the comment is wrong**, not the mutation. Keying
+  `attachLineCounts()` on `oldPath` was supposed to break deletes and broke
+  only renames — `oldPath` is empty for every kind but rename/copy — so both
+  the comment and the test's rationale were corrected.
 - **A comment claiming its bounds are measured must be re-measured when
   anything upstream of the measurement moves.** A page recomposition is
-  upstream of every width in the row.
+  upstream of every width in the row. The same holds for a comment claiming a
+  *performance* property: `ChangedFile`'s 「Cheap: no content is read, so
+  clicking through commits stays instant」 stopped being true the round a
+  second git invocation was added, and that round owned rewriting it.
 - Stage by file when two changes are live in one directory: `git add -A <dir>`
-  once swept an unrelated in-progress change into a `refactor:` commit.
+  once swept an unrelated in-progress change into a `refactor:` commit. The
+  opposite error is filing a file by where its *assertions* belong rather than
+  where its *compilation* does: a commit that adds a `required` field to a
+  model must carry every fixture that constructs **or feeds** it — a raw-JSON
+  fixture is invisible to a grep for the constructor name, and a missing key
+  is `null as int` at runtime. Only a per-commit checkout sees this; every
+  run at the branch tip is green (line-counts round).
 
 ### Current known drift
 

--- a/app_flutter/integration_test/commit_file_counts_test.dart
+++ b/app_flutter/integration_test/commit_file_counts_test.dart
@@ -1,4 +1,6 @@
-// Device-tier E2E for the Changed files column (spec page 02 item 16).
+// Device-tier E2E for the two places a commit's file changes are counted:
+// the Changed files *column* (spec page 02 item 16) and the Changed files
+// *panel*'s per-row +N/-N badge (spec page 02 item 10).
 //
 // Why this file has to exist, and why a widget test cannot replace it:
 // `gbm_request_commit_file_counts` is a new C entry point with a matching
@@ -17,6 +19,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/changed_files_panel.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -114,4 +117,52 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets(
+    'the Changed files panel badges a selected commit\'s line counts',
+    (tester) async {
+      // Spec page 02 item 10. The counts reach the badge through a chain no
+      // other tier crosses end to end: DiffService joins `diff-tree --numstat`
+      // onto the raw list, capi serialises two new JSON keys, and the Dart
+      // model decodes them with a hard `as int`. test/** runs on
+      // FakeGbmBindings and tests/capi/** stops at the C++ side, so a payload
+      // the two halves disagree about is invisible everywhere but here -- and
+      // a stale libgbm_capi would surface as a Dart decode error rather than
+      // as a missing badge.
+      //
+      // Its own commit rather than one of _buildMergeHistory's: +7/-3 is
+      // asymmetric and appears nowhere else on screen, where the fixture's
+      // one-line files would give a "+1" that half the UI could produce.
+      File('$repo/counts.txt').writeAsStringSync('l1\nl2\nl3\nl4\nl5\n');
+      runGit(repo, <String>['add', 'counts.txt']);
+      runGit(repo, <String>['commit', '-m', 'add counts']);
+      File(
+        '$repo/counts.txt',
+      ).writeAsStringSync('l1\nA\nB\nC\nD\nE\nF\nG\nl5\n');
+      runGit(repo, <String>['add', 'counts.txt']);
+      runGit(repo, <String>['commit', '-m', 'edit counts']);
+
+      await pumpRealAppOn(tester, repo);
+
+      expect(_rowFor('edit counts'), findsOneWidget);
+      await tester.tap(_rowFor('edit counts'));
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final Finder panel = find.byType(ChangedFilesPanelCore);
+      expect(
+        find.descendant(of: panel, matching: find.text('counts.txt')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: panel, matching: find.text('+7')),
+        findsOneWidget,
+        reason: 'the added-line badge must carry the real numstat count',
+      );
+      expect(
+        find.descendant(of: panel, matching: find.text('-3')),
+        findsOneWidget,
+        reason: 'the removed-line badge must not repeat the added count',
+      );
+    },
+  );
 }

--- a/app_flutter/lib/data/models/changed_file.dart
+++ b/app_flutter/lib/data/models/changed_file.dart
@@ -12,6 +12,8 @@ class ChangedFile {
     required this.oldBlob,
     required this.newBlob,
     required this.similarity,
+    required this.addedLines,
+    required this.removedLines,
   });
 
   factory ChangedFile.fromJson(Map<String, dynamic> json) {
@@ -24,6 +26,8 @@ class ChangedFile {
       oldBlob: json['oldBlob'] as String,
       newBlob: json['newBlob'] as String,
       similarity: json['similarity'] as int,
+      addedLines: json['addedLines'] as int,
+      removedLines: json['removedLines'] as int,
     );
   }
 
@@ -41,4 +45,12 @@ class ChangedFile {
   final String oldBlob;
   final String newBlob;
   final int similarity;
+
+  /// Spec page 02 item 10's "+12" badge, from `git diff-tree --numstat`
+  /// joined onto the raw file list in `DiffService::changedFiles()`. Both
+  /// read 0 for a binary blob -- numstat reports "-" rather than a number
+  /// there -- and the Changed files panel draws no badge for a 0, which is
+  /// the honest rendering for something that has no lines.
+  final int addedLines;
+  final int removedLines;
 }

--- a/app_flutter/lib/features/history_graph/commit_selection_summary.dart
+++ b/app_flutter/lib/features/history_graph/commit_selection_summary.dart
@@ -9,11 +9,18 @@ import '../../data/models/list_selection.dart';
 /// user looking at three greyed-out menu items needs somewhere that says why.
 ///
 /// **Reduced deliberately: no 合計 diff.** The spec's own mock reads
-/// `4 commits · 連續 · 9 files changed · +311 −54`, but `ChangedFile` carries
-/// no added/removed line counts, and the only path in the core that runs
-/// `--numstat` is `CompareOps.cpp`'s range diff — so a running total would
-/// mean firing a range diff on every selection change. Absent rather than
-/// faked, same convention as `MULTIACTS`' `Squash`.
+/// `4 commits · 連續 · 9 files changed · +311 −54`. Half the original reason
+/// is gone: `ChangedFile` now *does* carry added/removed line counts, because
+/// `DiffService::changedFiles()` joins `diff-tree --numstat` onto the raw list
+/// for spec page 02 item 10's per-file badge (see docs/ledger.md's "Changed
+/// files line counts").
+///
+/// The other half stands, and is why this is still absent. A *total* spans a
+/// selection, so it needs the counts for every selected commit, not for the
+/// one whose panel is open — that means a `changedFiles()` call per commit on
+/// every selection change, each of which now runs two git invocations rather
+/// than one. Absent rather than faked, same convention as `MULTIACTS`'
+/// `Squash`.
 ///
 /// Returns null below two items rather than `1 commit · contiguous`: a single
 /// commit has nothing to be contiguous *with*, so the phrase would be filler,

--- a/app_flutter/lib/features/history_graph/widgets/changed_files_panel.dart
+++ b/app_flutter/lib/features/history_graph/widgets/changed_files_panel.dart
@@ -20,6 +20,7 @@ import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_row.dart';
 import '../../../widgets/file_list_mode_switcher.dart';
 import '../../../widgets/file_list_mode_toggle_button.dart';
+import '../../../widgets/gbm_badge.dart';
 import '../../../widgets/gbm_menu.dart';
 
 /// What to do with an export once its bytes land on disk. The capi echoes
@@ -427,14 +428,37 @@ class ChangedFilesPanelCore extends StatelessWidget {
       onTap: onFileTap == null ? null : () => onFileTap!(file.path),
       onSecondaryTapDown: (TapDownDetails details) =>
           _openContextMenu(context, details, file.path),
-      child: Text(
-        file.path,
-        style: TextStyle(
-          fontSize: GbmTypography.textSm,
-          color: colors.textPrimary,
-        ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+      // Spec page 02 item 10 draws each row as `檔名 + 綠色 +12 badge`. Same
+      // shape and the same source as `compare_page.dart`'s file rows -- both
+      // read counts that `DiffService` gets from `git diff-tree --numstat` --
+      // so History and Compare cannot disagree about a file's size.
+      //
+      // A zero draws nothing rather than "+0": binary blobs and mode-only
+      // changes both arrive as 0/0, and a badge there would claim a
+      // measurement that was never made.
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              file.path,
+              style: TextStyle(
+                fontSize: GbmTypography.textSm,
+                color: colors.textPrimary,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (file.addedLines > 0)
+            GbmBadge(label: '+${file.addedLines}', kind: GbmBadgeKind.added),
+          if (file.removedLines > 0) ...<Widget>[
+            const SizedBox(width: GbmSpacing.space1),
+            GbmBadge(
+              label: '-${file.removedLines}',
+              kind: GbmBadgeKind.removed,
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/app_flutter/test/data/models/model_parsing_test.dart
+++ b/app_flutter/test/data/models/model_parsing_test.dart
@@ -185,7 +185,8 @@ void main() {
   test('ChangedFile.fromJson decodes every field', () {
     final Map<String, dynamic> json = jsonDecode(
       '{"path":"b.txt","oldPath":"a.txt","kind":3,"oldMode":"100644",'
-      '"newMode":"100644","oldBlob":"aaa","newBlob":"bbb","similarity":92}',
+      '"newMode":"100644","oldBlob":"aaa","newBlob":"bbb","similarity":92,'
+      '"addedLines":12,"removedLines":3}',
     );
     final ChangedFile file = ChangedFile.fromJson(json);
 
@@ -197,14 +198,20 @@ void main() {
     expect(file.oldBlob, 'aaa');
     expect(file.newBlob, 'bbb');
     expect(file.similarity, 92);
+    // Spec page 02 item 10's badge. Two different non-zero numbers, so a
+    // decoder that read one key into both fields fails here.
+    expect(file.addedLines, 12);
+    expect(file.removedLines, 3);
   });
 
   test('ChangedFile.listFromJson decodes an array in order', () {
     final List<dynamic> json = jsonDecode(
       '[{"path":"a.txt","oldPath":"","kind":1,"oldMode":"","newMode":"100644",'
-      '"oldBlob":"","newBlob":"aaa","similarity":0},'
+      '"oldBlob":"","newBlob":"aaa","similarity":0,'
+      '"addedLines":7,"removedLines":0},'
       '{"path":"b.txt","oldPath":"","kind":2,"oldMode":"100644","newMode":"",'
-      '"oldBlob":"bbb","newBlob":"","similarity":0}]',
+      '"oldBlob":"bbb","newBlob":"","similarity":0,'
+      '"addedLines":0,"removedLines":5}]',
     );
     final List<ChangedFile> files = ChangedFile.listFromJson(json);
 
@@ -213,6 +220,10 @@ void main() {
       FileChangeKind.added,
       FileChangeKind.deleted,
     ]);
+    // An add carries only additions and a delete only removals, so these
+    // also pin that the two entries did not get their counts swapped.
+    expect(files.map((f) => f.addedLines), <int>[7, 0]);
+    expect(files.map((f) => f.removedLines), <int>[0, 5]);
   });
 
   test('ParsedDiff.fromJson decodes nested files/hunks/lines', () {

--- a/app_flutter/test/features/context_menus/context_menu_parity_test.dart
+++ b/app_flutter/test/features/context_menus/context_menu_parity_test.dart
@@ -163,6 +163,8 @@ ChangedFile _changedFile({String path = 'lib/main.dart'}) {
     oldBlob: '',
     newBlob: '',
     similarity: 0,
+    addedLines: 0,
+    removedLines: 0,
   );
 }
 

--- a/app_flutter/test/features/history_graph/history_page_layout_test.dart
+++ b/app_flutter/test/features/history_graph/history_page_layout_test.dart
@@ -68,6 +68,11 @@ ChangedFile _file(String path) => ChangedFile(
   oldBlob: 'aaa',
   newBlob: 'bbb',
   similarity: 0,
+  // 0/0 draws no badge, so these rows render exactly as they did before
+  // spec P02-10's line counts existed -- this file is about something
+  // else and should not start depending on them.
+  addedLines: 0,
+  removedLines: 0,
 );
 
 CommitMeta _meta(String oid) => CommitMeta(

--- a/app_flutter/test/features/history_graph/widgets/changed_files_panel_test.dart
+++ b/app_flutter/test/features/history_graph/widgets/changed_files_panel_test.dart
@@ -13,16 +13,22 @@ import 'package:gbm_flutter/widgets/file_tree_folder_row.dart';
 
 import '../../../support/pump_app.dart';
 
-ChangedFile _file(String path) => ChangedFile(
-  path: path,
-  oldPath: path,
-  kind: FileChangeKind.modified,
-  oldMode: '100644',
-  newMode: '100644',
-  oldBlob: 'aaa',
-  newBlob: 'bbb',
-  similarity: 0,
-);
+ChangedFile _file(String path, {int addedLines = 0, int removedLines = 0}) =>
+    ChangedFile(
+      path: path,
+      oldPath: path,
+      kind: FileChangeKind.modified,
+      oldMode: '100644',
+      newMode: '100644',
+      oldBlob: 'aaa',
+      newBlob: 'bbb',
+      similarity: 0,
+      // Defaulted so the cases that predate spec P02-10's badge keep
+      // asserting what they always did; every badge case passes both
+      // explicitly, so none of them can pass on a default.
+      addedLines: addedLines,
+      removedLines: removedLines,
+    );
 
 void main() {
   testWidgets('shows "No files changed" when no commit is selected', (

--- a/app_flutter/test/features/history_graph/widgets/changed_files_panel_test.dart
+++ b/app_flutter/test/features/history_graph/widgets/changed_files_panel_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/theme/tokens.dart';
 import 'package:gbm_flutter/features/history_graph/widgets/commit_row.dart';
+import 'package:gbm_flutter/widgets/gbm_badge.dart';
 import 'package:gbm_flutter/widgets/gbm_row.dart';
 import 'package:gbm_flutter/data/models/changed_file.dart';
 import 'package:gbm_flutter/data/models/working_copy_status.dart';
@@ -99,6 +100,116 @@ void main() {
     // `ListTile` as its finder.
     expect(tester.getSize(find.byType(GbmRow).first).height, kCommitRowHeight);
     expect(kCommitRowHeight, GbmSpacing.rowHeightCompact);
+  });
+
+  // --- spec page 02 item 10: the "+12" badge -----------------------------
+  //
+  // The mockup row is `檔名 + 綠色 +12 badge`. Compare's file rows already
+  // draw the same pair from the same numstat data, so these pin that History
+  // now agrees with it rather than pinning a new invention.
+
+  testWidgets('a changed file shows its added and removed line counts', (
+    tester,
+  ) async {
+    await pumpGbmWidget(
+      tester,
+      child: ChangedFilesPanelCore(
+        hasSelectedCommit: true,
+        files: <ChangedFile>[
+          _file('lib/a.dart', addedLines: 12, removedLines: 3),
+        ],
+        selectedPath: null,
+        onFileTap: (_) {},
+      ),
+    );
+
+    // Both signs asserted, and with different numbers: a widget that wired
+    // the same field to both badges, or swapped them, still renders two
+    // badges and would pass an either-or check.
+    expect(find.text('+12'), findsOneWidget);
+    expect(find.text('-3'), findsOneWidget);
+  });
+
+  testWidgets('a pure addition shows no removed badge', (tester) async {
+    await pumpGbmWidget(
+      tester,
+      child: ChangedFilesPanelCore(
+        hasSelectedCommit: true,
+        files: <ChangedFile>[
+          _file('lib/new.dart', addedLines: 40, removedLines: 0),
+        ],
+        selectedPath: null,
+        onFileTap: (_) {},
+      ),
+    );
+
+    expect(find.text('+40'), findsOneWidget);
+    // Not "-0". A zero is not a change, and drawing it would put a red badge
+    // on every added file in the list.
+    expect(find.text('-0'), findsNothing);
+  });
+
+  testWidgets('a file with no line counts shows no badge at all', (
+    tester,
+  ) async {
+    // Binary blobs and mode-only changes both land here: numstat reports "-"
+    // for a binary file and the core leaves both counts at 0, so the row has
+    // nothing truthful to put in a badge.
+    await pumpGbmWidget(
+      tester,
+      child: ChangedFilesPanelCore(
+        hasSelectedCommit: true,
+        files: <ChangedFile>[_file('assets/logo.png')],
+        selectedPath: null,
+        onFileTap: (_) {},
+      ),
+    );
+
+    expect(find.text('assets/logo.png'), findsOneWidget);
+    expect(find.byType(GbmBadge), findsNothing);
+  });
+
+  testWidgets('a long path and both badges fit the real 186px column', (
+    tester,
+  ) async {
+    // Non-null by construction: splitterMainFiles is a
+    // GbmSplitterSpec.extent, whose defaultExtent is always set.
+    final double columnWidth = GbmLayout.splitterMainFiles.defaultExtent!;
+    // GbmLayout.splitterMainFiles' own default width, not a canvas this test
+    // picked. The badges are non-flex children, so RenderFlex lays them out
+    // first and divides what is left among the Expanded path -- a placement
+    // that overflows here would be invisible at the 800px default canvas,
+    // which is the shape CLAUDE.md records the column-picker popover
+    // shipping off-screen for.
+    await pumpGbmWidget(
+      tester,
+      child: SizedBox(
+        width: columnWidth,
+        child: ChangedFilesPanelCore(
+          hasSelectedCommit: true,
+          files: <ChangedFile>[
+            _file(
+              'lib/features/history_graph/widgets/changed_files_panel.dart',
+              addedLines: 1234,
+              removedLines: 5678,
+            ),
+          ],
+          selectedPath: null,
+          onFileTap: (_) {},
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    // Not just "no exception": Expanded satisfies that while collapsing its
+    // child to zero width, so the badges have to be shown to be on screen.
+    expect(find.text('+1234'), findsOneWidget);
+    expect(find.text('-5678'), findsOneWidget);
+    for (final String label in <String>['+1234', '-5678']) {
+      final Rect rect = tester.getRect(find.text(label));
+      expect(rect.width, greaterThan(0));
+      expect(rect.right, lessThanOrEqualTo(columnWidth));
+    }
   });
 
   testWidgets('tapping a file invokes onFileTap with its path', (tester) async {

--- a/app_flutter/test/integration/history_commit_file_menu_test.dart
+++ b/app_flutter/test/integration/history_commit_file_menu_test.dart
@@ -49,6 +49,11 @@ ChangedFile _file(String path) => ChangedFile(
   oldBlob: 'aaa',
   newBlob: 'bbb',
   similarity: 0,
+  // 0/0 draws no badge, so these rows render exactly as they did before
+  // spec P02-10's line counts existed -- this file is about something
+  // else and should not start depending on them.
+  addedLines: 0,
+  removedLines: 0,
 );
 
 /// Records launch attempts instead of spawning anything, mirroring

--- a/app_flutter/test/integration/workspace_file_list_view_mode_test.dart
+++ b/app_flutter/test/integration/workspace_file_list_view_mode_test.dart
@@ -39,6 +39,11 @@ ChangedFile _file(String path) => ChangedFile(
   oldBlob: 'aaa',
   newBlob: 'bbb',
   similarity: 0,
+  // 0/0 draws no badge, so these rows render exactly as they did before
+  // spec P02-10's line counts existed -- this file is about something
+  // else and should not start depending on them.
+  addedLines: 0,
+  removedLines: 0,
 );
 
 void main() {

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -2579,3 +2579,135 @@ One trap worth carrying: **`Picture.toImage()` inside `testWidgets` hangs
 forever without `tester.runAsync()`**, with no output and no timeout of its
 own — the first attempt was killed at eight minutes having printed nothing.
 flutter_test's fake-async zone never completes it.
+
+### Changed files line counts (feat/changed-files-line-counts)
+
+Spec P02 item 10's mockup draws each Changed files row as `檔名 + 綠色 +12
+badge`. The panel drew only the檔名. This round carried added/removed line
+counts from git to that badge, through all four layers.
+
+#### The gap was already written down — as the reason for a *different* cut
+
+`commit_selection_summary.dart` explains why P13's status-bar 合計 diff was cut:
+
+> **Reduced deliberately: no 合計 diff.** … `ChangedFile` carries no
+> added/removed line counts, and the only path in the core that runs
+> `--numstat` is `CompareOps.cpp`'s range diff — so a running total would mean
+> firing a range diff on every selection change.
+
+That was accurate about the cause and it named the fix, but the *other* feature
+sitting on the same missing field — P02-10's badge, which needs no running
+total and no range diff, only the counts for one commit — was never filed. The
+note is now corrected in place to say the field exists; the 合計 diff stays
+absent for its own separate reason (it would still have to sum across a
+selection). **A reduction note names one victim of a missing capability; it is
+not a survey of them.** Grep for other readers of the thing being called absent
+before assuming the note covers the whole blast radius.
+
+#### `--raw` and `--numstat` cannot be the same invocation
+
+git's diff-options output-format is a single slot, so `diff-tree --raw
+--numstat` silently honours one of them. `CompareOps.cpp`'s `readFiles()`
+already worked around this for the Compare tab by running two commands and
+joining by path; `DiffService::attachLineCounts()` is the same shape for
+`changedFiles()`. What that costs and what pays for it:
+
+- The numstat pass makes git actually compute the diff, so `changedFiles()` is
+  no longer as close to free as `diff-tree --raw` alone. `ChangedFile`'s own
+  「Cheap: no content is read, so clicking through commits stays instant」
+  comment was rewritten rather than left standing — **a comment asserting a
+  performance property is a claim, and the round that invalidates it owns it.**
+- The join happens *before* `fileListCache_.put()`, so a cached list is never
+  one missing its badges, and clicking back to a visited commit re-runs
+  nothing.
+
+#### Every flag on the raw call had to be repeated, and each one fails silently
+
+This is the whole risk of the change, and all three failure modes look
+identical on screen — a file listed with no badge, no error anywhere:
+
+| Missing flag | What numstat returns | Which commits lose their badge |
+|---|---|---|
+| `--root` | nothing | the first commit of every repository |
+| `--diff-merges=first-parent` | nothing | every merge |
+| matching `rawRenameFlag()` | a different path set | renames, which then join to nothing |
+
+Each is pinned by a test that fails *alone* under that mutation:
+`ReportsLineCountsForARootCommit`, the line-count assertion added to
+`ReportsAMergeCommitAgainstItsFirstParent`, and
+`JoinsLineCountsOntoARenamedFileByItsNewPath`. Measured, not reasoned about —
+each flag was removed in turn and the red confirmed narrow.
+
+#### `-z` numstat spends three records on a rename
+
+Every other change kind is one record (`added\tremoved\tpath`). A rename is
+`added\tremoved\t` with an **empty** path field, then the old path, then the
+new path. A loop that assumes one record per entry reads the old path as the
+next entry's counts and every count after that point is wrong — not missing,
+*wrong*, which is worse. Mutation-checked by collapsing the three-step to two:
+only the rename test went red.
+
+#### The join key is `path`, and the reason is narrower than it first looks
+
+The implementation comment first claimed a join on `oldPath` would break
+deletes. Mutating the key to `oldPath` proved otherwise: `parseRawRecords()`
+leaves `oldPath` **empty** for everything except renames and copies, so such a
+join breaks nearly everything and the delete case is not special at all. Both
+the comment and the test's rationale were corrected to the true reason —
+`path` is the only field populated for every kind. **A mutation that fails to
+land where the comment predicted is the comment being wrong, not the mutation.**
+
+#### Binary reads 0/0 and no `binary` flag was added
+
+numstat prints `-` for a binary blob. `std::from_chars` leaves its output
+untouched on a non-numeric field, so a missing check produces 0/0 *by
+accident*; the guard is explicit anyway so a later reader cannot mistake the
+zero for a measurement. A `ChangedFile::binary` field was deliberately **not**
+added: no UI would have read it, which is exactly the orphan-wiring shape this
+repo has shipped at least five times (**#102**).
+
+#### The 186px test is the only one that could see the layout bug
+
+Four widget tests cover the badge. Removing the `Expanded` around the path
+`Text` — a real overflow at the column's true width — was caught by **only**
+the test that sizes itself to `GbmLayout.splitterMainFiles.defaultExtent`.
+The other three, on the default 800×600 canvas, passed with the broken layout.
+Same mechanism as the column-picker popover that shipped off-screen.
+
+#### Deliberately not done
+
+- **No file icon.** P02-10's mockup row is `icFile + 檔名 + badge`; only the
+  badge was added. Compare's file rows are also icon-less, and matching the
+  shipped precedent beat matching the illustration. Recorded here so the next
+  conformance audit reads it as a decision rather than filing it as a bug.
+- **Working Copy (P03) still has no counts.** Its `+34` comes from
+  `StatusService`/`WorkingCopyEntry`, an entirely separate data path needing
+  its own numstat runs against index and worktree. Out of this round's scope
+  by explicit decision, not oversight.
+
+#### Smaller things
+
+- `JsonCodec.cpp` has **two** serializers emitting `addedLines` — `DiffFile`'s
+  (pre-existing, for Compare) and `ChangedFile`'s (new). A mutation script
+  anchored on the field name alone matched both and the `count(old) == 1`
+  guard caught it. That guard earns its keep; the anchor had to include the
+  neighbouring `similarity` line to be unique.
+- The Dart fields are `required` with no default. Five fixtures broke and were
+  updated by hand, which is the point: a default of 0 would have made every
+  one of them silently assert "no badge".
+- `model_parsing_test.dart`'s ChangedFile case is named 「decodes every field」
+  and did not decode the new two. A test whose name is a completeness claim
+  has to be revisited whenever the shape it covers grows.
+- **The commit that made those fields `required` was red on its own**, and the
+  full-suite run that would have shown it happened one commit later. Commit 3
+  shipped the model plus five of the six fixture sites; the sixth,
+  `model_parsing_test.dart`, was filed with commit 4 because that is where its
+  *assertions* belonged. But `fromJson` reads `json['addedLines'] as int`, so a
+  fixture without the key is `null as int` — checking out commit 3 alone fails
+  two tests. Caught by review, not by any run, because every run was at the
+  branch tip. Commits 3–6 were rewritten to move the file (the resulting tree
+  is byte-identical: `git diff` against a backup branch was empty), and each of
+  3 and 4 was then checked out detached and verified green — 1930 and 1934
+  tests respectively. **Rule**: a commit that adds a `required` field to a
+  model must carry every fixture that constructs *or feeds* it, including raw
+  JSON fixtures, which grep for the constructor name will not find.

--- a/src/capi/JsonCodec.cpp
+++ b/src/capi/JsonCodec.cpp
@@ -469,6 +469,10 @@ std::string toJson(const ChangedFile& file) {
     jsonAppendEscaped(out, file.newBlob);
     out += ",\"similarity\":";
     jsonAppendInt(out, file.similarity);
+    out += ",\"addedLines\":";
+    jsonAppendInt(out, file.addedLines);
+    out += ",\"removedLines\":";
+    jsonAppendInt(out, file.removedLines);
     out += '}';
     return out;
 }

--- a/src/core/git/DiffService.cpp
+++ b/src/core/git/DiffService.cpp
@@ -2,6 +2,8 @@
 
 #include "core/base/ThreadCheck.h"
 
+#include <charconv>
+#include <unordered_map>
 #include <utility>
 
 namespace gbm {
@@ -200,6 +202,109 @@ LineSink collectFields(std::vector<std::string>& records) {
     };
 }
 
+/// Joins `diff-tree --numstat` line counts onto an already-parsed `--raw`
+/// list, keyed by path.
+///
+/// Two invocations rather than one because git's diff-options output-format
+/// field is a single slot: `--raw` and `--numstat` cannot both take effect in
+/// the same command. `CompareOps.cpp`'s readFiles() works around the same
+/// constraint for the Compare tab, and the record shapes below match its
+/// parser deliberately.
+///
+/// Every flag the raw call passes is repeated here. They are not decorative:
+/// without `--root` a parentless commit numstats to nothing, without
+/// `--diff-merges=first-parent` a *merge* numstats to nothing, and with a
+/// different rename flag the two outputs disagree about which paths exist --
+/// each of which shows up as a file listed with no badge rather than as an
+/// error.
+GitResult<void> attachLineCounts(IProcessRunner& runner,
+                                 const RepoPaths& paths,
+                                 const ObjectId& commit,
+                                 const DiffOptions& options,
+                                 std::vector<ChangedFile>& files,
+                                 CancellationToken token) {
+    if (files.empty()) {
+        return {};
+    }
+
+    std::vector<std::string> args{"diff-tree", "-r", "--numstat", "-z", "--no-commit-id", "--root"};
+    args.emplace_back(rawRenameFlag(options));
+    if (options.firstParentOnly) {
+        args.emplace_back("--diff-merges=first-parent");
+    }
+    args.push_back(commit.hex());
+
+    GitCommand command(paths.commandDir(), std::move(args));
+    command.timeout = std::chrono::seconds(120);
+
+    std::vector<std::string> records;
+    auto result = runner.streamSeparated(
+        command, IProcessRunner::Separator::Nul, collectFields(records), nullptr, token);
+    if (!result) {
+        return fail(std::move(result).error());
+    }
+
+    // Keyed on `path` because it is the one field parseRawRecords() fills for
+    // every change kind: the new path for a rename or copy, and the single
+    // path for everything else including a delete. (`oldPath` is empty unless
+    // the kind has two paths, so it cannot serve as the key.) numstat prints
+    // that same path in each case, which is what makes the join total.
+    std::unordered_map<std::string_view, ChangedFile*> byPath;
+    byPath.reserve(files.size());
+    for (ChangedFile& file : files) {
+        byPath.emplace(file.path, &file);
+    }
+
+    for (std::size_t i = 0; i < records.size();) {
+        const std::string_view record = records[i++];
+        const std::size_t firstTab = record.find('\t');
+        if (firstTab == std::string_view::npos) {
+            continue;
+        }
+        const std::size_t secondTab = record.find('\t', firstTab + 1);
+        if (secondTab == std::string_view::npos) {
+            continue;
+        }
+        const std::string_view addedField = record.substr(0, firstTab);
+        const std::string_view removedField = record.substr(firstTab + 1, secondTab - firstTab - 1);
+        std::string_view pathField = record.substr(secondTab + 1);
+
+        if (pathField.empty()) {
+            // Rename or copy: under -z the path field is empty and the next
+            // two records are the old and the new path. Only the new one is
+            // needed -- it is what byPath is keyed on -- but both must be
+            // consumed or the loop reads the old path as the next entry's
+            // counts and every count after this point is wrong.
+            if (i < records.size()) {
+                ++i;  // old path, unused
+            }
+            if (i >= records.size()) {
+                break;
+            }
+            pathField = records[i++];
+        }
+
+        const auto found = byPath.find(pathField);
+        if (found == byPath.end()) {
+            continue;
+        }
+        // "-" for either field means a binary blob. Left at 0 rather than
+        // parsed: std::from_chars would leave the value untouched anyway, but
+        // saying so here is what stops a later reader treating 0 as measured.
+        if (addedField == "-" || removedField == "-") {
+            continue;
+        }
+        std::uint32_t added = 0;
+        std::uint32_t removed = 0;
+        std::from_chars(addedField.data(), addedField.data() + addedField.size(), added);
+        std::from_chars(removedField.data(), removedField.data() + removedField.size(), removed);
+        found->second->addedLines = added;
+        found->second->removedLines = removed;
+    }
+
+    return {};
+}
+
 }  // namespace
 
 GitResult<DiffService::ChangedFilesPtr> DiffService::changedFiles(const ObjectId& commit,
@@ -234,6 +339,14 @@ GitResult<DiffService::ChangedFilesPtr> DiffService::changedFiles(const ObjectId
 
     auto files =
         std::make_shared<std::vector<ChangedFile>>(parseRawRecords(records, 0, records.size()));
+
+    // Before the cache write, so a cached list is never one that is missing
+    // its badges. A numstat failure fails the whole call rather than
+    // returning a half-filled list -- the panel would otherwise render every
+    // row as "0 lines changed" with nothing anywhere saying why.
+    if (auto counts = attachLineCounts(runner_, paths_, commit, options, *files, token); !counts) {
+        return fail(std::move(counts).error());
+    }
 
     fileListCache_.put(cacheKey, files, estimateBytes(*files));
     return ChangedFilesPtr(files);

--- a/src/core/git/DiffService.h
+++ b/src/core/git/DiffService.h
@@ -18,8 +18,13 @@
 
 namespace gbm {
 
-/// One entry in a commit's changed-file list, from `diff-tree --raw`. Cheap: no
-/// content is read, so clicking through commits stays instant.
+/// One entry in a commit's changed-file list, from `diff-tree --raw` plus a
+/// second `diff-tree --numstat` pass for the line counts.
+///
+/// No file *content* is read either way -- both are summaries -- but the
+/// numstat pass does make git compute the diff, so this is no longer as close
+/// to free as the raw pass alone was. `fileListCache_` covers the repeat cost
+/// of clicking back to a commit already visited.
 struct ChangedFile {
     std::string path;
     std::string oldPath;  ///< Set for renames and copies.
@@ -29,6 +34,12 @@ struct ChangedFile {
     std::string oldBlob;
     std::string newBlob;
     int similarity = 0;
+
+    /// Spec page 02 item 10's "+12" badge. Both stay 0 for a binary blob,
+    /// which numstat reports as "-" rather than a number -- no badge is the
+    /// honest rendering for something that has no lines.
+    std::uint32_t addedLines = 0;
+    std::uint32_t removedLines = 0;
 };
 
 /// How many files one commit changed. The Changed files column's whole

--- a/tests/capi/CommitFilesApiTest.cpp
+++ b/tests/capi/CommitFilesApiTest.cpp
@@ -135,6 +135,39 @@ TEST_F(CommitFilesApiTest, RequestCommitFilesReturnsAddedFile) {
     EXPECT_NE(payload.find("\"files\":["), std::string::npos) << payload;
     EXPECT_NE(payload.find("\"path\":\"file.txt\""), std::string::npos) << payload;
     EXPECT_NE(payload.find("\"kind\":1"), std::string::npos) << payload;  // FileChangeKind::Added = 1
+
+    // Spec page 02 item 10's badge reads these two. file.txt is one line, so
+    // an added file is +1/-0; a JSON writer that emitted the pair in the
+    // wrong order would produce 0/1 and fail here.
+    EXPECT_NE(payload.find("\"addedLines\":1"), std::string::npos) << payload;
+    EXPECT_NE(payload.find("\"removedLines\":0"), std::string::npos) << payload;
+}
+
+TEST_F(CommitFilesApiTest, RequestCommitFilesReportsAsymmetricLineCounts) {
+    // The +1/-0 above cannot tell a real count from a constant, and its two
+    // numbers are 1 and 0 -- which also appear in this payload as "kind" and
+    // "similarity". A second commit with counts that are non-zero, unequal,
+    // and not otherwise present in the JSON is what makes the assertion mean
+    // "the numstat join survived the capi boundary".
+    std::ofstream(repo_ / "file.txt", std::ios::trunc) << "a\nb\nc\nd\n";
+    ASSERT_EQ(runGit({"add", "file.txt"}), 0);
+    ASSERT_EQ(runGit({"commit", "--quiet", "-m", "rewrite file"}), 0);
+    const std::string oid = revParseHead();
+    ASSERT_FALSE(oid.empty());
+
+    gbm_request_commit_files(session_, oid.c_str());
+
+    ASSERT_TRUE(log_.waitFor([](const auto& events) {
+        for (const auto& [type, payload] : events) {
+            if (type == GBM_EVENT_COMMIT_FILES_READY) return true;
+        }
+        return false;
+    }));
+
+    const std::string payload = log_.lastPayloadOfType(GBM_EVENT_COMMIT_FILES_READY);
+    EXPECT_NE(payload.find("\"path\":\"file.txt\""), std::string::npos) << payload;
+    EXPECT_NE(payload.find("\"addedLines\":4"), std::string::npos) << payload;
+    EXPECT_NE(payload.find("\"removedLines\":1"), std::string::npos) << payload;
 }
 
 TEST_F(CommitFilesApiTest, RequestCommitFileDiffReturnsFileDiff) {

--- a/tests/unit/GitIntegrationTest.cpp
+++ b/tests/unit/GitIntegrationTest.cpp
@@ -123,6 +123,15 @@ protected:
     /// `name` is UTF-8, matching how the rest of the codebase treats a path in a
     /// std::string -- ProcessRunner widens argv with CP_UTF8, so this is the same
     /// name git will be given.
+    /// Writes a file without staging or committing it, for the tests that
+    /// need several kinds of change in one commit. Same char8_t construction
+    /// as commitFile() below, and for the same reason.
+    void writeFile(const std::string& name, const std::string& contents) {
+        const std::u8string utf8(reinterpret_cast<const char8_t*>(name.data()), name.size());
+        std::ofstream out(repo_ / std::filesystem::path(utf8), std::ios::binary | std::ios::trunc);
+        out << contents;
+    }
+
     void commitFile(const std::string& name,
                     const std::string& contents,
                     const std::string& message) {
@@ -565,6 +574,134 @@ TEST_F(RealRepoTest, HandlesAddedAndDeletedFilesInDiffs) {
     EXPECT_EQ((*files)->at(0).path, "gone.txt");
 }
 
+// ---------------------------------------------------------------------------
+// Spec page 02 item 10: the Changed files panel draws a "+12" badge per row,
+// so `changedFiles()` has to carry line counts. `diff-tree --raw` cannot --
+// raw records hold modes, blobs and a status letter and nothing else -- so a
+// second `--numstat` invocation is joined onto the list by path. These four
+// tests pin the join rather than the arithmetic: each case is one where a
+// dropped flag or a mis-stepped record still produces a plausible-looking
+// file list, so only the counts can tell the difference.
+// ---------------------------------------------------------------------------
+
+TEST_F(RealRepoTest, ReportsAddedAndRemovedLineCountsPerChangedFile) {
+    commitFile("mod.txt", "a\nb\nc\n", "c1");
+    commitFile("gone.txt", "1\n2\n", "c2");
+
+    // One commit touching all three change kinds at once, because each fills
+    // the counts from a different direction and a join can be right about one
+    // while wrong about another. The delete is the one worth spelling out:
+    // numstat reports it as "0\t2\tgone.txt", so the row that carries the
+    // *only* interesting number carries it on the removed side. A join that
+    // silently dropped deletes would leave 0/0 there -- which reads exactly
+    // like a file whose lines did not change, and draws no badge either way.
+    writeFile("mod.txt", "a\nB\nc\n");
+    writeFile("new.txt", "x\ny\n");
+    ASSERT_TRUE(run({"rm", "--quiet", "gone.txt"}));
+    ASSERT_TRUE(run({"add", "-A"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "touch all three kinds"}));
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+
+    DiffService diffs(*runner_, paths_);
+    auto files =
+        diffs.changedFiles(ObjectId::fromHex(head->out), DiffOptions{}, CancellationToken{});
+    ASSERT_TRUE(files) << files.error().message;
+    ASSERT_EQ((*files)->size(), 3u);
+
+    std::map<std::string, const ChangedFile*> byPath;
+    for (const ChangedFile& file : **files) {
+        byPath[file.path] = &file;
+    }
+    ASSERT_EQ(byPath.count("mod.txt"), 1u);
+    ASSERT_EQ(byPath.count("new.txt"), 1u);
+    ASSERT_EQ(byPath.count("gone.txt"), 1u);
+
+    // A one-line edit is +1/-1, not +1/-0. Asserting both halves is what
+    // separates a real join from a list whose counts all defaulted to zero
+    // on one side.
+    EXPECT_EQ(byPath["mod.txt"]->addedLines, 1u);
+    EXPECT_EQ(byPath["mod.txt"]->removedLines, 1u);
+
+    EXPECT_EQ(byPath["new.txt"]->addedLines, 2u);
+    EXPECT_EQ(byPath["new.txt"]->removedLines, 0u);
+
+    EXPECT_EQ(byPath["gone.txt"]->addedLines, 0u);
+    EXPECT_EQ(byPath["gone.txt"]->removedLines, 2u);
+}
+
+TEST_F(RealRepoTest, ReportsLineCountsForARootCommit) {
+    // --root, for the same reason changedFiles()' raw call passes it: without
+    // the flag diff-tree prints nothing at all for a parentless commit, so
+    // the counts would come back 0 beside a file list that is not empty --
+    // the badge silently vanishing on exactly one commit per repository.
+    commitFile("first.txt", "1\n2\n3\n", "root");
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+
+    DiffService diffs(*runner_, paths_);
+    auto files =
+        diffs.changedFiles(ObjectId::fromHex(head->out), DiffOptions{}, CancellationToken{});
+    ASSERT_TRUE(files) << files.error().message;
+    ASSERT_EQ((*files)->size(), 1u);
+    EXPECT_EQ((*files)->at(0).path, "first.txt");
+    EXPECT_EQ((*files)->at(0).addedLines, 3u);
+    EXPECT_EQ((*files)->at(0).removedLines, 0u);
+}
+
+TEST_F(RealRepoTest, JoinsLineCountsOntoARenamedFileByItsNewPath) {
+    // The record shape that breaks a naive parser. Under -z, numstat prints a
+    // rename as *three* NUL records -- "added\tremoved\t" with an empty path
+    // field, then the old path, then the new path -- where every other kind
+    // is one record. A loop that assumes one record per file reads the old
+    // path as the next entry's counts, and everything after this point in the
+    // output is wrong. Five lines with one edited leaves similarity at 80%,
+    // comfortably inside --find-renames' default threshold.
+    commitFile("old.txt", "l1\nl2\nl3\nl4\nl5\n", "c1");
+
+    ASSERT_TRUE(run({"mv", "old.txt", "new.txt"}));
+    writeFile("new.txt", "l1\nEDITED\nl3\nl4\nl5\n");
+    ASSERT_TRUE(run({"add", "new.txt"}));
+    ASSERT_TRUE(run({"commit", "--quiet", "-m", "rename and edit"}));
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+
+    DiffService diffs(*runner_, paths_);
+    auto files =
+        diffs.changedFiles(ObjectId::fromHex(head->out), DiffOptions{}, CancellationToken{});
+    ASSERT_TRUE(files) << files.error().message;
+    ASSERT_EQ((*files)->size(), 1u);
+    EXPECT_EQ((*files)->at(0).kind, FileChangeKind::Renamed);
+    EXPECT_EQ((*files)->at(0).oldPath, "old.txt");
+    EXPECT_EQ((*files)->at(0).path, "new.txt");
+    EXPECT_EQ((*files)->at(0).addedLines, 1u);
+    EXPECT_EQ((*files)->at(0).removedLines, 1u);
+}
+
+TEST_F(RealRepoTest, ReportsZeroLineCountsForABinaryFile) {
+    // numstat writes "-\t-\t<path>" for a binary blob. std::from_chars leaves
+    // its output untouched on a non-numeric field rather than erroring, so a
+    // missing binary check produces 0/0 by accident and looks correct here;
+    // what this pins is that the file is still *listed* while both counts
+    // read 0. No badge is the honest rendering for a blob that has no lines.
+    commitFile("bin.dat", std::string("\x00\x01\x02\x03", 4), "add binary");
+
+    auto head = run({"rev-parse", "HEAD"});
+    ASSERT_TRUE(head);
+
+    DiffService diffs(*runner_, paths_);
+    auto files =
+        diffs.changedFiles(ObjectId::fromHex(head->out), DiffOptions{}, CancellationToken{});
+    ASSERT_TRUE(files) << files.error().message;
+    ASSERT_EQ((*files)->size(), 1u);
+    EXPECT_EQ((*files)->at(0).path, "bin.dat");
+    EXPECT_EQ((*files)->at(0).addedLines, 0u);
+    EXPECT_EQ((*files)->at(0).removedLines, 0u);
+}
+
 TEST_F(RealRepoTest, ReportsAMergeCommitAgainstItsFirstParent) {
     // `diff-tree` prints nothing at all for a merge unless told which parent
     // to diff against, so before --diff-merges=first-parent this whole test
@@ -613,6 +750,14 @@ TEST_F(RealRepoTest, ReportsAMergeCommitAgainstItsFirstParent) {
     ASSERT_EQ((*files)->size(), 1u) << "a merge must diff against its first parent only";
     EXPECT_EQ((*files)->at(0).path, "side.txt");
     EXPECT_EQ((*files)->at(0).kind, FileChangeKind::Added);
+
+    // The line counts have to survive the same flag. `--numstat` is a second
+    // diff-tree invocation, and it needs --diff-merges=first-parent just as
+    // much as the raw one does -- without it numstat prints nothing for a
+    // merge, so the panel would list side.txt with no badge beside it while
+    // every non-merge commit showed one.
+    EXPECT_EQ((*files)->at(0).addedLines, 1u);
+    EXPECT_EQ((*files)->at(0).removedLines, 0u);
 
     // The other half. Listing the files while every one of them opens an
     // empty diff would be worse than honestly reporting nothing, so the list


### PR DESCRIPTION
規格第 02 頁標號 **10「Changed files」** 的 mockup，每一列是 `檔名 + 綠色 +12 badge`：

```
LaneAllocator.h        [+12]
GraphBuilderTest.cpp   [+40]
```

實際上 `changed_files_panel.dart` 的每一列只有一個 `Text(file.path)`。缺口在最底層：`ChangedFile` 這個型別**從 C++ 到 Dart 一路都沒有行數欄位**，因為 `DiffService::changedFiles()` 走的是 `git diff-tree --raw`，raw 格式只有 mode/blob/status。

## 這個缺口早就被寫下來過，但被記成了另一件事的理由

`commit_selection_summary.dart` 的註解明講「Reduced deliberately: no 合計 diff⋯`ChangedFile` carries no added/removed line counts」——P13 的狀態列合計 diff 是**為了這個缺口被砍掉的**，而 P02-10 的 badge 則從來沒人發現它是同一個缺口的受害者。這正是 CLAUDE.md「Nothing is silently dropped」條目沒有涵蓋到的形狀：**一份 reduction note 只點名了一個受害者，不是全部**。這條已經補進 CLAUDE.md。

同一個 badge **Compare 分頁早就有了**（資料來自 `CompareOps.cpp` 的 `git diff --numstat`）。所以這次不是發明新做法，是把既有那條路徑接到 History，並刻意沿用同一個 `GbmBadge` 造型——History 與 Compare 不能對同一個檔案的大小有兩種說法。

## 核心：git 的 diff 輸出格式是單一槽位

`--raw` 與 `--numstat` **不可能在同一次 invocation 同時生效**。所以 `changedFiles()` 現在跑兩次 `diff-tree`，依 path join（`DiffService::attachLineCounts()`），與 `CompareOps.cpp` 的 `readFiles()` 同一個形狀。

第二次呼叫**必須逐字重複第一次的每一個旗標**，而且三種漏法各自都是靜默的：

| 漏掉 | 後果 |
|---|---|
| `--root` | 第一筆 commit 完全沒有行數 |
| `--diff-merges=first-parent` | 每一個 merge commit 完全沒有行數 |
| `rawRenameFlag()` | 兩次輸出對 rename 的認定不同，join 不到 |

三種都是「該列有檔名、沒有 badge、任何地方都沒有錯誤訊息」。測試矩陣針對前兩者各有一個案例。

**`-z` 之下 numstat 對 rename 花三筆 record**（空的 path 欄、舊路徑、新路徑），其餘每種 kind 只花一筆——一筆一圈的迴圈會讓第一個 rename 之後的每個計數都錯位。

**join key 是 `path`，理由比第一眼窄**：它是 `parseRawRecords()` 對**每一種** kind 都會填的唯一欄位。`oldPath` 只有 rename 與 copy 才有值，所以當不了 key。這一點是被 mutation 打臉才確定的——見下。

**binary 讀 0/0，而且沒有加 `binary` 欄位**。numstat 對 binary 印的是 `-` 而不是數字，不能餵給 `from_chars`。刻意不加 `ChangedFile::binary`：UI 沒有任何消費者，會直接變成 CLAUDE.md 記載的「orphan wiring」缺陷形狀（已出貨至少五次，#102）。

## 唯一看得見版面缺陷的測試是 186px 那一個

`_buildFileRow()` 的 child 從單一 `Text` 變成 `Row`，檔名走 `Expanded`，badge 是非 flex child。`RenderFlex` 先配置非 flex child 再分剩下的，所以拿掉 `Expanded` 就會 overflow——但**只有用 `GbmLayout.splitterMainFiles` 真實 186px 欄寬的那一個測試會紅**，另外三個跑在預設 800×600 畫布上的全部照樣過。這正是 CLAUDE.md 那條「預設畫布比真實視窗大，版面缺陷對它是隱形的」的又一個實例。

## 一次 mutation 推翻了我自己寫的註解

把 join key 改成 `oldPath` 本來預期會弄壞**刪除檔**的案例，結果只弄壞了 **rename**——因為 `oldPath` 對 rename/copy 以外的每一種 kind 都是空的。**mutation 沒有紅在註解預測的地方，代表註解是錯的**，不是 mutation 錯了。實作註解與測試的 rationale 兩邊都已改成真正的理由。

## 收尾複查抓到的 commit 結構問題（已修）

原本的 commit 3 **單獨 checkout 是紅的**，違反本 repo「每個 commit 自己是綠的」的要求。commit 3 把兩個欄位設成 `required`，但 `model_parsing_test.dart` 的兩份 raw JSON fixture 被歸到 commit 4（因為斷言屬於那裡）。`fromJson` 讀 `json['addedLines'] as int`，缺 key 就是 `null` 轉 `int`。所有驗證都跑在分支頂端，所以沒有任何一次 run 看得到。

已改寫 commit 3–6 把該檔案搬進 commit 3。**最終樹 byte-identical**（對備份分支 `git diff` 為空），commit 3 與 commit 4 各自 detached checkout 驗證為綠（1930 / 1934 tests）。

規則已寫進 CLAUDE.md：新增 `required` 欄位的 commit 必須帶上**建構或餵給**它的每一份 fixture——raw JSON fixture 用 grep 建構子名稱是找不到的。

## 兩個刻意的取捨，可以推翻

1. **沒有加檔案圖示。** P02-10 的 mockup 是 `icFile + 檔名 + badge`，這次只補 badge。理由是 Compare 分頁的檔案列同樣只有檔名加 badge，跟著既有先例走比跟著單張 mockup 走安全（CLAUDE.md：「A mockup shows what the user sees, not who draws it」）。這個省略已寫進 ledger，避免下一次規格稽核把它當 bug 開單。

2. **P03 Working Copy 的 `+34` 不在範圍內。** 它走 `StatusService` / `WorkingCopyEntry` 一條完全不同的資料路徑，與這次的 `ChangedFile` 沒有共用。

## 效能

`ChangedFile` 原本的註解寫「Cheap: no content is read, so clicking through commits stays instant」。多跑一次 numstat 之後這句不再為真——numstat 會讓 git 真的算 diff。註解已改寫成誠實的版本（兩次都是 summary、都不讀檔案內容，但 numstat 這一次不再接近免費；`fileListCache_` 覆蓋重複點選的成本）。CLAUDE.md 也補了對應條目：**宣稱效能性質的註解，在它上游的東西動過之後必須重測**。

## 驗證

- [x] `ctest --preset capi-only` — **566/566**
- [x] `flutter test` — **1934 pass**
- [x] `flutter analyze` — 零 issue（CI 沒有容忍旗標）
- [x] `dart format --set-exit-if-changed` — 414 檔 0 changed
- [x] `scripts/format-check.sh` — 176 檔 clang-format v18 clean
- [x] 每個新測試都做過 mutation check，且確認紅得**窄**
- [x] commit 3 / commit 4 各自 detached checkout 驗證為綠
- [x] device tier 9 個檔案跑了 8 個，各自單獨 `-d macos`，全綠

### 兩點沒有覆蓋到的

- **`integration_test/update_check_flow_test.dart` 沒跑**：需要網路、會打真實 GitHub Releases API 並下載約 24MB asset，與本 diff 無關。
- **`flutter build linux --debug` 本機重現不了**，是 PR CI 唯一沒能在本機覆蓋的 gate。
