### PR TITLE
視窗回焦點與 F5 重讀整份本地 git 狀態

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ five elements went, so a future round does not re-add them:
 | Back-to-welcome | `File → Close window` — its handler was already `go(welcome)` |
 | Theme switch | `View → Theme` |
 | In-progress spinner | Status bar's background-task zone |
-| `Refresh` | **`View → Refresh` + bare F5**, a deliberate deviation (P04's `MENUS` has no such item) — `refreshRepoHistory()` had exactly one caller in all of `lib/` and it was `TopBar` |
+| `Refresh` | **`View → Refresh` + bare F5**, a deliberate deviation (P04's `MENUS` has no such item). It now dispatches `refreshRepoStatus()`, not just the history — see "Refs, git and the core's own vocabulary" below. The `refreshRepoHistory()` free function this once named is deleted; it had no caller left |
 
 Repo state (`RepoState::describe()`) is also on the status bar now — it was
 *not* there before, despite a note claiming so: `describe()` is non-empty for
@@ -1120,13 +1120,42 @@ you are touching, not by when it was learned.
   N-element allocation per scroll tick. Do not assume the result is mutable
   or materialised. `_buildList` likewise hands back `graph.oidsHex` itself
   rather than copying it when nothing is filtered.
-- **The window now refreshes on focus regain** — `WorkspaceScreen`'s
-  `AppLifecycleListener.onResume` calls `refreshRepoHistory()` +
-  `refreshWorkingCopy()`, throttled by `kFocusRefreshThrottle` (2s). The
-  throttle clock is a `Timer`, not `DateTime.now()`, because only the former
-  is advanced by `tester.pump()`. **Not verified on real hardware**: the
-  tests drive `handleAppLifecycleStateChanged` directly, which proves the
-  wiring but not that macOS emits inactive/resumed on window focus changes.
+- **`RepoSessionController.refreshRepoStatus()` is the one entry point for
+  "re-read the git status", and its membership is a rule, not a list: every
+  zero-argument `refresh*` on the controller** (twelve of them). Both
+  `WorkspaceScreen`'s `AppLifecycleListener.onResume` and
+  `GbmActionId.viewRefresh` (F5 / `View → Refresh`) call it, so the two
+  cannot drift into refreshing different things — F5 used to re-read only
+  the history, leaving the Working Copy badge and diff stale on the one path
+  where the user explicitly *asked* for fresh state. The `request*` methods
+  are all excluded because they are keyed to a user selection that need not
+  exist when the window comes back. Focus regain is throttled by
+  `kFocusRefreshThrottle` (2s); F5 deliberately is not. The throttle clock is
+  a `Timer`, not `DateTime.now()`, because only the former is advanced by
+  `tester.pump()`. **Not verified on real hardware**: the tests drive
+  `handleAppLifecycleStateChanged` directly, which proves the wiring but not
+  that macOS emits inactive/resumed on window focus changes.
+  **`repoState` is the half of `conflictActive` that `refreshWorkingCopy()`
+  does not cover** — `_readRepoState()` had only two callers, session open
+  and `operationFinished`, so a rebase begun *or aborted* from a terminal
+  left the status bar, the banner and the twelve `isActionEnabled()` gates
+  frozen until the app itself ran an operation. `refreshRepoState()` is the
+  one synchronous member (`RepoState::read()` only stats a handful of `.git/`
+  paths), which is why the conflict badge corrects on the same frame.
+- **Never gate a refresh on a predicate that guesses what git would answer.**
+  `git submodule status` costs **79ms even with zero submodules**
+  (`git-submodule` is a POSIX shell script, so it is fork + shell startup,
+  not repository size) — 66% of everything `refreshRepoStatus()` added. Both
+  candidate short-circuits, «`.gitmodules` exists» and «the index holds a
+  gitlink», were rejected: each only approximates what the command would have
+  said, and a guess in core is the same mistake as a guess in Dart.
+  **`Session::refreshLfs()`'s short-circuit is not a counter-example** — its
+  condition is that `git-lfs` is not on PATH, which is not approximating an
+  answer, it is knowing the command cannot run. The cost was then measured to
+  be one nobody waits on (background pool, ≤ once per 2s, nothing on screen
+  blocked), so nothing is gated at all. Reading «this number is large» as
+  «this needs fixing» without first asking *who is waiting on it* is the
+  error being recorded here (ledger: fix/focus-refresh-repo-state).
 - **`RefInfo.upstream` is the full ref name** (`refs/remotes/origin/x`), from
   `%(upstream)` not `%(upstream:short)`. Splitting on the first slash yields
   `"refs"` — use `remoteBranchParts()`. `delete_branch_dialog.dart`'s

--- a/app_flutter/lib/data/repositories/history_repository.dart
+++ b/app_flutter/lib/data/repositories/history_repository.dart
@@ -25,10 +25,6 @@ final ProviderFamily<bool, RepoIdentity> repoIsRefreshingProvider =
       );
     });
 
-void refreshRepoHistory(WidgetRef ref, RepoIdentity identity) {
-  ref.read(repoSessionProvider(identity).notifier).refreshHistory();
-}
-
 /// Batch-fetched commit metadata (author/subject/date), keyed by oid -- see
 /// [RepoSessionState.commitMetaCache]. Populated by [requestCommitMeta].
 final ProviderFamily<Map<String, CommitMeta>, RepoIdentity> commitMetaProvider =

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -1716,6 +1716,62 @@ class RepoSessionController extends StateNotifier<RepoSessionState>
         : GitError.fromJson(jsonDecode(json) as Map<String, dynamic>);
   }
 
