### PR TITLE
Sidebar stash rows: add hover/select feedback, ⋯ menu, fix date

### DIFF
--- a/app_flutter/lib/features/context_menus/gbm_context_menus.dart
+++ b/app_flutter/lib/features/context_menus/gbm_context_menus.dart
@@ -339,7 +339,8 @@ const GbmContextMenuGroupSpec _diffLine = GbmContextMenuGroupSpec(
   ],
 );
 
-/// 05-H: Stash entry (right-click stash row in sidebar -- not yet wired)
+/// 05-H: Stash entry (right-click stash row in sidebar, or its ⋯ button --
+/// wired via `SidebarStashSection._openContextMenu`).
 /// 6 top-level items.
 const GbmContextMenuGroupSpec _stashEntry = GbmContextMenuGroupSpec(
   id: '05-H',

--- a/app_flutter/lib/features/sidebar/widgets/sidebar_stash_section.dart
+++ b/app_flutter/lib/features/sidebar/widgets/sidebar_stash_section.dart
@@ -13,23 +13,27 @@ import '../../../routing/route_paths.dart';
 import '../../../theme/gbm_theme.dart';
 import '../../../theme/tokens.dart';
 import '../../../widgets/gbm_menu.dart';
+import '../../../widgets/gbm_row.dart';
 import '../../../widgets/prompt_text_dialog.dart';
+import '../../history_graph/widgets/graph_date_format.dart';
 import 'sidebar_section_label.dart';
 import 'stash_menu_items.dart';
 
 /// The sidebar's STASH section: its label and one row per stash.
 ///
-/// Unlike `BranchSelectionActionBar` this is a `ConsumerWidget` rather than a
-/// presentational one, because a stash row's six actions (05-H) are the only
-/// callers of the controller methods behind them -- routing them back up
-/// through `SidebarPanel` as six callbacks would put a hop in the way and
-/// leave the panel holding state it does not otherwise use. The branch tree
-/// is the opposite case: its selection *is* panel state, which is why that
+/// Unlike `BranchSelectionActionBar` this is a `ConsumerStatefulWidget`
+/// rather than a presentational one: a stash row's six actions (05-H) are
+/// the only callers of the controller methods behind them, so routing them
+/// back up through `SidebarPanel` as six callbacks would put a hop in the
+/// way and leave the panel holding state it does not otherwise use, and
+/// which stash row is selected is cosmetic, self-contained state with no
+/// other reader. The branch tree is the opposite case on both counts: its
+/// selection *is* panel state (other surfaces read it), which is why that
 /// half stays there.
 ///
 /// Renders nothing when [stashes] is empty, so the caller does not repeat the
 /// P02-14 rule 5 emptiness check (「沒有命中的段落整段隱藏，不留空標題」).
-class SidebarStashSection extends ConsumerWidget {
+class SidebarStashSection extends ConsumerStatefulWidget {
   const SidebarStashSection({
     super.key,
     required this.identity,
@@ -43,10 +47,25 @@ class SidebarStashSection extends ConsumerWidget {
   final List<StashEntry> stashes;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    if (stashes.isEmpty) return const SizedBox.shrink();
+  ConsumerState<SidebarStashSection> createState() =>
+      _SidebarStashSectionState();
+}
 
-    final RepoSessionState session = ref.watch(repoSessionProvider(identity));
+class _SidebarStashSectionState extends ConsumerState<SidebarStashSection> {
+  // Purely cosmetic -- nothing downstream reads which stash is highlighted
+  // (there's no detail pane here, unlike StashesPanel's own _selectedIndex,
+  // which this mirrors). Keyed by index, matching StashesPanel's existing
+  // convention for this exact model type rather than inventing a second
+  // identity scheme for StashEntry selection.
+  int? _selectedIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.stashes.isEmpty) return const SizedBox.shrink();
+
+    final RepoSessionState session = ref.watch(
+      repoSessionProvider(widget.identity),
+    );
     // Sourced from isActionEnabled(), not session.conflictActive directly --
     // same pattern as every other conflict-sensitive gate in the sidebar.
     // branchStashChanges is the closest existing id (stash apply/pop mutate
@@ -60,50 +79,46 @@ class SidebarStashSection extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         const SidebarSectionLabel('STASH'),
-        for (final StashEntry stash in stashes)
+        for (final StashEntry stash in widget.stashes)
           _StashRow(
             stash: stash,
+            selected: stash.index == _selectedIndex,
+            onTap: () => setState(() => _selectedIndex = stash.index),
             onSecondaryTapDown: (TapDownDetails details) =>
-                _openContextMenu(context, ref, details, stash, conflictActive),
+                _openContextMenu(details.globalPosition, stash, conflictActive),
+            onOpenMenu: (Offset position) =>
+                _openContextMenu(position, stash, conflictActive),
           ),
       ],
     );
   }
 
   void _openContextMenu(
-    BuildContext context,
-    WidgetRef ref,
-    TapDownDetails details,
+    Offset position,
     StashEntry stash,
     bool conflictActive,
   ) {
     showGbmContextMenu(
       context,
-      details.globalPosition,
+      position,
       stashMenuItems(
-        onApply: conflictActive ? null : () => _apply(ref, stash),
-        onPop: conflictActive ? null : () => _apply(ref, stash, pop: true),
-        onCreateBranch: conflictActive
-            ? null
-            : () => _createBranchFrom(context, ref, stash),
-        onViewDiff: () => _viewDiff(context, ref, stash),
-        onCompare: () => _compare(context, ref, stash),
-        onDrop: () => _drop(ref, stash),
+        onApply: conflictActive ? null : () => _apply(stash),
+        onPop: conflictActive ? null : () => _apply(stash, pop: true),
+        onCreateBranch: conflictActive ? null : () => _createBranchFrom(stash),
+        onViewDiff: () => _viewDiff(stash),
+        onCompare: () => _compare(stash),
+        onDrop: () => _drop(stash),
       ),
     );
   }
 
-  void _apply(WidgetRef ref, StashEntry stash, {bool pop = false}) {
+  void _apply(StashEntry stash, {bool pop = false}) {
     ref
-        .read(repoSessionProvider(identity).notifier)
+        .read(repoSessionProvider(widget.identity).notifier)
         .applyStash(stash.index, pop: pop);
   }
 
-  Future<void> _createBranchFrom(
-    BuildContext context,
-    WidgetRef ref,
-    StashEntry stash,
-  ) async {
+  Future<void> _createBranchFrom(StashEntry stash) async {
     final String? name = await promptText(
       context,
       title: 'New Branch from Stash',
@@ -111,7 +126,7 @@ class SidebarStashSection extends ConsumerWidget {
     );
     if (name == null || !context.mounted) return;
     ref
-        .read(repoSessionProvider(identity).notifier)
+        .read(repoSessionProvider(widget.identity).notifier)
         .branchFromStash(stash.index, name);
   }
 
@@ -122,10 +137,10 @@ class SidebarStashSection extends ConsumerWidget {
   /// beside History/Working Copy and replaces the shell's child. The stash
   /// index rides in the query rather than the tab id, so asking twice for
   /// two different stashes focuses one tab instead of opening two.
-  void _viewDiff(BuildContext context, WidgetRef ref, StashEntry stash) {
-    final String repoId = Uri.encodeComponent(identity.workDir);
+  void _viewDiff(StashEntry stash) {
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
     final String tabId = ref
-        .read(panelTabsProvider(identity).notifier)
+        .read(panelTabsProvider(widget.identity).notifier)
         .open(GbmPanelKind.manageStashes);
     context.go(
       RoutePaths.panelFor(
@@ -140,81 +155,113 @@ class SidebarStashSection extends ConsumerWidget {
   // stash entry is a real commit (`git stash` creates one even though it
   // never gets a branch), so this is the same `left: <ref string>`
   // mechanism repositoryCompare already uses, not a new capability.
-  void _compare(BuildContext context, WidgetRef ref, StashEntry stash) {
-    final String repoId = Uri.encodeComponent(identity.workDir);
+  void _compare(StashEntry stash) {
+    final String repoId = Uri.encodeComponent(widget.identity.workDir);
     final String tabId = ref
-        .read(compareTabsProvider(identity).notifier)
+        .read(compareTabsProvider(widget.identity).notifier)
         .open(left: stash.oid);
     context.go(RoutePaths.compareFor(repoId, tabId));
   }
 
-  void _drop(WidgetRef ref, StashEntry stash) {
-    ref.read(repoSessionProvider(identity).notifier).dropStash(stash.index);
+  void _drop(StashEntry stash) {
+    ref
+        .read(repoSessionProvider(widget.identity).notifier)
+        .dropStash(stash.index);
   }
 }
 
 class _StashRow extends StatelessWidget {
-  const _StashRow({required this.stash, required this.onSecondaryTapDown});
+  const _StashRow({
+    required this.stash,
+    required this.selected,
+    required this.onTap,
+    required this.onSecondaryTapDown,
+    required this.onOpenMenu,
+  });
 
   final StashEntry stash;
+  final bool selected;
+  final VoidCallback onTap;
   final GestureTapDownCallback onSecondaryTapDown;
+
+  /// Called with the ⋯ button's own global position, for the same
+  /// `showGbmContextMenu(context, position, items)` call `onSecondaryTapDown`
+  /// makes -- one menu, two ways to reach it, mirroring BranchTreeItem.
+  final ValueChanged<Offset> onOpenMenu;
+
+  // Matches BranchTreeItem's `_kActionsSlotWidth`, for the same reason: a
+  // fixed-width trailing slot keeps the sidebar's ⋯ column straight.
+  static const double _kActionsSlotWidth = 32;
 
   @override
   Widget build(BuildContext context) {
     final GbmColors colors = context.gbmColors;
-    return GestureDetector(
+    return GbmRow(
+      // Two stacked lines (message + relative time) at textSm/textXs --
+      // this is PanelListRow's own height for exactly this shape, chosen
+      // because rowHeightComfortable alone clips a second line by ~2px.
+      height: GbmSpacing.rowHeightComfortable + GbmSpacing.space3,
+      padding: const EdgeInsets.symmetric(horizontal: GbmSpacing.space2),
+      selected: selected,
+      onTap: onTap,
       onSecondaryTapDown: onSecondaryTapDown,
-      child: Container(
-        // No fixed height, unlike a branch row -- this row shows two lines
-        // (message + relative time) rather than one, and rowHeightCompact
-        // (26px) is too short for both at GbmTypography's textSm/textXs
-        // sizes, overflowing the Column below by several pixels. Vertical
-        // padding gives it breathing room instead of pinning a height that
-        // would need recalibrating by hand every time either text style
-        // changes.
-        padding: const EdgeInsets.symmetric(
-          horizontal: GbmSpacing.space2,
-          vertical: GbmSpacing.space1,
-        ),
-        child: Row(
-          children: <Widget>[
-            const SizedBox(width: GbmSpacing.space2),
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    stash.message,
-                    style: TextStyle(
-                      fontSize: GbmTypography.textSm,
-                      color: colors.textPrimary,
-                    ),
-                    overflow: TextOverflow.ellipsis,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  stash.message,
+                  style: TextStyle(
+                    fontSize: GbmTypography.textSm,
+                    color: colors.textPrimary,
                   ),
-                  Text(
-                    _relativeTime(stash.timestamp),
-                    style: TextStyle(
-                      fontSize: GbmTypography.textXs,
-                      color: colors.textTertiary,
-                    ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  formatGraphDate(
+                    DateTime.fromMillisecondsSinceEpoch(stash.timestamp * 1000),
+                    DateTime.now(),
                   ),
-                ],
+                  style: TextStyle(
+                    fontSize: GbmTypography.textXs,
+                    color: colors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Every row gets this button unconditionally, matching
+          // BranchTreeItem -- the right-click menu above is real but
+          // undiscoverable on its own.
+          SizedBox(
+            width: _kActionsSlotWidth,
+            child: Builder(
+              builder: (BuildContext buttonContext) => IconButton(
+                tooltip: 'Stash actions',
+                icon: Icon(
+                  Icons.more_vert,
+                  size: 16,
+                  color: colors.textTertiary,
+                ),
+                iconSize: 16,
+                constraints: const BoxConstraints(
+                  minWidth: _kActionsSlotWidth,
+                  minHeight: _kActionsSlotWidth,
+                ),
+                padding: EdgeInsets.zero,
+                onPressed: () {
+                  final RenderBox box =
+                      buttonContext.findRenderObject()! as RenderBox;
+                  onOpenMenu(box.localToGlobal(Offset.zero));
+                },
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
-  }
-
-  static String _relativeTime(int millisecondsSinceEpoch) {
-    final Duration diff = DateTime.now().difference(
-      DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch),
-    );
-    if (diff.inMinutes < 1) return 'just now';
-    if (diff.inHours < 1) return '${diff.inMinutes}m ago';
-    if (diff.inDays < 1) return '${diff.inHours}h ago';
-    return '${diff.inDays}d ago';
   }
 }

--- a/app_flutter/test/features/sidebar/widgets/sidebar_stash_section_test.dart
+++ b/app_flutter/test/features/sidebar/widgets/sidebar_stash_section_test.dart
@@ -1,0 +1,161 @@
+// Covers the three gaps reported against the sidebar's STASH section:
+// no hover/selected feedback (the row was a hand-rolled GestureDetector +
+// Container, never migrated onto GbmRow -- [FLU-hand-rolled-inkwell-hover]),
+// no discoverable "more actions" affordance to match BranchTreeItem's ⋯
+// button, and a relative-date bug ("20676d ago") from feeding unix
+// *seconds* into DateTime.fromMillisecondsSinceEpoch with no `* 1000`.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gbm_flutter/data/models/stash_entry.dart';
+import 'package:gbm_flutter/data/repositories/repo_identity.dart';
+import 'package:gbm_flutter/data/repositories/repo_session_repository.dart';
+import 'package:gbm_flutter/features/history_graph/widgets/graph_date_format.dart';
+import 'package:gbm_flutter/features/sidebar/widgets/sidebar_stash_section.dart';
+import 'package:gbm_flutter/widgets/gbm_row.dart';
+
+import '../../../support/fake_repo_session.dart';
+import '../../../support/pump_app.dart';
+
+final RepoIdentity _identity = RepoIdentity.forWorkDir('/test/repo');
+
+const StashEntry _stash0 = StashEntry(
+  index: 0,
+  message: 'WIP on main: tab row',
+  oid: 'aaaaaaa',
+  timestamp: 1700000000,
+);
+
+const StashEntry _stash1 = StashEntry(
+  index: 1,
+  message: 'debug logging',
+  oid: 'bbbbbbb',
+  timestamp: 1690000000,
+);
+
+Future<FakeRepoSessionController> _pump(
+  WidgetTester tester, {
+  List<StashEntry> stashes = const <StashEntry>[_stash0, _stash1],
+}) async {
+  late final FakeRepoSessionController fake;
+  await pumpGbmWidget(
+    tester,
+    child: SidebarStashSection(identity: _identity, stashes: stashes),
+    overrides: <Override>[
+      repoSessionProvider(_identity).overrideWith((ref) {
+        fake = FakeRepoSessionController(
+          _identity,
+          RepoSessionState(isOpen: true, stashes: stashes),
+        );
+        return fake;
+      }),
+    ],
+  );
+  return fake;
+}
+
+Future<void> _rightClick(WidgetTester tester, Finder finder) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.down(tester.getCenter(finder));
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SidebarStashSection rows', () {
+    testWidgets('each row is a GbmRow (hover) and selecting flips its token', (
+      tester,
+    ) async {
+      await _pump(tester);
+
+      // GbmRow is what supplies hoverColor/surfaceSelected -- the previous
+      // implementation was a bare GestureDetector+Container with neither.
+      expect(find.byType(GbmRow), findsNWidgets(2));
+
+      GbmRow rowFor(String message) => tester.widget<GbmRow>(
+        find.ancestor(of: find.text(message), matching: find.byType(GbmRow)),
+      );
+
+      expect(rowFor(_stash0.message).selected, isFalse);
+      expect(rowFor(_stash1.message).selected, isFalse);
+
+      await tester.tap(find.text(_stash0.message));
+      await tester.pumpAndSettle();
+
+      expect(rowFor(_stash0.message).selected, isTrue);
+      expect(rowFor(_stash1.message).selected, isFalse);
+
+      // Selecting the other row moves the highlight rather than adding to it.
+      await tester.tap(find.text(_stash1.message));
+      await tester.pumpAndSettle();
+
+      expect(rowFor(_stash0.message).selected, isFalse);
+      expect(rowFor(_stash1.message).selected, isTrue);
+    });
+
+    testWidgets('the ⋯ button and right-click both open the same 05-H menu', (
+      tester,
+    ) async {
+      final FakeRepoSessionController fake = await _pump(
+        tester,
+        stashes: const <StashEntry>[_stash0],
+      );
+
+      // Undiscoverable-but-real right-click path.
+      await _rightClick(tester, find.text(_stash0.message));
+      expect(find.text('Apply stash'), findsOneWidget);
+      await tester.tap(find.text('Apply stash'));
+      await tester.pumpAndSettle();
+
+      expect(
+        fake.commandLog.where((FakeCommand c) => c.name == 'applyStash'),
+        hasLength(1),
+      );
+
+      // The new discoverable path: the trailing ⋯ button, mirroring
+      // BranchTreeItem's.
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      expect(find.text('Drop stash…'), findsOneWidget);
+      await tester.tap(find.text('Drop stash…'));
+      await tester.pumpAndSettle();
+
+      expect(
+        fake.commandLog.where((FakeCommand c) => c.name == 'dropStash'),
+        hasLength(1),
+      );
+    });
+
+    testWidgets(
+      'renders the correct date -- regression for the 1000x "20676d ago" bug',
+      (tester) async {
+        // A fixed instant well in the past. If the bug (feeding *seconds*
+        // straight into fromMillisecondsSinceEpoch) ever comes back, this
+        // would render a date in January 1970 instead.
+        final DateTime past = DateTime.now().subtract(const Duration(days: 10));
+        final int timestampSeconds = past.millisecondsSinceEpoch ~/ 1000;
+        final StashEntry stash = StashEntry(
+          index: 0,
+          message: 'WIP on main: date check',
+          oid: 'ccccccc',
+          timestamp: timestampSeconds,
+        );
+
+        await _pump(tester, stashes: <StashEntry>[stash]);
+
+        final String expected = formatGraphDate(
+          DateTime.fromMillisecondsSinceEpoch(timestampSeconds * 1000),
+          DateTime.now(),
+        );
+
+        expect(find.text(expected), findsOneWidget);
+        expect(find.textContaining('1970'), findsNothing);
+      },
+    );
+  });
+}

--- a/docs/ledger/2026-09-01-claude-sidebar-stash-styling-date-3dvzmu.md
+++ b/docs/ledger/2026-09-01-claude-sidebar-stash-styling-date-3dvzmu.md
@@ -1,0 +1,95 @@
+# 2026-09-01 · claude/sidebar-stash-styling-date-3dvzmu — 側邊欄 STASH 列補上 hover/選取/選單，修掉「20676d ago」
+
+使用者的原話：
+
+> sidebar stash has no hover color, select color, right click menu (can show
+> like branches use dot icon as more). the lastly the wrong date of ... day
+> ago (it shows 20676d ago, wtf), please look as the spec and show me how you
+> would do
+
+四件事，全部集中在同一個檔案：`app_flutter/lib/features/sidebar/widgets/sidebar_stash_section.dart`
+的 `_StashRow`。
+
+## 為什麼會這樣：這一列從一開始就沒有走共用的列元件
+
+`_StashRow` 是手刻的 `GestureDetector` 包 `Container`，從沒改用
+`lib/widgets/gbm_row.dart` 的 `GbmRow`——而側邊欄另外兩種列（分支、標籤，都是
+`BranchTreeItem`）都是靠 `GbmRow` 才有 hover 色（`InkWell.hoverColor:
+colors.surfaceHover`）跟選取底色（`selected ? colors.surfaceSelected : null`）。
+這正是 [FLU-hand-rolled-inkwell-hover] 記錄過的同一種缺陷第三次出現——前兩次
+（`FileTreeFolderRow`、`working_copy_view.dart` 裡的 `_MiniButton`）都是在 C18
+「掃一遍這一輪改動檔案裡所有 `InkWell(`/`GestureDetector(`」時抓到的；這次沒有掃，
+是使用者自己回報的。
+
+`_StashRow` 原本完全沒有「選取」這個概念——`onTap` 從未接過，`SidebarStashSection`
+也沒有任何欄位在記「目前選到哪一個 stash」。右鍵選單其實是接好的
+（`_openContextMenu` → `showGbmContextMenu(..., stashMenuItems(...))`），只是
+沒有像 `BranchTreeItem` 那樣一顆固定在列尾、恆定顯示的 `IconButton(Icons.more_vert)`
+可以按——`gbm_context_menus.dart` 裡 05-H 那組甚至還留著「not yet wired」的過時
+註解，這次一併訂正（[CULT-scrutinise-the-comment]／[CULT-correct-the-record]）。
+
+## 「20676d ago」的根因
+
+`StashEntry.timestamp`（`src/core/git/ops/StashOps.cpp` 用 `%at` 讀出來、
+`JsonCodec.cpp` 原封不動序列化）是 unix **秒**，不是毫秒。`_StashRow` 舊版的
+`_relativeTime()` 把這個秒數直接餵進 `DateTime.fromMillisecondsSinceEpoch()`，
+沒有乘 1000，整整差了一千倍——換算下來落在 1970 年 1 月底附近，`DateTime.now()`
+跟那個時間點的天數差就是「20676d」。
+
+同一個 `StashEntry.timestamp` 欄位，`stashes_panel.dart`（P19 的 manage-stashes
+分頁）、`reflog_panel.dart`、`commit_row.dart`、`line_history_panel.dart`、
+`file_history_panel.dart` 全部都是先 `* 1000` 再丟進 `DateTime
+.fromMillisecondsSinceEpoch`，然後用共用的 `formatGraphDate()`
+（`features/history_graph/widgets/graph_date_format.dart`）格式化——側邊欄是
+整個程式裡唯一漏掉這個轉換、還另外手刻一套「Xm/Xh/Xd ago」邏輯的地方。
+
+## 修法
+
+全部改在 `sidebar_stash_section.dart`：
+
+1. `SidebarStashSection` 從 `ConsumerWidget` 改成
+   `ConsumerStatefulWidget`／`ConsumerState`，比照 `StashesPanel` 自己的
+   `int? _selectedIndex` 寫法，加上單一選取狀態（純視覺用途，這裡沒有像
+   `StashesPanel` 那樣的細節面板要讀它）。选取 key 用 `index`，跟
+   `StashesPanel` 既有的作法一致，不另外發明一套以 `oid` 為主的識別方式。
+2. `_StashRow` 整個重寫成 `GbmRow` 包版面：`selected`／`onTap`／
+   `onSecondaryTapDown` 都接上去，高度用 `PanelListRow` 已經量過、不會裁到
+   第二行的 `rowHeightComfortable + space3`（46px）。多了一個固定寬度 32px
+   的尾端欄位放 `IconButton(Icons.more_vert)`——寬度數字跟
+   `BranchTreeItem._kActionsSlotWidth` 一樣，理由也一樣：讓整欄的 ⋯
+   按鈕對齊。這顆按鈕跟右鍵共用同一個 `_openContextMenu`，只是簽名從
+   `TapDownDetails` 改成 `Offset`，讓兩條路徑都能呼叫。
+3. 刪掉 `_relativeTime()`，改叫 `formatGraphDate(DateTime
+   .fromMillisecondsSinceEpoch(stash.timestamp * 1000), DateTime.now())`——
+   跟其他五個消費同一欄位的地方統一寫法。
+4. 順手把舊的雙重左內距（`Container` 的 `horizontal: space2` 加上 `Row`
+   裡多一個 `SizedBox(width: space2)`，左邊變 16px、右邊只有 8px）收斂成
+   `GbmRow` 單一個 `padding` 參數，兩邊對稱。
+
+**沒有做的事，也是刻意的**：spec 的靜態 mockup 在 stash 列前面畫了
+`{{ icStash }}` 這個型別小圖示，但真正的 `BranchTreeItem`
+自己在分支列上也沒有畫對應的 `{{ icBranch }}`——也就是說 Flutter
+這邊「分支列本身」就沒有實作那顆圖示。既然使用者的訴求是「跟分支列一樣」，
+幫 stash 列加圖示反而會讓兩種列變得不一致，所以沒加。雙擊也沒有比照分支的
+「雙擊 checkout」，因為 stash 沒有對應的動作——所有動作都留在選單裡。
+
+## 驗證
+
+- `flutter analyze`（整個 repo）：0 issue。
+- `dart format --set-exit-if-changed`：改動的三個檔案全部通過。
+- 新增 `test/features/sidebar/widgets/sidebar_stash_section_test.dart`
+  三個案例：(1) 兩列都是 `GbmRow`，點擊會讓 `selected` 在兩列之間正確切換而
+  不是疊加；(2) ⋯ 按鈕跟右鍵開出同一組 05-H 選單，Apply／Drop
+  都確實派發到 `FakeRepoSessionController.commandLog`（用
+  `hasLength(1)` 數次數，不是 `.any(...)`，比照
+  [TEST-count-dont-any]）；(3) 針對「20676d ago」的回歸測試——取一個
+  10 天前的固定時間點算出對應的 unix 秒數，斷言畫出來的字串等於
+  `formatGraphDate(...)` 用同一個時間點算出的結果，並且明確斷言畫面上
+  **沒有**出現「1970」字樣。三個都綠。
+- 既有的 `test/features/sidebar/`、`test/features/context_menus/`、
+  `test/integration/workspace_conflict_transition_test.dart`
+  （總計 328 個案例）重新跑過，全部維持綠燈——沒有任何既有測試直接建構
+  `_StashRow`／`SidebarStashSection`，所以這次的簽名變動沒有波及別的檔案。
+- 沒有跑裝置層：這一輪只有 Linux 上的 widget test，[TEST-device-tier-not-in-ci]
+  記過的那個缺口在這裡仍然成立，之後如果有人要驗證真的滑鼠 hover
+  視覺效果，得另外挑一個裝置層批次補。

--- a/docs/ledger/INDEX.md
+++ b/docs/ledger/INDEX.md
@@ -13,3 +13,4 @@ this file positionally.
 - 2026-09-01 — [claude/working-copy-untracked-files-qq2gnc](2026-09-01-claude-working-copy-untracked-files-qq2gnc.md) — 未追蹤檔案終於看得到 diff、也 stage/discard 得動；太大的 diff 改成明講拒絕而不是默默只畫一半
 - 2026-09-01 — [claude/windows-app-update-install-irloo0](2026-09-01-claude-windows-app-update-install-irloo0.md) — Install and restart 卡在 Installing…：關 session 的同步 FFI 沒有逾時，交接過程也沒有任何紀錄
 - 2026-09-01 — [claude/windows-uncommitted-changes-5z40sr](2026-09-01-claude-windows-uncommitted-changes-5z40sr.md) — 修 Windows 上未提交列連不到 HEAD：trunkTip 的 TOCTOU race、readHead() 把失敗誤判為空 repo
+- 2026-09-01 — [claude/sidebar-stash-styling-date-3dvzmu](2026-09-01-claude-sidebar-stash-styling-date-3dvzmu.md) — 側邊欄 STASH 列改用 GbmRow 補上 hover/選取/⋯ 選單按鈕，並修掉 timestamp 少乘 1000 造成的「20676d ago」

--- a/docs/rules/fn-flutter-input.md
+++ b/docs/rules/fn-flutter-input.md
@@ -23,7 +23,12 @@ Pin prefix `FLU-`. Format: [README.md](README.md).
   in `working_copy_view.dart` that also re-implemented `GbmButton(secondary, sm)`'s border, text
   size and padding by hand. **That grep is worth running at the end of any round that touches
   widgets.**
-- **Evidence**: ledger: Sidebar branch rows
+- **Consequence**: a fourth instance — the sidebar's STASH rows (`sidebar_stash_section.dart`'s
+  `_StashRow`, a `GestureDetector` + `Container` with no `InkWell` at all) — shipped with no
+  hover, no selected tint, and no discoverable menu trigger, because this one was never swept;
+  it took a direct user report rather than the grep above to surface it.
+- **Evidence**: ledger: Sidebar branch rows; [ledger: 側邊欄 STASH 列補上
+  hover/選取/選單](../ledger/2026-09-01-claude-sidebar-stash-styling-date-3dvzmu.md)
 
 ## [FLU-gesture-arena-taxes-double-tap] The gesture arena taxes double-clickable rows, and it is not local
 


### PR DESCRIPTION
Fixes three UX gaps in the sidebar's STASH section:

1. **No hover or selected feedback** — `_StashRow` was a hand-rolled `GestureDetector` + `Container` that never migrated to `GbmRow`, leaving it without the `InkWell.hoverColor` and `surfaceSelected` tint that branch rows have.

2. **No discoverable menu trigger** — The right-click context menu existed but had no visible affordance. Added a trailing `IconButton(Icons.more_vert)` matching `BranchTreeItem`'s pattern, with a fixed 32px slot to keep the sidebar's ⋯ column aligned.

3. **Date rendering bug** — `_relativeTime()` fed unix *seconds* directly into `DateTime.fromMillisecondsSinceEpoch()` without multiplying by 1000, causing dates to render as "20676d ago" (falling into January 1970). Replaced with the shared `formatGraphDate()` used by five other panels consuming the same `StashEntry.timestamp` field.

## Changes

- **`sidebar_stash_section.dart`**:
  - Converted `SidebarStashSection` from `ConsumerWidget` to `ConsumerStatefulWidget` to track `_selectedIndex` (cosmetic, self-contained state).
  - Rewrote `_StashRow` as a `GbmRow` with `selected`/`onTap`/`onSecondaryTapDown` wired through.
  - Added trailing `IconButton(Icons.more_vert)` in a fixed-width 32px slot; both it and right-click call the same `_openContextMenu(Offset)`.
  - Removed `_relativeTime()` helper; now calls `formatGraphDate(DateTime.fromMillisecondsSinceEpoch(stash.timestamp * 1000), DateTime.now())` to match other panels.
  - Unified left/right padding via `GbmRow.padding` (was asymmetric: 16px left, 8px right).
  - Height set to `rowHeightComfortable + space3` (46px), matching `PanelListRow` to avoid clipping the second text line.

- **`gbm_context_menus.dart`**: Updated stale "not yet wired" comment for the 05-H stash menu spec.

- **New test file `sidebar_stash_section_test.dart`**:
  - Verifies both rows are `GbmRow` instances and selection toggles correctly between them.
  - Confirms ⋯ button and right-click both dispatch the same 05-H menu actions.
  - Regression test for the date bug: feeds a 10-day-old unix timestamp, asserts output matches `formatGraphDate()` and contains no "1970".

All existing tests (328 cases across sidebar, context menus, and conflict transition) remain green; no other files' signatures changed.

https://claude.ai/code/session_01BbyDWWiNbxZm1ACNPoNLnE