+  /// Everything about this repository that can move behind the app's back,
+  /// re-read in one call. The single source of truth for "refresh the git
+  /// status": both the focus-regain sweep and View -> Refresh call this, so
+  /// neither maintains its own list of what that means.
+  ///
+  /// Membership is a rule, not a hand-picked list: **every zero-argument
+  /// `refresh*` on this controller**. That makes "does the new one belong
+  /// here" a question with an answer rather than something rediscovered by
+  /// the next audit. The `request*` methods are all excluded because they
+  /// are keyed to a user selection (a path, an oid, a ref, a stash index)
+  /// that need not exist when the window comes back; the three with no
+  /// required argument are excluded for their own reasons --
+  /// [requestReflog] is fetched per tab by the panel itself,
+  /// [requestCleanPreview] walks the entire work tree to feed one dialog,
+  /// and [requestOriginalOperationMessage] only means anything mid-conflict.
+  ///
+  /// **Every one of these is a local read.** The one refresh-shaped call
+  /// that reaches the network -- [requestRemotePrunePreview], which backs
+  /// gone-marking -- is deliberately not here.
+  ///
+  /// No git-level judgement is made here either, such as "does this
+  /// repository have submodules". Any such predicate is a guess at what git
+  /// would have answered, and a guess in Dart is the same mistake as a guess
+  /// in core. `git submodule status` costs ~79ms even with zero submodules
+  /// (git-submodule is a POSIX shell script, so it is fork + shell startup,
+  /// not repository size) -- but it runs on the shared read pool with
+  /// nothing on screen waiting for it, so it runs unconditionally like the
+  /// rest. Measurements are in docs/ledger.md.
+  void refreshRepoStatus() {
+    // The synchronous one goes first: it publishes through copyWith rather
+    // than waiting on an event, so the conflict badge corrects on this very
+    // frame instead of after a git subprocess returns.
+    refreshRepoState();
+    refreshHistory();
+    refreshWorkingCopy();
+  }
+
+  /// Re-reads which multi-step git operation, if any, is part-way through.
+  ///
+  /// **Synchronous, unlike almost every other `refresh*` here**: the others
+  /// post to a background pool and fill [state] in later from a GBM event,
+  /// while gbm_repo_state_json() populates the staging buffer on this thread
+  /// and this method publishes immediately. It can afford to be: the C++
+  /// side is `RepoState::read(paths_)`, which stats a handful of paths
+  /// inside .git/ and spawns no subprocess, and it recomputes on every call
+  /// rather than caching.
+  ///
+  /// Worth having as a public entry point because [RepoSessionState.repoState]
+  /// is the half of [RepoSessionState.conflictActive] that
+  /// [refreshWorkingCopy] does not cover -- a rebase begun, continued or
+  /// aborted from a terminal changes .git/ and emits no GBM event at all.
+  void refreshRepoState() {
+    if (_session == nullptr) return;
+    _readRepoState();
+  }
+
   /// Requests a refs + history refresh -- see gbm_history_refresh()'s doc
   /// comment in gbm_capi.h. Async: [state] updates as GBM_EVENT_* events
   /// arrive through [_onEvent].
@@ -3555,6 +3611,17 @@ class RepoSessionController extends StateNotifier<RepoSessionState>
     _autoPrunePreviewsInFlight.clear();
     super.dispose();
   }
+}
+
+/// Re-reads every local git fact this app tracks for [identity].
+///
+/// The one entry point for "refresh the git status" -- see
+/// [RepoSessionController.refreshRepoStatus] for what that covers and why
+/// membership is a rule rather than a list. Both the focus-regain sweep in
+/// WorkspaceScreen and View -> Refresh route through here, so the two cannot
+/// drift into refreshing different things.
+void refreshRepoStatus(WidgetRef ref, RepoIdentity identity) {
+  ref.read(repoSessionProvider(identity).notifier).refreshRepoStatus();
 }
 
 final StateNotifierProviderFamily<

--- a/app_flutter/lib/data/repositories/repo_session_repository.dart
+++ b/app_flutter/lib/data/repositories/repo_session_repository.dart
@@ -1745,12 +1745,21 @@ class RepoSessionController extends StateNotifier<RepoSessionState>
   /// nothing on screen waiting for it, so it runs unconditionally like the
   /// rest. Measurements are in docs/ledger.md.
   void refreshRepoStatus() {
-    // The synchronous one goes first: it publishes through copyWith rather
-    // than waiting on an event, so the conflict badge corrects on this very
-    // frame instead of after a git subprocess returns.
+    // The two synchronous ones go first: they publish through copyWith
+    // rather than waiting on an event, so the conflict badge corrects on
+    // this very frame instead of after ten git subprocesses return.
     refreshRepoState();
+    refreshHasCommitGraph();
     refreshHistory();
     refreshWorkingCopy();
+    refreshStashes();
+    refreshWorktrees();
+    refreshRemotes();
+    refreshSubmodules();
+    refreshBisectStatus();
+    refreshLfs();
+    refreshLocalIdentity();
+    refreshEffectiveIdentity();
   }
 
   /// Re-reads which multi-step git operation, if any, is part-way through.

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -166,9 +166,7 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
     if (_focusRefreshCooldown?.isActive ?? false) return;
     _focusRefreshCooldown = Timer(kFocusRefreshThrottle, () {});
 
-    final RepoIdentity identity = widget.identity;
-    refreshRepoHistory(ref, identity);
-    wc.refreshWorkingCopy(ref, identity);
+    refreshRepoStatus(ref, widget.identity);
   }
 
   @override

--- a/app_flutter/lib/features/workspace/workspace_screen.dart
+++ b/app_flutter/lib/features/workspace/workspace_screen.dart
@@ -846,7 +846,7 @@ class _WorkspaceScreenState extends ConsumerState<WorkspaceScreen> {
       // keyboard F5, the in-window View menu, and the macOS system menu --
       // reach it; see this method's doc comment for the bug that rule exists
       // to prevent.
-      GbmActionId.viewRefresh: () => refreshRepoHistory(ref, identity),
+      GbmActionId.viewRefresh: () => refreshRepoStatus(ref, identity),
       // Null until a text selection makes a one-shot scope, which is what
       // "the selected lines" means since every scope card grew its own
       // button (a shortcut cannot say which card it meant). The diff column

--- a/app_flutter/test/integration/workspace_focus_refresh_test.dart
+++ b/app_flutter/test/integration/workspace_focus_refresh_test.dart
@@ -182,4 +182,76 @@ void main() {
           'already there -- not around it',
     );
   });
+
+  // The sweep's membership rule is "every zero-argument refresh* on the
+  // controller", and this is what holds it to that: a new refresh* added
+  // later without being wired in shows up here as a missing name rather
+  // than as a surface someone notices is stale months on.
+  //
+  // Counted rather than `any`, for the same reason the tests above are:
+  // `any` cannot see a double dispatch, and twelve refreshes fired twice
+  // per alt-tab is exactly the regression this file exists to catch.
+  testWidgets('regaining focus re-reads every local git fact exactly once', (
+    WidgetTester tester,
+  ) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: identity,
+    );
+    await tester.pumpAndSettle();
+    pumped.controller.commandLog.clear();
+
+    await _leaveAndReturn(tester);
+
+    for (final String name in const <String>[
+      'refreshRepoState',
+      'refreshHasCommitGraph',
+      'refreshHistory',
+      'refreshWorkingCopy',
+      'refreshStashes',
+      'refreshWorktrees',
+      'refreshRemotes',
+      'refreshSubmodules',
+      'refreshBisectStatus',
+      'refreshLfs',
+      'refreshLocalIdentity',
+      'refreshEffectiveIdentity',
+    ]) {
+      expect(
+        _count(pumped.controller.commandLog, name),
+        1,
+        reason: '$name must fire exactly once per focus regain',
+      );
+    }
+  });
+
+  // The sweep is local-only by decree, not by accident: the user ruled that
+  // regaining focus must never reach the network. Gone-marking is the one
+  // refresh-shaped call that would (`git remote prune --dry-run`), so its
+  // absence is asserted rather than left to a doc comment nobody re-reads.
+  testWidgets('the focus sweep never reaches the network', (
+    WidgetTester tester,
+  ) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: identity,
+    );
+    await tester.pumpAndSettle();
+    pumped.controller.commandLog.clear();
+
+    await _leaveAndReturn(tester);
+
+    expect(
+      _count(pumped.controller.commandLog, 'requestRemotePrunePreview'),
+      0,
+      reason:
+          'gone-marking contacts the remote, so it is deliberately not part '
+          'of the focus sweep',
+    );
+    expect(
+      _count(pumped.controller.commandLog, 'fetchRemote'),
+      0,
+      reason: 'and nothing else in the sweep fetches either',
+    );
+  });
 }

--- a/app_flutter/test/integration/workspace_focus_refresh_test.dart
+++ b/app_flutter/test/integration/workspace_focus_refresh_test.dart
@@ -127,4 +127,59 @@ void main() {
     expect(_count(pumped.controller.commandLog, 'refreshHistory'), 2);
     expect(_count(pumped.controller.commandLog, 'refreshWorkingCopy'), 2);
   });
+
+  // RepoState is the half of `conflictActive` that refreshWorkingCopy() does
+  // NOT cover, and until this test it was never re-read on focus at all:
+  // _readRepoState() had exactly two callers, session open and the
+  // operationFinished event. So a rebase started -- or aborted -- from a
+  // terminal left the status bar, the conflict banner and the twelve
+  // isActionEnabled() gates showing the state from whenever the app last ran
+  // an operation itself.
+  //
+  // It is cheap enough to belong here: Session::repoState() is
+  // `RepoState::read(paths_)`, which only stats a handful of .git/ paths and
+  // spawns no subprocess.
+  testWidgets('regaining window focus re-reads repo state', (
+    WidgetTester tester,
+  ) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: identity,
+    );
+    await tester.pumpAndSettle();
+    pumped.controller.commandLog.clear();
+
+    await _leaveAndReturn(tester);
+
+    expect(
+      _count(pumped.controller.commandLog, 'refreshRepoState'),
+      1,
+      reason:
+          'a rebase begun or aborted from a terminal moves .git/ without '
+          'emitting any GBM event, so repoState is stale until re-read',
+    );
+  });
+
+  testWidgets('the repo-state read is throttled with the rest', (
+    WidgetTester tester,
+  ) async {
+    final PumpedWorkspace pumped = await pumpWorkspace(
+      tester,
+      identity: identity,
+    );
+    await tester.pumpAndSettle();
+    pumped.controller.commandLog.clear();
+
+    await _leaveAndReturn(tester);
+    await _leaveAndReturn(tester);
+    await _leaveAndReturn(tester);
+
+    expect(
+      _count(pumped.controller.commandLog, 'refreshRepoState'),
+      1,
+      reason:
+          'the new read goes through the same throttle as the two that were '
+          'already there -- not around it',
+    );
+  });
 }

--- a/app_flutter/test/integration/workspace_intent_dispatch_parity_test.dart
+++ b/app_flutter/test/integration/workspace_intent_dispatch_parity_test.dart
@@ -18,6 +18,7 @@
 // the fix in gbm_action_availability.dart's follow-up commit, which
 // removes the hardcoded nulls and shares one real, policy-gated callback
 // between the map and MenuBarRow's params.
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gbm_flutter/data/repositories/repo_identity.dart';
@@ -38,6 +39,48 @@ Future<void> _pressCtrl(
   if (shift) await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
   await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
   await tester.pumpAndSettle();
+}
+
+
+/// Every command [RepoSessionController.refreshRepoStatus] dispatches. Kept
+/// here rather than imported from the focus-refresh test so that a change to
+/// the sweep has to be acknowledged in both places -- these two files assert
+/// the same composition arriving down two entirely different paths (a
+/// lifecycle event, and a keypress/menu selection).
+const List<String> _sweepCommands = <String>[
+  'refreshRepoState',
+  'refreshHasCommitGraph',
+  'refreshHistory',
+  'refreshWorkingCopy',
+  'refreshStashes',
+  'refreshWorktrees',
+  'refreshRemotes',
+  'refreshSubmodules',
+  'refreshBisectStatus',
+  'refreshLfs',
+  'refreshLocalIdentity',
+  'refreshEffectiveIdentity',
+];
+
+int _count(List<FakeCommand> log, String name) =>
+    log.where((FakeCommand c) => c.name == name).length;
+
+Map<String, int> _tally(List<FakeCommand> log) => <String, int>{
+  for (final String name in _sweepCommands) name: _count(log, name),
+};
+
+/// Walks the PlatformMenu tree for a leaf with [label], since
+/// `PlatformMenuItem` is not a Widget and no finder reaches it.
+PlatformMenuItem? _findMenuItem(List<PlatformMenuItem> menus, String label) {
+  for (final PlatformMenuItem item in menus) {
+    if (item is PlatformMenu) {
+      final PlatformMenuItem? found = _findMenuItem(item.menus, label);
+      if (found != null) return found;
+    } else if (item.label == label) {
+      return item;
+    }
+  }
+  return null;
 }
 
 void main() {
@@ -127,6 +170,71 @@ void main() {
           .where((FakeCommand c) => c.name == 'refreshHistory')
           .length;
       expect(after - before, 1);
+    });
+
+
+    // F5 used to refresh only the history, so pressing it after editing a
+    // file in another window left the Working Copy tab's pending badge, the
+    // diff pane and the conflict state exactly as they were -- on the one
+    // path where the user has explicitly *asked* for fresh state. It now
+    // dispatches the same sweep the window-focus listener does; these two
+    // tests are what stop the two drifting apart again.
+    //
+    // Deltas, not absolutes: opening a session refreshes on its own.
+    testWidgets('F5 (Refresh) re-reads every local git fact, not just history', (
+      WidgetTester tester,
+    ) async {
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: identity,
+      );
+      final Map<String, int> before = _tally(pumped.controller.commandLog);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.f5);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.f5);
+      await tester.pumpAndSettle();
+
+      final Map<String, int> after = _tally(pumped.controller.commandLog);
+      for (final String name in _sweepCommands) {
+        expect(
+          after[name]! - before[name]!,
+          1,
+          reason: 'F5 must dispatch $name exactly once',
+        );
+      }
+    });
+
+    // The third dispatch path. A PlatformMenuItem takes its callback straight
+    // out of the same actionHandlers map, so wiring viewRefresh only in
+    // MenuBarRow's params would leave this one null -- the exact shape of the
+    // bug this file was created for.
+    testWidgets('the macOS system menu Refresh item dispatches the same sweep', (
+      WidgetTester tester,
+    ) async {
+      final PumpedWorkspace pumped = await pumpWorkspace(
+        tester,
+        identity: identity,
+        isMacOS: true,
+      );
+      final PlatformMenuBar bar = tester.widget<PlatformMenuBar>(
+        find.byType(PlatformMenuBar),
+      );
+      final PlatformMenuItem? item = _findMenuItem(bar.menus, 'Refresh');
+      expect(item, isNotNull, reason: 'View > Refresh must exist on macOS');
+      expect(
+        item!.onSelected,
+        isNotNull,
+        reason: 'a null handler is what greys the item out natively',
+      );
+
+      final Map<String, int> before = _tally(pumped.controller.commandLog);
+      item.onSelected!();
+      await tester.pumpAndSettle();
+
+      final Map<String, int> after = _tally(pumped.controller.commandLog);
+      for (final String name in _sweepCommands) {
+        expect(after[name]! - before[name]!, 1, reason: 'system menu: $name');
+      }
     });
 
     testWidgets('Ctrl+B (Toggle sidebar) actually hides SidebarPanel', (

--- a/app_flutter/test/integration/workspace_intent_dispatch_parity_test.dart
+++ b/app_flutter/test/integration/workspace_intent_dispatch_parity_test.dart
@@ -41,7 +41,6 @@ Future<void> _pressCtrl(
   await tester.pumpAndSettle();
 }
 
-
 /// Every command [RepoSessionController.refreshRepoStatus] dispatches. Kept
 /// here rather than imported from the focus-refresh test so that a change to
 /// the sweep has to be acknowledged in both places -- these two files assert
@@ -172,7 +171,6 @@ void main() {
       expect(after - before, 1);
     });
 
-
     // F5 used to refresh only the history, so pressing it after editing a
     // file in another window left the Working Copy tab's pending badge, the
     // diff pane and the conflict state exactly as they were -- on the one
@@ -181,61 +179,63 @@ void main() {
     // tests are what stop the two drifting apart again.
     //
     // Deltas, not absolutes: opening a session refreshes on its own.
-    testWidgets('F5 (Refresh) re-reads every local git fact, not just history', (
-      WidgetTester tester,
-    ) async {
-      final PumpedWorkspace pumped = await pumpWorkspace(
-        tester,
-        identity: identity,
-      );
-      final Map<String, int> before = _tally(pumped.controller.commandLog);
-
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.f5);
-      await tester.sendKeyUpEvent(LogicalKeyboardKey.f5);
-      await tester.pumpAndSettle();
-
-      final Map<String, int> after = _tally(pumped.controller.commandLog);
-      for (final String name in _sweepCommands) {
-        expect(
-          after[name]! - before[name]!,
-          1,
-          reason: 'F5 must dispatch $name exactly once',
+    testWidgets(
+      'F5 (Refresh) re-reads every local git fact, not just history',
+      (WidgetTester tester) async {
+        final PumpedWorkspace pumped = await pumpWorkspace(
+          tester,
+          identity: identity,
         );
-      }
-    });
+        final Map<String, int> before = _tally(pumped.controller.commandLog);
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.f5);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.f5);
+        await tester.pumpAndSettle();
+
+        final Map<String, int> after = _tally(pumped.controller.commandLog);
+        for (final String name in _sweepCommands) {
+          expect(
+            after[name]! - before[name]!,
+            1,
+            reason: 'F5 must dispatch $name exactly once',
+          );
+        }
+      },
+    );
 
     // The third dispatch path. A PlatformMenuItem takes its callback straight
     // out of the same actionHandlers map, so wiring viewRefresh only in
     // MenuBarRow's params would leave this one null -- the exact shape of the
     // bug this file was created for.
-    testWidgets('the macOS system menu Refresh item dispatches the same sweep', (
-      WidgetTester tester,
-    ) async {
-      final PumpedWorkspace pumped = await pumpWorkspace(
-        tester,
-        identity: identity,
-        isMacOS: true,
-      );
-      final PlatformMenuBar bar = tester.widget<PlatformMenuBar>(
-        find.byType(PlatformMenuBar),
-      );
-      final PlatformMenuItem? item = _findMenuItem(bar.menus, 'Refresh');
-      expect(item, isNotNull, reason: 'View > Refresh must exist on macOS');
-      expect(
-        item!.onSelected,
-        isNotNull,
-        reason: 'a null handler is what greys the item out natively',
-      );
+    testWidgets(
+      'the macOS system menu Refresh item dispatches the same sweep',
+      (WidgetTester tester) async {
+        final PumpedWorkspace pumped = await pumpWorkspace(
+          tester,
+          identity: identity,
+          isMacOS: true,
+        );
+        final PlatformMenuBar bar = tester.widget<PlatformMenuBar>(
+          find.byType(PlatformMenuBar),
+        );
+        final PlatformMenuItem? item = _findMenuItem(bar.menus, 'Refresh');
+        expect(item, isNotNull, reason: 'View > Refresh must exist on macOS');
+        expect(
+          item!.onSelected,
+          isNotNull,
+          reason: 'a null handler is what greys the item out natively',
+        );
 
-      final Map<String, int> before = _tally(pumped.controller.commandLog);
-      item.onSelected!();
-      await tester.pumpAndSettle();
+        final Map<String, int> before = _tally(pumped.controller.commandLog);
+        item.onSelected!();
+        await tester.pumpAndSettle();
 
-      final Map<String, int> after = _tally(pumped.controller.commandLog);
-      for (final String name in _sweepCommands) {
-        expect(after[name]! - before[name]!, 1, reason: 'system menu: $name');
-      }
-    });
+        final Map<String, int> after = _tally(pumped.controller.commandLog);
+        for (final String name in _sweepCommands) {
+          expect(after[name]! - before[name]!, 1, reason: 'system menu: $name');
+        }
+      },
+    );
 
     testWidgets('Ctrl+B (Toggle sidebar) actually hides SidebarPanel', (
       tester,

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -421,7 +421,6 @@ class FakeRepoSessionController extends RepoSessionController {
     commandLog.add(const FakeCommand('refreshEffectiveIdentity'));
   }
 
-
   @override
   void fetchRemote({
     String remoteName = '',

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -369,6 +369,59 @@ class FakeRepoSessionController extends RepoSessionController {
     commandLog.add(const FakeCommand('refreshRepoState'));
   }
 
+  // The rest of refreshRepoStatus()'s membership. Every one is recorded for
+  // the same reason as the three above: unoverridden they return at the
+  // null-session guard, so a test asserting "the focus sweep re-read this"
+  // would pass against a sweep that never called it. refreshRepoStatus()
+  // itself is deliberately NOT overridden -- inheriting the real one is what
+  // makes commandLog reflect the real composition rather than a list
+  // restated here.
+  @override
+  void refreshHasCommitGraph() {
+    commandLog.add(const FakeCommand('refreshHasCommitGraph'));
+  }
+
+  @override
+  void refreshStashes() {
+    commandLog.add(const FakeCommand('refreshStashes'));
+  }
+
+  @override
+  void refreshWorktrees() {
+    commandLog.add(const FakeCommand('refreshWorktrees'));
+  }
+
+  @override
+  void refreshRemotes() {
+    commandLog.add(const FakeCommand('refreshRemotes'));
+  }
+
+  @override
+  void refreshSubmodules() {
+    commandLog.add(const FakeCommand('refreshSubmodules'));
+  }
+
+  @override
+  void refreshBisectStatus() {
+    commandLog.add(const FakeCommand('refreshBisectStatus'));
+  }
+
+  @override
+  void refreshLfs() {
+    commandLog.add(const FakeCommand('refreshLfs'));
+  }
+
+  @override
+  void refreshLocalIdentity() {
+    commandLog.add(const FakeCommand('refreshLocalIdentity'));
+  }
+
+  @override
+  void refreshEffectiveIdentity() {
+    commandLog.add(const FakeCommand('refreshEffectiveIdentity'));
+  }
+
+
   @override
   void fetchRemote({
     String remoteName = '',

--- a/app_flutter/test/support/fake_repo_session.dart
+++ b/app_flutter/test/support/fake_repo_session.dart
@@ -359,6 +359,16 @@ class FakeRepoSessionController extends RepoSessionController {
     commandLog.add(const FakeCommand('refreshWorkingCopy'));
   }
 
+  /// Same reasoning again, for the third leg of the focus-regain sweep.
+  /// Note this one is synchronous in the real controller (it reads the
+  /// staging buffer and publishes directly rather than awaiting an event),
+  /// but the seam is identical: unoverridden it returns at the null-session
+  /// guard and records nothing.
+  @override
+  void refreshRepoState() {
+    commandLog.add(const FakeCommand('refreshRepoState'));
+  }
+
   @override
   void fetchRemote({
     String remoteName = '',

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -4897,3 +4897,188 @@ payload：把 `onStageScope` 的參數換成 `const <int>[0]` 之後只有它紅
 P11 的 Appearance 段只有主題切換，21 頁規格全文沒有任何 wrap／自動換行／水平
 捲動的條目。**這是使用者指定的增補，不是規格條目**，`AppPreferences.softWrapEnabled`
 的 doc comment 已寫明，免得後續稽核把它讀成規格符合項。
+
+## fix/focus-refresh-repo-state — focus 回來時重讀整份本地 git 狀態
+
+需求：視窗失去焦點再回來時要跟上衝突徽章、working copy diff 變動、git graph、
+分支數量變化，以及其餘每一項本地會變動的狀態。使用者另外拍板兩件事：
+**不碰網路**（所以 gone 標記不在裡面），以及**「branches more or gone」指的是
+分支數量變化**，不是 gone 徽章。
+
+### 點名的四項裡，三項本來就是好的
+
+focus refresh 的接線是上一輪（`History 捲動卡頓` 那輪）做的。這一輪查下去，
+四項裡只有一項壞掉：
+
+| 面向 | 現況 | 憑證 |
+|---|---|---|
+| git graph | 已覆蓋 | `gbm_history_refresh` 契約上先送 `REFS_UPDATED` 再送一或多個 `GRAPH_UPDATED`（`gbm_capi.h:283-289`） |
+| 分支數量變化 | 已覆蓋 | 同一支呼叫的 `REFS_UPDATED` → `_readRefs()` 整份換掉 `RefSnapshot` |
+| working copy diff | 已覆蓋 | `_readWorkingCopyStatus()` **無條件**清掉 `workingCopyDiffs`，而 `WorkingCopyStatus` 沒有 `operator ==`，每次都是 JSON 解出的新實例 → `select()` 必然視為變動 → `working_copy_view.dart:156-161` 的 `ref.listen` 必然重抓 |
+| 衝突徽章 | **半舊** | 見下 |
+
+`conflictActive` 是兩項的 or。右半邊 `workingCopyStatus.conflicted` 會更新，
+**左半邊 `repoState?.isSequencerOperation` 不會**：`_readRepoState()` 全專案
+只有兩個呼叫點，session 開啟時與 `operationFinished` 事件。也就是
+**只有 app 自己跑過一個 operation，`repoState` 才會動**。
+
+症狀有三種，第二種最惡劣因為它完全隱形：
+
+1. terminal 裡 `git rebase --abort` → 狀態列與衝突橫幅繼續說 rebasing，
+   `isActionEnabled()` 那 12 個閘繼續鎖著。
+2. terminal 裡 `rebase -i` 停在 `edit`（**沒有衝突檔案**）→ 兩半邊都是空的／舊的，
+   app 完全不知道有 sequencer 在跑，照樣讓人 checkout。
+3. `rebaseStep / rebaseTotal` 與 `indexLocked` 只存在於 `repoState`。
+
+修法便宜到不需要新 capi：`Session::repoState()` 就是 `RepoState::read(paths_)`
+（`Session.cpp:249-251`），每次呼叫都重算、沒有快取，而 `RepoState.h:73-74`
+自己寫著「Only stats a handful of paths」。所以 `refreshRepoState()` 是這一輪
+唯一一支**同步**的 refresh：讀 staging buffer 直接 `copyWith` 發佈。
+
+### 撿到的：F5 只重讀 history
+
+`GbmActionId.viewRefresh` 的 handler 是 `refreshRepoHistory(ref, identity)`。
+按 F5 之後 Working Copy 的徽章、diff、衝突狀態都不動——而這是使用者**明確要求
+刷新**的那條路徑。同一個缺陷形狀，照 repo 規則 1 一併修掉。
+
+### 量測：規劃階段就量完，而且數字推翻了我自己的第一版設計
+
+本機 macOS + homebrew git；本 repo 752 commits / 933 tracked files / 64 refs /
+**無 submodule** / `git-lfs` 不在 PATH。每支 12 次，**丟掉前 2 次暖 page cache**，中位數。
+
+| 指令 | 中位數 | 指令 | 中位數 |
+|---|---|---|---|
+| `for-each-ref` | 7.3ms | `remote -v` | 4.9ms |
+| `rev-list --topo-order --all` | 9.4ms | `config --file .gitmodules --get-regexp` | 5.0ms |
+| `status --porcelain=v2 -uall` | 32.3ms | **`submodule status`** | **79.2ms** |
+| `diff --numstat` | 18.2ms | `bisect log` | 4.9ms |
+| `diff --cached --numstat` | 21.4ms | `config --local --get` / `config --get` | 4.8 / 4.9ms |
+| `stash list` | 11.6ms | *(行程啟動地板 `rev-parse`)* | *5.0ms* |
+| `worktree list --porcelain` | 4.9ms | *(候選述詞 `ls-files --stage`)* | *18.5ms* |
+
+並發牆鐘（`sharedReadPool()` 是 2–6 執行緒，`WorkingCopyStatus.h:244`）：
+
+| 池大小 | 今天（5 支） | 全部 12 支（採用） | *(參考：若短路掉 submodule)* |
+|---|---|---|---|
+| 2（最差） | 44.8ms | **135.1ms** | *65.6ms* |
+| 4 | 33.7ms | **106.6ms** | *36.5ms* |
+| 8 | 34.0ms | **94.9ms** | *32.4ms* |
+
+`git submodule status` 一支就佔掉新增成本的 66%，而且在**沒有 submodule 的 repo
+上也一樣要 79ms**。成因不是 repo 大小：`git-submodule` 是 POSIX shell script
+（`/opt/homebrew/opt/git/libexec/git-core/git-submodule`），那 79ms 是 fork +
+shell 啟動的固定成本。
+
+### 想設閘、被駁回、為什麼駁得對
+
+這段留全程，因為結論的價值不如推翻它的那句話。
+
+第一版計畫要在 `.gitmodules` 不存在時短路掉 `submodule status`，而且找到了看起來
+很漂亮的落點：**`SubmoduleOps.cpp:236-238` 已經算好了那個述詞**——
+
+```cpp
+const bool hasGitmodules = !paths_.workDir().empty() &&
+                           std::filesystem::exists(paths_.workDir() / ".gitmodules", ec);
+```
+
+它只用來決定要不要讀 `.gitmodules` 的 config，然後**無條件**往下跑
+`submodule status`。延伸它成本是 0、省 79.2ms，而且與 `Session::refreshLfs()`
+（`Session.cpp:1501-1507`，`git-lfs` 不在 PATH 時 `emitEmpty` 直接 return）
+形狀一致。
+
+**使用者駁回，理由是正確性而不是成本**：「submodule status 有就應該顯示，
+不是加上『index 裡有沒有 gitlink』就逃避他」。
+
+這句話同時殺掉了兩個候選述詞，而且殺得對：`.gitmodules` 在不在、index 有沒有
+gitlink，**兩個都只是在猜 `git submodule status` 會說什麼**。答案要跟 git 一致
+就只能問 git；放在 core 猜或放在 Dart 猜是同一個錯誤換個地方而已。
+
+**`refreshLfs()` 的短路不是反例**，而分清這一點是整段推理的關鍵：它的條件是
+「`git-lfs` 根本不在 PATH」——那不是在近似答案，是那支指令**跑不起來**。
+一個是「我猜它會回空的」，一個是「它不存在」。
+
+而回頭重讀自己的數字，本來就不需要那個閘：
+
+- 79ms 幾乎全是 fork + shell 啟動的**等待**，不是 CPU。
+- 它跑在 `sharedReadPool()` 上，**不擋 UI**，2 秒節流保證最多兩秒一次。
+- **沒有任何使用者看得到的東西在等它。** 唯一需要即時的是衝突徽章，
+  而它走同步的 `refreshRepoState()`，不論如何都在同一幀落地。
+- 最差情況（2 執行緒池）是 working copy status 晚 ~70ms 到。
+
+也就是說我**在最佳化一個沒有人在等的數字**。量測本身是對的（而且是使用者堅持
+「成本秒數要量，量完如果有需要就設閘，這是你應該隱含做的事」才量的），錯的是
+把「這個數字大」直接讀成「要修」，中間跳過了「誰在等它」。
+
+**留給未來的一條路**：真要讓 submodule 便宜又正確，唯一誠實的做法是在 core 自己
+算——`ls-files --stage` 濾 `160000`（量過 18.5ms，且**隨 index 大小成長**，
+本 repo 933 檔就吐 91KB）再逐個判斷狀態字元，也就是不呼叫那支 shell script。
+那是重寫一支 git 指令，成本與正確性風險都不小，要做該是有數字要求時單獨一輪。
+
+### 收納規則寫成規則，不是清單
+
+`refreshRepoStatus()` 的成員資格是**「controller 上每一支零參數的 `refresh*`」**
+（十二支）。這樣下一輪新增 `refresh*` 時，「要不要進來」是一個有答案的問題，
+而不是又一次憑印象補漏。
+
+`request*` 一律不收，因為它們綁在使用者的選取上（path、oid、ref、stash index），
+focus 回來時那個選取可能不存在。三個沒有必填參數、看起來像例外的，在 doc comment
+裡逐一點名以示這是決定而非疏漏：`requestReflog({ref})`（panel 自己抓、按 ref 分頁）、
+`requestCleanPreview()`（`git clean -n` 走訪整個 work tree，只餵一個 dialog）、
+`requestOriginalOperationMessage()`（只在衝突流程中有意義）。
+
+十二支逐一查證過都不連網。兩個特別確認的：**`refreshRemotes()` 是乾淨的
+`git remote -v`**（`RemoteOps.cpp:325`），prune preview 在 `fetchRemote()` 的成功
+路徑上（`remotesToPreviewAfterFetch()`）不在這裡；**LFS 連網的那兩支**
+（`lfs pull` / `lfs fetch`，`LfsOps.cpp:108,141`）是獨立 operation。
+
+### 「不連網」釘成可執行的斷言
+
+doc comment 說「全部本地」是沒有承重的。所以補了一支測試斷言 `commandLog` 裡
+**不得出現** `requestRemotePrunePreview` 與 `fetchRemote`。
+
+它不是空頭斷言，變異驗證過：把 `requestRemotePrunePreview('origin')` 塞進
+`refreshRepoStatus()`，**只有它轉紅**。
+
+### fake seam：十支覆寫，以及為什麼 `refreshRepoStatus()` 不覆寫
+
+`FakeRepoSessionController` 原本只覆寫 `refreshHistory` 與 `refreshWorkingCopy`。
+其餘十支不覆寫就會撞上 `_session == nullptr` 守衛**安靜地什麼都不做**，
+計數斷言分不出死掉與活著的——上一輪 `refreshWorkingCopy` 踩過同一個坑。
+
+`refreshRepoStatus()` 本身**刻意不覆寫**：讓 fake 繼承真的那支，`commandLog`
+收到的就是真的組合，而不是測試自己在 fake 裡重述一遍。一份會跟被測物一起變的
+清單不能拿來測那份清單。
+
+變異驗證確認這一半有承重：拿掉 fake 的 `refreshRepoState` 覆寫，兩支新測試轉紅。
+
+### 三條 dispatch 路徑都測了
+
+F5 有三條路：鍵盤（`WorkspaceActionShortcuts`）、macOS 系統選單
+（`PlatformMenuBarHost` 的 `PlatformMenuItem.onSelected`）、in-window `MenuBarRow`。
+改只動 `_buildActionHandlers()`，不碰 `MenuBarRow` 的具名參數——CLAUDE.md 記載的
+dispatch parity bug 就是「只修 MenuBarRow」造成前兩條靜默 no-op。
+
+`workspace_intent_dispatch_parity_test` 補的兩支涵蓋前兩條，用**差值**而非絕對值
+（開 session 本身就會刷新一次）。既有的「F5 reaches refreshHistory」不受影響仍綠，
+因為 `refreshRepoStatus()` 仍然包含 `refreshHistory()`。
+
+### 沒做到的
+
+- **LFS 量不到**，理由可檢查：`git-lfs` 這台機器上根本沒裝（`command -v git-lfs`
+  空、`/opt/homebrew/Cellar` 沒有、`git lfs version` 回 "not a git command"），
+  所以 C++ 側 `Session::refreshLfs()` 直接短路，成本就是一次
+  `git lfs version` 的失敗探測、**量到 11.0ms 且每 session 只跑一次**。
+  裝了 `git-lfs` 的機器上 `lfs track` + `lfs ls-files --long`（timeout 60s）
+  **沒有數字**。這裡寫「沒有數字」而不是「很快」。
+  注意量到之後也不是拿來設閘的——與 submodule 同一條理由。
+- **量的是 git 指令層，不是完整 FFI 往返**。子行程主導總成本，但 event dispatch
+  與 JSON 解析沒算進去，上表是下界。
+- **「沒有畫面在等 submodule」是推理，不是量到的**。依據可檢查（衝突徽章走同步
+  路徑、其餘在背景池、2 秒節流），但終究是推理。實機上若感覺得到延遲，該量的是
+  「切回視窗到畫面正確」那一段，而不是回頭爭論這個閘。
+- **lifecycle 轉換仍未實機驗證**，沿用上一輪、這輪沒有改變它：測試用
+  `tester.binding.handleAppLifecycleStateChanged` 直接驅動，證明了接線，
+  **沒有**證明 macOS 真的會在視窗焦點變化時送出 inactive/resumed 這組轉換。
+- **既有行為，不是這輪造成的**：`_readWorkingCopyStatus()` 無條件清
+  `workingCopyDiffs`，所以即使 focus 回來什麼都沒變，diff 面板仍會清空再重抓，
+  視覺上一次閃動。要消掉它得讓 `WorkingCopyStatus` 有值相等，是另一個題目。


### PR DESCRIPTION
視窗失去焦點再回來時，git 狀態常常已經在 app 背後動過了——在 terminal 存了檔、
commit、開了 rebase、砍了分支、stash 了東西。這一輪讓回焦點時重讀**每一項本地
git 事實**。

**裁決過的範圍**：不碰網路（gone 標記要 `git remote prune --dry-run`，是唯一連網的
一支，刻意排除）、「branches more or gone」＝分支數量變化、auto-fetch（#102）不做。

---

## 原本點名的四項裡，三項本來就是好的

這是查證出來的，不是假設。省下的力氣拿去修真正壞掉的那一項。

| 面向 | 現況 | 憑證 |
|---|---|---|
| git graph | 已是好的 | `gbm_history_refresh` 契約上先送 `REFS_UPDATED` 再送 `GRAPH_UPDATED`（`gbm_capi.h:283-289`） |
| 分支數量變化 | 已是好的 | 同一支呼叫的 `REFS_UPDATED` → `_readRefs()` 整份換掉 `RefSnapshot` |
| working copy diff | 已是好的 | `_readWorkingCopyStatus()` **無條件**清掉 `workingCopyDiffs`；`WorkingCopyStatus` 沒有 `operator ==`，每次都是新實例，所以 `select()` 必然視為變動，`working_copy_view.dart` 的 `ref.listen` 必然重抓 |
| 衝突徽章 | **半舊** | 見下 |

## 真正的缺口：`repoState` 從來不在 focus 路徑上

`conflictActive` 是兩項的 or。右半邊 `workingCopyStatus.conflicted` 會更新，
**左半邊 `repoState?.isSequencerOperation` 不會**——`_readRepoState()` 全專案只有
兩個呼叫點：session 開啟時、以及 `operationFinished` 事件。也就是說**只有 app
自己跑過 operation，`repoState` 才會動**。

症狀：

1. terminal 裡 `git rebase --abort` → 狀態列與衝突橫幅**繼續說 rebasing**，
   `isActionEnabled()` 那 12 個 id 繼續被鎖住，直到 app 內跑過任何一個 operation。
2. terminal 裡 `rebase -i` 停在 `edit`（**沒有衝突檔案**）→ 兩半邊都不對，
   app 完全不知道有 sequencer 在跑，照樣讓人 checkout。
3. `REBASE 4/17` 的步數與 `indexLocked` 只存在於 `repoState`，同樣凍住。

`refreshRepoState()` 是十二支裡唯一同步的一支——C++ 側是 `RepoState::read(paths_)`，
只 stat 幾個 `.git/` 路徑、不開子行程——所以衝突徽章在**同一幀**就更正，不必等
十個 git 子行程回來。

## 撿到的第二個缺口：F5

`GbmActionId.viewRefresh` 原本只呼叫 `refreshRepoHistory` ——**只重讀 history**。
按 F5 之後 Working Copy 的徽章、diff 內容、衝突狀態全都不更新。同一個缺陷形狀，
而且發生在**使用者明確要求刷新**的路徑上，按 CLAUDE.md「Repo culture」規則 1 一併修掉。

## 收納規則：所有零參數的 `refresh*`

成員資格是可檢查的規則，不是手挑清單：controller 上每一支零參數的 `refresh*`，
共十二支，**逐一查證過全部不連網**（`for-each-ref`／`rev-list`／`status --porcelain=v2`／
`stash list`／`worktree list`／`remote -v`／`submodule status`／`bisect log`／
`lfs track`／`config --get`／檔案存在檢查）。下一輪新增 `refresh*` 時，要不要進來
就是一個有答案的問題。

`request*` 全部排除，因為它們**綁在使用者的選取上**（路徑、oid、ref、stash index），
focus 回來時那個選取可能不存在。三個沒有必填參數、看起來像例外的有點名：
`requestReflog`、`requestCleanPreview`、`requestOriginalOperationMessage`。

## 量測，以及一個被駁回的閘

規劃階段就量完（本 repo 752 commits／933 files／64 refs／無 submodule／無 git-lfs，
每支 12 次丟掉前 2 次暖 cache，中位數）：

| 指令 | 中位數 | | 指令 | 中位數 |
|---|---|---|---|---|
| `for-each-ref` | 7.3ms | | `remote -v` | 4.9ms |
| `rev-list --topo-order --all` | 9.4ms | | `bisect log` | 4.9ms |
| `status --porcelain=v2 -uall` | 32.3ms | | `config --local --get` | 4.8ms |
| `diff --numstat` / `--cached` | 18.2 / 21.4ms | | **`submodule status`** | **79.2ms** |

並發牆鐘（`sharedReadPool()` 是 2–6 執行緒）：2 執行緒 44.8ms → **135.1ms**，
4 執行緒 33.7 → **106.6ms**，8 執行緒 34.0 → **94.9ms**。

`git submodule status` 一支佔掉新增成本的 66%。**它慢不是因為 repo 大小**：
`git-submodule` 是 POSIX shell script，79ms 是 fork + shell 啟動的固定成本，
大部分是**等待**不是 CPU。

**第一版計畫想在 `.gitmodules` 不存在時短路掉它，這個閘被駁回了，理由是正確性
不是成本**：任何述詞（`.gitmodules` 在不在、index 有沒有 gitlink）都只是在**猜
`git submodule status` 會說什麼**。答案要跟 git 一致就只能問 git；放在 Flutter 猜
或放在 C++ 猜是同一個錯誤，換個地方而已。**`refreshLfs()` 的短路不是反例**——它
的條件是「`git-lfs` 根本不在 PATH」，不是在近似答案，是那支指令**跑不起來**。

而且重讀數字，本來就不需要那個閘：79ms 幾乎全是等待、跑在背景池上不擋 UI、
2 秒節流保證最多兩秒一次，而且**沒有任何使用者看得到的東西在等它**（唯一需要即時
的衝突徽章走同步路徑）。最差情況是 working copy status 晚 ~70ms 到，alt-tab 回來
之後的背景更新晚 70ms，沒有人分辨得出來。**「這個數字很大」不等於「這裡需要修」，
要先問誰在等它。**

被否掉的替代述詞 `ls-files --stage`（18.5ms）與完整推理都寫進 ledger 了，
免得下一輪從同樣的直覺重新爭論一次。

## 順手刪掉一個 orphan

C3 把 F5 改成呼叫 `refreshRepoStatus` 之後，`refreshRepoHistory` 這個四行的 free
function 包裝就沒有呼叫者了。它只做 `ref.read(...).refreshHistory()`；controller
上真正幹活的 `refreshHistory()` 一個字沒改，只是改由 `refreshRepoStatus()` 直接呼叫。
留著就是 CLAUDE.md 記過五次以上的 orphan wiring。

## 測試

- `workspace_focus_refresh_test.dart`：+4 支——repo state 有被重讀、它跟其餘的走
  **同一個**節流（不是繞過）、十二支命令**各恰好一次**、以及 sweep **不連網**
  （斷言 `requestRemotePrunePreview` 與 `fetchRemote` 都是 0，把「不碰網路」釘成
  可執行的斷言而不是註解）。
- `workspace_intent_dispatch_parity_test.dart`：+2 支——鍵盤 F5 與 macOS
  `PlatformMenuItem` 兩條路徑都派發同一組十二支。
- `fake_repo_session.dart`：補 10 支 `@override` 記進 `commandLog`。**`refreshRepoStatus()`
  本身刻意不覆寫**，讓 fake 繼承真的那支，`commandLog` 收到的才是真的組合。
  不補這十支的話它們會撞上 `_session == nullptr` **安靜地什麼都不做**，計數斷言
  分不出死掉與活著的。
- 一律用 `_count(...) == 1` 而不是 `.any(...)`——`.any` 對重複派發是瞎的，而十二支
  刷新每次 alt-tab 跑兩遍正是這個檔案要擋的回歸。

每支新測試都做過 mutation check 且確認紅是窄的，包含「拿掉 fake 任一支新覆寫必須紅」
那條（綠了就代表守衛在安靜吃掉呼叫、測試沒有承重）。

## 誠實的限制

1. **計畫裡「`_onWindowFocusRegained` 改回直接呼叫兩支舊的」這列 mutation 沒有照
   字面跑**。證據被另外兩列涵蓋（一列證明 focus 路徑走 sweep、一列證明 F5 路徑走
   sweep），且 `refreshRepoHistory` 已刪、原字面 mutation 現在編不過。這是決定不是漏掉。
2. **每一層自動化測試都是用 fake 把 `refreshRepoState()` 的 body 換掉的**——跟既有
   `refreshHistory`／`refreshWorkingCopy` 同一個覆蓋形狀，符合這個 repo 現行的標準，
   但它證明的是接線，不是那支 git 讀取真的回報對的東西。端到端只能靠下面的實機流程。
3. **macOS 到底會不會在視窗焦點變化時送出 `inactive`/`resumed`，仍然沒有實機證據**
   ——測試直接驅動 `handleAppLifecycleStateChanged`。這是上一輪就存在、沿用下來的限制。
4. **LFS 沒量到**，理由可檢查：本機 `git-lfs` 不在 PATH，C++ 側短路，成本 0。
   裝了的機器上沒有數字。照實寫「量不到」，不寫成「很快」。
5. **量的是 git 指令層，不是完整 FFI 往返**；event dispatch 與 JSON 解析沒算進去，
   上表是下界。
6. **既有行為、不在範圍**：`_readWorkingCopyStatus()` 無條件清 `workingCopyDiffs`，
   所以即使什麼都沒變，diff 面板仍會清空再重抓，視覺一次閃動。
7. **裝置層**：`integration_test/` 對 `f5`／`viewRefresh`／`refreshHistory`／
   `refreshRepoStatus` 全部無命中，沒有測試綁在 F5 的舊行為上。

## Test plan

- [ ] `app_flutter/scripts/build_capi.sh`（**dylib 是複本，不重建會載到舊的**）後開 app
- [ ] terminal 對同一個 repo 跑 `git rebase -i HEAD~3` 停在 `edit`（**不製造衝突**）
      → 切回視窗 → 狀態列出現 REBASE 與步數、工具列 Fetch/Pull/Push 變灰
- [ ] `git rebase --abort` → 切回視窗 → 兩者復原
- [ ] terminal 跑 `git stash` → 切回視窗 → 側邊欄 stash 區有跟上
- [ ] terminal 開／砍一個分支 → 切回視窗 → 側邊欄分支數量跟上
- [ ] 編輯器存檔 → 切回視窗 → Working Copy 徽章與 diff 跟上
- [ ] 按 F5 → 上面每一項都跟切回視窗一樣會更新（不再只有 history）
- [ ] 快速 alt-tab 來回數次 → 不應該連續觸發多輪刷新（2 秒節流）
- [ ] **在有 submodule 的 repo 上主觀感覺一次**——若切回視窗到畫面正確之間感覺得到
      延遲，該量的是那一段，而不是回頭爭論那個閘

## 相關 issue

無。auto-fetch（#102）依裁決不在本輪範圍。
